### PR TITLE
add check if there is actually a package manager in the run command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,8 @@ In the example above, you'll notice properties are being accessed from the `inpu
 
 You should also write a test for your rule(s). There are many examples of these in the `checks/cloud` directory.
 
+This repository formats all rules with the `opa fmt -w <path>` option, so make sure to run it on your files before you commit.
+
 Finally, you'll want to generate documentation for your newly added rule. Please run `make docs` to generate the documentation for your new policy and submit a PR for us to take a look at.
 
 You can see a full example PR for a new rule being added here: [https://github.com/aquasecurity/defsec/pull/1000](https://github.com/aquasecurity/defsec/pull/1000).

--- a/checks/docker/update_instruction_alone.rego
+++ b/checks/docker/update_instruction_alone.rego
@@ -24,6 +24,7 @@ deny[res] {
 
 	command = concat(" ", run.Value)
 
+	is_package_manager(command)
 	is_valid_update(command)
 	not update_followed_by_install(command)
 
@@ -31,16 +32,16 @@ deny[res] {
 	res := result.new(msg, run)
 }
 
+package_manager_regex := `(apk)|(apt-get)|(yum)`
+
+is_package_manager(command) {
+	regex.match(package_manager_regex, command)
+}
+
+update_regex := `( update)|( check-update)`
+
 is_valid_update(command) {
-	chained_parts := regex.split(`\s*&&\s*`, command)
-
-	array_split := split(chained_parts[_], " ")
-
-	len = count(array_split)
-
-	update := {"update", "--update"}
-
-	array_split[len - 1] == update[_]
+	regex.match(update_regex, command)
 }
 
 update_followed_by_install(command) {

--- a/checks/docker/update_instruction_alone_test.rego
+++ b/checks/docker/update_instruction_alone_test.rego
@@ -77,15 +77,19 @@ test_allowed {
 		},
 		{
 			"Cmd": "run",
-			"Value": ["apt-get update     && apt-get install -y --no-install-recommends mysql-client     && rm -rf /var/lib/apt/lists/*"],
+			"Value": ["apt-get update && apt-get install -y --no-install-recommends mysql-client && rm -rf /var/lib/apt/lists/*"],
 		},
 		{
 			"Cmd": "run",
-			"Value": ["apk update     && apk add --no-cache git ca-certificates"],
+			"Value": ["apk update && apk add --no-cache git ca-certificates"],
 		},
 		{
 			"Cmd": "run",
 			"Value": ["apk --update add easy-rsa"],
+		},
+		{
+			"Cmd": "run",
+			"Value": ["/bin/sh /scripts/someScript.sh update"],
 		},
 		{
 			"Cmd": "entrypoint",


### PR DESCRIPTION
Simplify rule to use regex instead of splitting

closes https://github.com/aquasecurity/defsec/issues/1256