### PR TITLE
feat(rego): add `result` package

### DIFF
--- a/.github/workflows/test-rego.yaml
+++ b/.github/workflows/test-rego.yaml
@@ -20,8 +20,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
       - name: Setup OPA
         uses: ./.github/actions/setup-opa
+
       - name: OPA Format
         run: |
           files=$(opa fmt --list . | grep -v vendor || true)
@@ -30,8 +32,6 @@ jobs:
             echo "$files"
             exit 1
           fi
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-          cache-dependency-path: go.sum
+
+      - name: OPA Test
+        run: make test-rego

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,17 @@ DYNAMIC_REGO_FOLDER=./checks/kubernetes/policies/dynamic
 test:
 	go test -v ./...
 
+
 .PHONY: rego
-rego: fmt-rego
+rego: fmt-rego test-rego
+
+.PHONY: test-rego
+test-rego: 
+	opa test -v checks/ lib/
 
 .PHONY: fmt-rego
 fmt-rego:
-	opa fmt -w checks/
+	opa fmt -w checks/ lib/
 
 .PHONY: bundle
 bundle: create-bundle verify-bundle

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ rego: fmt-rego test-rego
 
 .PHONY: test-rego
 test-rego: 
-	opa test -v checks/ lib/
+	opa test checks/ lib/
 
 .PHONY: fmt-rego
 fmt-rego:

--- a/checks/cloud/aws/iam/filter_iam_pass_role.rego
+++ b/checks/cloud/aws/iam/filter_iam_pass_role.rego
@@ -22,6 +22,8 @@
 #           provider: aws
 package builtin.aws.iam.aws0342
 
+import data.lib.result
+
 allows_permission(statements, permission, effect) {
 	statement := statements[_]
 	statement.Effect == effect

--- a/checks/cloud/aws/rds/disable_public_access.rego
+++ b/checks/cloud/aws/rds/disable_public_access.rego
@@ -26,6 +26,8 @@
 
 package builtin.aws.rds.aws0180
 
+import data.lib.result
+
 deny[res] {
 	instance := input.aws.rds.instances[_]
 	instance.publicaccess.value

--- a/checks/cloud/aws/rds/enable_cluster_deletion_protection.rego
+++ b/checks/cloud/aws/rds/enable_cluster_deletion_protection.rego
@@ -21,6 +21,8 @@
 #           provider: aws
 package builtin.aws.rds.aws0343
 
+import data.lib.result
+
 deny[res] {
 	cluster := input.aws.rds.clusters[_]
 	not cluster.deletionprotection.value

--- a/checks/cloud/aws/rds/enable_deletion_protection.rego
+++ b/checks/cloud/aws/rds/enable_deletion_protection.rego
@@ -21,6 +21,8 @@
 #           provider: aws
 package builtin.aws.rds.aws0177
 
+import data.lib.result
+
 deny[res] {
 	instance := input.aws.rds.instances[_]
 	not instance.deletionprotection.value

--- a/checks/cloud/aws/rds/enable_iam_auth.rego
+++ b/checks/cloud/aws/rds/enable_iam_auth.rego
@@ -21,6 +21,8 @@
 #           provider: aws
 package builtin.aws.rds.aws0176
 
+import data.lib.result
+
 deny[res] {
 	instance := input.aws.rds.instances[_]
 	instance.engine.value == ["postgres", "mysql"][_]

--- a/checks/cloud/aws/s3/dns_compliant_name.rego
+++ b/checks/cloud/aws/s3/dns_compliant_name.rego
@@ -22,6 +22,8 @@
 #           provider: aws
 package builtin.aws.s3.aws0320
 
+import data.lib.result
+
 deny[res] {
 	bucket := input.aws.s3.buckets[_]
 	indexof(bucket.name.value, ".") != -1

--- a/checks/cloud/aws/s3/enable_logging.rego
+++ b/checks/cloud/aws/s3/enable_logging.rego
@@ -27,6 +27,8 @@
 #       good_examples: "checks/cloud/aws/s3/enable_bucket_logging.cf.go"
 package builtin.aws.s3.aws0089
 
+import data.lib.result
+
 deny[res] {
 	bucket := input.aws.s3.buckets[_]
 	not bucket.acl.value == "log-delivery-write"

--- a/checks/docker/add_instead_of_copy.rego
+++ b/checks/docker/add_instead_of_copy.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS005
 
 import data.lib.docker
+import data.lib.result
 
 get_add[output] {
 	add := docker.add[_]

--- a/checks/docker/apt_get_missing_no_install_recommends.rego
+++ b/checks/docker/apt_get_missing_no_install_recommends.rego
@@ -19,6 +19,7 @@
 package builtin.dockerfile.DS029
 
 import data.lib.docker
+import data.lib.result
 
 deny[res] {
 	output := get_apt_get[_]

--- a/checks/docker/apt_get_missing_yes_flag_to_avoid_manual_input.rego
+++ b/checks/docker/apt_get_missing_yes_flag_to_avoid_manual_input.rego
@@ -19,6 +19,7 @@
 package builtin.dockerfile.DS021
 
 import data.lib.docker
+import data.lib.result
 
 deny[res] {
 	output := get_apt_get[_]

--- a/checks/docker/copy_from_references_current_from_alias.rego
+++ b/checks/docker/copy_from_references_current_from_alias.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS006
 
 import data.lib.docker
+import data.lib.result
 
 get_alias_from_copy[output] {
 	copies := docker.stage_copies[stage]

--- a/checks/docker/copy_with_more_than_two_arguments_not_ending_with_slash.rego
+++ b/checks/docker/copy_with_more_than_two_arguments_not_ending_with_slash.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS011
 
 import data.lib.docker
+import data.lib.result
 
 get_copy_arg[output] {
 	copy := docker.copy[_]

--- a/checks/docker/latest_tag.rego
+++ b/checks/docker/latest_tag.rego
@@ -16,6 +16,7 @@
 package builtin.dockerfile.DS001
 
 import data.lib.docker
+import data.lib.result
 
 # returns element after AS
 get_alias(values) = alias {

--- a/checks/docker/maintainer_is_deprecated.rego
+++ b/checks/docker/maintainer_is_deprecated.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS022
 
 import data.lib.docker
+import data.lib.result
 
 get_maintainer[mntnr] {
 	mntnr := input.Stages[_].Commands[_]

--- a/checks/docker/missing_apk_no_cache.rego
+++ b/checks/docker/missing_apk_no_cache.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS025
 
 import data.lib.docker
+import data.lib.result
 
 get_apk[output] {
 	run := docker.run[_]

--- a/checks/docker/missing_dnf_clean_all.rego
+++ b/checks/docker/missing_dnf_clean_all.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS019
 
 import data.lib.docker
+import data.lib.result
 
 install_regex := `(dnf install)|(dnf in)|(dnf reinstall)|(dnf rei)|(dnf install-n)|(dnf install-na)|(dnf install-nevra)`
 

--- a/checks/docker/missing_microdnf_clean_all.rego
+++ b/checks/docker/missing_microdnf_clean_all.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS027
 
 import data.lib.docker
+import data.lib.result
 
 install_regex := `(microdnf install)|(microdnf reinstall)`
 

--- a/checks/docker/missing_zypper_clean.rego
+++ b/checks/docker/missing_zypper_clean.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS020
 
 import data.lib.docker
+import data.lib.result
 
 install_regex := `(zypper in)|(zypper remove)|(zypper rm)|(zypper source-install)|(zypper si)|(zypper patch)|(zypper (-(-)?[a-zA-Z]+ *)*install)`
 

--- a/checks/docker/multiple_cmd_instructions_listed.rego
+++ b/checks/docker/multiple_cmd_instructions_listed.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS016
 
 import data.lib.docker
+import data.lib.result
 
 deny[res] {
 	cmds := docker.stage_cmd[name]

--- a/checks/docker/multiple_entrypoint_instructions_listed.rego
+++ b/checks/docker/multiple_entrypoint_instructions_listed.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS007
 
 import data.lib.docker
+import data.lib.result
 
 deny[res] {
 	entrypoints := docker.stage_entrypoints[stage]

--- a/checks/docker/multiple_healthcheck_instructions.rego
+++ b/checks/docker/multiple_healthcheck_instructions.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS023
 
 import data.lib.docker
+import data.lib.result
 
 deny[res] {
 	healthchecks := docker.stage_healthcheck[name]

--- a/checks/docker/no_healthcheck_instruction.rego
+++ b/checks/docker/no_healthcheck_instruction.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS026
 
 import data.lib.docker
+import data.lib.result
 
 deny[res] {
 	count(docker.healthcheck) == 0

--- a/checks/docker/port22.rego
+++ b/checks/docker/port22.rego
@@ -16,6 +16,7 @@
 package builtin.dockerfile.DS004
 
 import data.lib.docker
+import data.lib.result
 
 # deny_list contains the port numbers which needs to be denied.
 denied_ports := ["22", "22/tcp", "22/udp"]

--- a/checks/docker/root_user.rego
+++ b/checks/docker/root_user.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS002
 
 import data.lib.docker
+import data.lib.result
 
 # get_user returns all the usernames from
 # the USER command.

--- a/checks/docker/root_user_test.rego
+++ b/checks/docker/root_user_test.rego
@@ -1,6 +1,7 @@
 package builtin.dockerfile.DS002
 
 import data.lib.docker
+import data.lib.result
 
 test_not_root_allowed {
 	r := deny with input as {"Stages": [{

--- a/checks/docker/run_apt_get_dist_upgrade.rego
+++ b/checks/docker/run_apt_get_dist_upgrade.rego
@@ -16,6 +16,7 @@
 package builtin.dockerfile.DS024
 
 import data.lib.docker
+import data.lib.result
 
 get_apt_get_dist_upgrade[run] {
 	run := docker.run[_]

--- a/checks/docker/run_command_cd_instead_of_workdir.rego
+++ b/checks/docker/run_command_cd_instead_of_workdir.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS013
 
 import data.lib.docker
+import data.lib.result
 
 get_cd[output] {
 	run := docker.run[_]

--- a/checks/docker/run_using_sudo.rego
+++ b/checks/docker/run_using_sudo.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS010
 
 import data.lib.docker
+import data.lib.result
 
 has_sudo(commands) {
 	parts = split(commands, "&&")

--- a/checks/docker/run_using_wget_and_curl.rego
+++ b/checks/docker/run_using_wget_and_curl.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS014
 
 import data.lib.docker
+import data.lib.result
 
 deny[res] {
 	wget := get_tool_usage(docker.run[_], "wget")

--- a/checks/docker/same_alias_in_different_froms.rego
+++ b/checks/docker/same_alias_in_different_froms.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS012
 
 import data.lib.docker
+import data.lib.result
 
 get_duplicate_alias[output] {
 	output1 := get_aliased_name[_]

--- a/checks/docker/unix_ports_out_of_range.rego
+++ b/checks/docker/unix_ports_out_of_range.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS008
 
 import data.lib.docker
+import data.lib.result
 
 invalid_ports[output] {
 	expose := docker.expose[_]

--- a/checks/docker/update_instruction_alone.rego
+++ b/checks/docker/update_instruction_alone.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS017
 
 import data.lib.docker
+import data.lib.result
 
 deny[res] {
 	run := docker.run[_]

--- a/checks/docker/workdir_path_not_absolute.rego
+++ b/checks/docker/workdir_path_not_absolute.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS009
 
 import data.lib.docker
+import data.lib.result
 
 get_work_dir[output] {
 	workdir := docker.workdir[_]

--- a/checks/docker/yum_clean_all_missing.rego
+++ b/checks/docker/yum_clean_all_missing.rego
@@ -18,6 +18,7 @@
 package builtin.dockerfile.DS015
 
 import data.lib.docker
+import data.lib.result
 
 get_yum[output] {
 	run := docker.run[_]

--- a/checks/kubernetes/advanced/default_namespace_should_not_be_used.rego
+++ b/checks/kubernetes/advanced/default_namespace_should_not_be_used.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV110
 
 import data.lib.kubernetes
+import data.lib.result
 
 default defaultNamespaceInUse = false
 

--- a/checks/kubernetes/advanced/optional/capabilities_no_drop_at_least_one.rego
+++ b/checks/kubernetes/advanced/optional/capabilities_no_drop_at_least_one.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV004
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 default failCapsDropAny = false

--- a/checks/kubernetes/advanced/optional/manages_etc_hosts.rego
+++ b/checks/kubernetes/advanced/optional/manages_etc_hosts.rego
@@ -25,6 +25,7 @@
 package builtin.kubernetes.KSV007
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 # failHostAliases is true if spec.hostAliases is set (on all controllers)

--- a/checks/kubernetes/advanced/optional/use_limit_range.rego
+++ b/checks/kubernetes/advanced/optional/use_limit_range.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KSV039
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 limitRangeConfigure {

--- a/checks/kubernetes/advanced/optional/use_resource_quota.rego
+++ b/checks/kubernetes/advanced/optional/use_resource_quota.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KSV040
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 resourceQuotaConfigure {

--- a/checks/kubernetes/advanced/optional/uses_untrusted_azure_registry.rego
+++ b/checks/kubernetes/advanced/optional/uses_untrusted_azure_registry.rego
@@ -25,6 +25,7 @@
 package builtin.kubernetes.KSV032
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 default failTrustedAzureRegistry = false

--- a/checks/kubernetes/advanced/optional/uses_untrusted_ecr_registry.rego
+++ b/checks/kubernetes/advanced/optional/uses_untrusted_ecr_registry.rego
@@ -25,6 +25,7 @@
 package builtin.kubernetes.KSV035
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 default failTrustedECRRegistry = false

--- a/checks/kubernetes/advanced/optional/uses_untrusted_gcr_registry.rego
+++ b/checks/kubernetes/advanced/optional/uses_untrusted_gcr_registry.rego
@@ -25,6 +25,7 @@
 package builtin.kubernetes.KSV033
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 default failTrustedGCRRegistry = false

--- a/checks/kubernetes/advanced/optional/uses_untrusted_public_registries.rego
+++ b/checks/kubernetes/advanced/optional/uses_untrusted_public_registries.rego
@@ -25,6 +25,7 @@
 package builtin.kubernetes.KSV034
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 default failPublicRegistry = false

--- a/checks/kubernetes/advanced/protect_core_components_namespace.rego
+++ b/checks/kubernetes/advanced/protect_core_components_namespace.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KSV037
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 systemNamespaceInUse(metadata, spec) {

--- a/checks/kubernetes/advanced/protecting_pod_service_account_tokens.rego
+++ b/checks/kubernetes/advanced/protecting_pod_service_account_tokens.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KSV036
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 mountServiceAccountToken(spec) {

--- a/checks/kubernetes/advanced/selector_usage_in_network_policies.rego
+++ b/checks/kubernetes/advanced/selector_usage_in_network_policies.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KSV038
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 hasSelector(spec) {

--- a/checks/kubernetes/aquacommercial/configMap_with_secrets.rego
+++ b/checks/kubernetes/aquacommercial/configMap_with_secrets.rego
@@ -19,6 +19,7 @@
 package builtin.kubernetes.KSV0109
 
 import data.lib.kubernetes
+import data.lib.result
 
 # More patterns can be added here, adding more patterns may lead to performance issue
 patterns := [

--- a/checks/kubernetes/aquacommercial/configmap_with_sensitive.rego
+++ b/checks/kubernetes/aquacommercial/configmap_with_sensitive.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KSV01010
 
 import data.lib.kubernetes
+import data.lib.result
 
 # More patterns can be added here, adding more patterns may lead to performance issue
 # some patterns are taken from https://github.com/americanexpress/earlybird/blob/d0b63538c1acbb5ab0cacf0541df5ea088d45d70/config/content.json

--- a/checks/kubernetes/aquacommercial/service_with_externalip.rego
+++ b/checks/kubernetes/aquacommercial/service_with_externalip.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KSV0108
 
 import data.lib.kubernetes
+import data.lib.result
 
 allowedIPs = set()
 

--- a/checks/kubernetes/cisbenchmarks/apiserver/admin_conf_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/admin_conf_ownership.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0061
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_conf_ownership(sp) := {"adminConfFileOwnership": violation} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/apiserver/admin_conf_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/admin_conf_permission.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0060
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_conf_permission(sp) := {"adminConfFilePermissions": violation} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/apiserver/always_admit_plugin.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/always_admit_plugin.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0011
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/always_pull_images_plugin.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/always_pull_images_plugin.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0012
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/anonymous_auth.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/anonymous_auth.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0001
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/audit_log_maxage.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/audit_log_maxage.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0020
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/audit_log_maxbackup.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/audit_log_maxbackup.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0021
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/audit_log_maxsize.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/audit_log_maxsize.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0022
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/audit_log_path.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/audit_log_path.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0019
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/authorization_mode.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/authorization_mode.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0007
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/authorization_mode_includes_node.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/authorization_mode_includes_node.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0008
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/authorization_mode_includes_rbac.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/authorization_mode_includes_rbac.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0009
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/client_ca_file.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/client_ca_file.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0028
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/deny_service_external_ips_plugin.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/deny_service_external_ips_plugin.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0003
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/encryption_provider_config.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/encryption_provider_config.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0030
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/etcd_cafile.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/etcd_cafile.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0029
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/etcd_certfile_and_keyfile.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/etcd_certfile_and_keyfile.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0026
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/event_rate_limit_plugin.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/event_rate_limit_plugin.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0010
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/kubelet_certificate_authority.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/kubelet_certificate_authority.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0006
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/kubelet_client_certificate_and_key.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/kubelet_client_certificate_and_key.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0005
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/kubelet_https.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/kubelet_https.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0004
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/kubernetes_pki_cert_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/kubernetes_pki_cert_permission.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0068
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_pki_cert_permission(sp) := {"kubernetesPKICertificateFilePermissions": violation} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/apiserver/kubernetes_pki_directory_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/kubernetes_pki_directory_ownership.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0066
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_pki_directory_ownership(sp) := {"kubePKIDirectoryFileOwnership": violation} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/apiserver/kubernetes_pki_key_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/kubernetes_pki_key_permission.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0067
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_pki_key_permission(sp) := {"kubePKIKeyFilePermissions": violation} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/apiserver/namespace_lifecycle_plugin.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/namespace_lifecycle_plugin.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0015
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/node_restriction_plugin.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/node_restriction_plugin.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0016
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/pod_spec_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/pod_spec_ownership.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0049
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_spec_ownership(sp) := {"kubeAPIServerSpecFileOwnership": violation} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/apiserver/pod_spec_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/pod_spec_permission.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0048
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_spec_permission(sp) := {"kubeAPIServerSpecFilePermission": violation} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/apiserver/profiling.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/profiling.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0018
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/secure_port.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/secure_port.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0017
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/security_context_deny_plugin.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/security_context_deny_plugin.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0013
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/service_account_key_file.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/service_account_key_file.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0025
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/service_account_lookup.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/service_account_lookup.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0024
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/service_account_plugin.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/service_account_plugin.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0014
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/tls_cert_file_and_private_key_file.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/tls_cert_file_and_private_key_file.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0027
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/apiserver/token_auth_file.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/token_auth_file.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0002
 
 import data.lib.kubernetes
+import data.lib.result
 
 check_flag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/cni/pod_spec_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/cni/pod_spec_ownership.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0057
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_spec_ownership(sp) := {"containerNetworkInterfaceFileOwnership": violation} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/cni/pod_spec_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/cni/pod_spec_permission.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0056
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_cni_permission(sp) := {"containerNetworkInterfaceFilePermissions": violation} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/controllermamager/bind_address.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/bind_address.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0039
 
 import data.lib.kubernetes
+import data.lib.result
 
 checkFlag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/controllermamager/controller_manager_conf_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/controller_manager_conf_ownership.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0065
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_conf_ownership(sp) := {"controllerManagerConfFileOwnership": violation} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/controllermamager/controller_manager_conf_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/controller_manager_conf_permission.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0064
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_conf_permission(sp) := {"controllerManagerConfFilePermissions": violation} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/controllermamager/pod_spec_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/pod_spec_ownership.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0051
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_spec_ownership(sp) := {"kubeControllerManagerSpecFileOwnership": violation} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/controllermamager/pod_spec_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/pod_spec_permission.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0050
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_spec_permission(sp) := {"kubeControllerManagerSpecFilePermission": violation} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/controllermamager/profiling.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/profiling.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0034
 
 import data.lib.kubernetes
+import data.lib.result
 
 checkFlag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/controllermamager/root_ca_file.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/root_ca_file.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0037
 
 import data.lib.kubernetes
+import data.lib.result
 
 checkFlag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/controllermamager/rotate_kubelet_server_certificate.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/rotate_kubelet_server_certificate.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0038
 
 import data.lib.kubernetes
+import data.lib.result
 
 checkFlag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/controllermamager/service_account_private_key_file.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/service_account_private_key_file.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0036
 
 import data.lib.kubernetes
+import data.lib.result
 
 checkFlag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/controllermamager/terminated_pod_gc_threshold.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/terminated_pod_gc_threshold.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0033
 
 import data.lib.kubernetes
+import data.lib.result
 
 checkFlag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/controllermamager/use_service_account_credentials.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/use_service_account_credentials.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0035
 
 import data.lib.kubernetes
+import data.lib.result
 
 checkFlag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/etcd/auto_tls.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/auto_tls.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0044
 
 import data.lib.kubernetes
+import data.lib.result
 
 checkFlag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/etcd/cert_file_and_key_file.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/cert_file_and_key_file.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0042
 
 import data.lib.kubernetes
+import data.lib.result
 
 checkFlag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/etcd/client_cert_auth.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/client_cert_auth.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0043
 
 import data.lib.kubernetes
+import data.lib.result
 
 checkFlag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/etcd/data_directory_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/data_directory_ownership.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0059
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_data_dir_ownership(sp) := {"etcdDataDirectoryOwnership": ownership} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/etcd/data_directory_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/data_directory_permission.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0058
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_spec_permission(sp) := {"etcdDataDirectoryPermissions": permission} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/etcd/peer_auto_tls.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/peer_auto_tls.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0047
 
 import data.lib.kubernetes
+import data.lib.result
 
 checkFlag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/etcd/peer_cert_file_and_key_file.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/peer_cert_file_and_key_file.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0045
 
 import data.lib.kubernetes
+import data.lib.result
 
 checkFlag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/etcd/peer_client_cert_auth.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/peer_client_cert_auth.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0046
 
 import data.lib.kubernetes
+import data.lib.result
 
 checkFlag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/etcd/pod_spec_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/pod_spec_ownership.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0055
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_spec_ownership(sp) := {"kubeEtcdSpecFileOwnership": violation} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/etcd/pod_spec_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/pod_spec_permission.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0054
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_spec_permission(sp) := {"kubeEtcdSpecFilePermission": violation} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/kubelet/certificate_authorities_file_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/certificate_authorities_file_ownership.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0076
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/certificate_authorities_file_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/certificate_authorities_file_permission.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0075
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_anonymous_auth_argument.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_anonymous_auth_argument.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0079
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_authorization_mode_argument.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_authorization_mode_argument.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0080
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_client_ca_file_argument.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_client_ca_file_argument.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0081
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_config_file_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_config_file_ownership.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0074
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_config_file_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_config_file_permission.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0073
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_config_yaml_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_config_yaml_ownership.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0078
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_config_yaml_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_config_yaml_permission.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0077
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_event_qps.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_event_qps.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0087
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_hostname_override.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_hostname_override.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0086
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_make_iptables_util_chains.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_make_iptables_util_chains.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0084
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_only_use_strong_cryptographic.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_only_use_strong_cryptographic.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0092
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_protect_kernel_defaults.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_protect_kernel_defaults.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0083
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_read_only_port_argument.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_read_only_port_argument.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0082
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_rotate_certificates.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_rotate_certificates.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0090
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_rotate_kubelet_server_certificate.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_rotate_kubelet_server_certificate.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0091
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_streaming_connection_argument.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_streaming_connection_argument.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0085
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_tls_cert_file.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_tls_cert_file.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0088
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_tls_key_file.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_tls_key_file.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0089
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kublet_service_file_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kublet_service_file_ownership.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0070
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/kublet_service_file_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kublet_service_file_permission.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0069
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/proxy_kube_config_file_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/proxy_kube_config_file_ownership.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0072
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/kubelet/proxy_kube_config_file_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/proxy_kube_config_file_permission.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0071
 
 import data.lib.kubernetes
+import data.lib.result
 
 types := ["master", "worker"]
 

--- a/checks/kubernetes/cisbenchmarks/scheduler/bind_address.rego
+++ b/checks/kubernetes/cisbenchmarks/scheduler/bind_address.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0041
 
 import data.lib.kubernetes
+import data.lib.result
 
 checkFlag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/scheduler/pod_spec_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/scheduler/pod_spec_ownership.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0053
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_spec_ownership(sp) := {"kubeSchedulerSpecFileOwnership": violation} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/scheduler/pod_spec_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/scheduler/pod_spec_permission.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0052
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_spec_permission(sp) := {"kubeSchedulerSpecFilePermission": violation} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/scheduler/profiling.rego
+++ b/checks/kubernetes/cisbenchmarks/scheduler/profiling.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0040
 
 import data.lib.kubernetes
+import data.lib.result
 
 checkFlag[container] {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/cisbenchmarks/scheduler/scheduler_conf_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/scheduler/scheduler_conf_ownership.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0063
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_conf_ownership(sp) := {"schedulerConfFileOwnership": violation} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/cisbenchmarks/scheduler/scheduler_conf_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/scheduler/scheduler_conf_permission.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KCV0062
 
 import data.lib.kubernetes
+import data.lib.result
 
 validate_conf_permission(sp) := {"schedulerConfFilePermissions": violation} {
 	sp.kind == "NodeInfo"

--- a/checks/kubernetes/dynamic/outdated_api.rego
+++ b/checks/kubernetes/dynamic/outdated_api.rego
@@ -2,6 +2,7 @@ package defsec.kubernetes.KSV107
 
 import data.k8s
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 __rego_metadata__ := {

--- a/checks/kubernetes/general/CPU_not_limited.rego
+++ b/checks/kubernetes/general/CPU_not_limited.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV011
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 default failLimitsCPU = false

--- a/checks/kubernetes/general/CPU_requests_not_specified.rego
+++ b/checks/kubernetes/general/CPU_requests_not_specified.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV015
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 default failRequestsCPU = false

--- a/checks/kubernetes/general/SYS_ADMIN_capability.rego
+++ b/checks/kubernetes/general/SYS_ADMIN_capability.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV005
 
 import data.lib.kubernetes
+import data.lib.result
 
 default failCapsSysAdmin = false
 

--- a/checks/kubernetes/general/SYS_MODULE_capability.rego
+++ b/checks/kubernetes/general/SYS_MODULE_capability.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV120
 
 import data.lib.kubernetes
+import data.lib.result
 
 default failCapsSysModule = false
 

--- a/checks/kubernetes/general/allowing_create_role_binding_and_associate_privileged_clusterrole.rego
+++ b/checks/kubernetes/general/allowing_create_role_binding_and_associate_privileged_clusterrole.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KSV051
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 readKinds := ["Role", "ClusterRole"]

--- a/checks/kubernetes/general/allowing_create_role_clusterrolebinding_and_associate_privileged_clusterrole.rego
+++ b/checks/kubernetes/general/allowing_create_role_clusterrolebinding_and_associate_privileged_clusterrole.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KSV052
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 readKinds := ["Role", "ClusterRole"]

--- a/checks/kubernetes/general/allowing_to_update_a_malicious_pod.rego
+++ b/checks/kubernetes/general/allowing_to_update_a_malicious_pod.rego
@@ -21,6 +21,7 @@
 package builtin.kubernetes.KSV048
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 workloads := ["pods", "deployments", "jobs", "cronjobs", "statefulsets", "daemonsets", "replicasets", "replicationcontrollers"]

--- a/checks/kubernetes/general/allowing_users_rolebinding_add_other_users_rolebindings.rego
+++ b/checks/kubernetes/general/allowing_users_rolebinding_add_other_users_rolebindings.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KSV055
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 readKinds := ["Role", "ClusterRole"]

--- a/checks/kubernetes/general/anonymous_user_bind.rego
+++ b/checks/kubernetes/general/anonymous_user_bind.rego
@@ -22,6 +22,7 @@
 package appshield.kubernetes.KSV122
 
 import data.lib.kubernetes
+import data.lib.result
 
 readRoleRefs := ["system:unauthenticated", "system:anonymous"]
 

--- a/checks/kubernetes/general/any_any.rego
+++ b/checks/kubernetes/general/any_any.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KSV044
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 readKinds := ["Role", "ClusterRole"]

--- a/checks/kubernetes/general/any_verb.rego
+++ b/checks/kubernetes/general/any_verb.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KSV045
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 resourceRead := ["secrets", "pods", "deployments", "daemonsets", "statefulsets", "replicationcontrollers", "replicasets", "cronjobs", "jobs", "roles", "clusterroles", "rolebindings", "clusterrolebindings", "users", "groups"]

--- a/checks/kubernetes/general/attaching_pod_view_logs_realtime.rego
+++ b/checks/kubernetes/general/attaching_pod_view_logs_realtime.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KSV054
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 readKinds := ["Role", "ClusterRole"]

--- a/checks/kubernetes/general/capabilities_no_drop_all.rego
+++ b/checks/kubernetes/general/capabilities_no_drop_all.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV003
 
 import data.lib.kubernetes
+import data.lib.result
 
 default checkCapsDropAll = false
 

--- a/checks/kubernetes/general/default_security_context.rego
+++ b/checks/kubernetes/general/default_security_context.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV118
 
 import data.lib.kubernetes
+import data.lib.result
 
 default failCapsDefaultSecurityContext = false
 

--- a/checks/kubernetes/general/delete_pod_logs.rego
+++ b/checks/kubernetes/general/delete_pod_logs.rego
@@ -21,6 +21,7 @@
 package builtin.kubernetes.KSV042
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 readVerbs := ["delete", "deletecollection", "*"]

--- a/checks/kubernetes/general/file_system_not_read_only.rego
+++ b/checks/kubernetes/general/file_system_not_read_only.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV014
 
 import data.lib.kubernetes
+import data.lib.result
 
 default failReadOnlyRootFilesystem = false
 

--- a/checks/kubernetes/general/get_shell_on_pod.rego
+++ b/checks/kubernetes/general/get_shell_on_pod.rego
@@ -21,6 +21,7 @@
 package builtin.kubernetes.KSV053
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 workloads := ["pods/exec"]

--- a/checks/kubernetes/general/impersonate_privileged_groups.rego
+++ b/checks/kubernetes/general/impersonate_privileged_groups.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KSV043
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 readKinds := ["Role", "ClusterRole"]

--- a/checks/kubernetes/general/manage_all_resources.rego
+++ b/checks/kubernetes/general/manage_all_resources.rego
@@ -20,6 +20,7 @@
 package builtin.kubernetes.KSV046
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 readVerbs := ["create", "update", "delete", "deletecollection", "impersonate", "*", "list", "get"]

--- a/checks/kubernetes/general/manage_all_resources_at_namespace.rego
+++ b/checks/kubernetes/general/manage_all_resources_at_namespace.rego
@@ -20,6 +20,7 @@
 package builtin.kubernetes.KSV112
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 readVerbs := ["create", "update", "delete", "deletecollection", "impersonate", "*", "list", "get"]

--- a/checks/kubernetes/general/manage_configmaps.rego
+++ b/checks/kubernetes/general/manage_configmaps.rego
@@ -21,6 +21,7 @@
 package builtin.kubernetes.KSV049
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 readVerbs := ["create", "update", "patch", "delete", "deletecollection", "impersonate", "*"]

--- a/checks/kubernetes/general/manage_eks_iam_auth_configmap.rego
+++ b/checks/kubernetes/general/manage_eks_iam_auth_configmap.rego
@@ -21,6 +21,7 @@
 package builtin.kubernetes.KSV115
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 readVerbs := ["create", "update", "patch", "delete", "deletecollection", "impersonate", "*"]

--- a/checks/kubernetes/general/manage_kubernetes_networking.rego
+++ b/checks/kubernetes/general/manage_kubernetes_networking.rego
@@ -21,6 +21,7 @@
 package builtin.kubernetes.KSV056
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 readKinds := ["Role", "ClusterRole"]

--- a/checks/kubernetes/general/manage_kubernetes_rbac_resources.rego
+++ b/checks/kubernetes/general/manage_kubernetes_rbac_resources.rego
@@ -21,6 +21,7 @@
 package builtin.kubernetes.KSV050
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 readVerbs := ["create", "update", "delete", "deletecollection", "impersonate", "*"]

--- a/checks/kubernetes/general/manage_namespace_secrets.rego
+++ b/checks/kubernetes/general/manage_namespace_secrets.rego
@@ -20,6 +20,7 @@
 package builtin.kubernetes.KSV113
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 readVerbs := ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection", "impersonate", "*"]

--- a/checks/kubernetes/general/manage_secrets.rego
+++ b/checks/kubernetes/general/manage_secrets.rego
@@ -20,6 +20,7 @@
 package builtin.kubernetes.KSV041
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 readVerbs := ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection", "impersonate", "*"]

--- a/checks/kubernetes/general/manage_webhook_configurations.rego
+++ b/checks/kubernetes/general/manage_webhook_configurations.rego
@@ -21,6 +21,7 @@
 package builtin.kubernetes.KSV114
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 readVerbs := ["create", "update", "patch", "delete", "deletecollection", "impersonate", "*"]

--- a/checks/kubernetes/general/memory_not_limited.rego
+++ b/checks/kubernetes/general/memory_not_limited.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV018
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 default failLimitsMemory = false

--- a/checks/kubernetes/general/memory_requests_not_specified.rego
+++ b/checks/kubernetes/general/memory_requests_not_specified.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV016
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 default failRequestsMemory = false

--- a/checks/kubernetes/general/mounts_docker_socket.rego
+++ b/checks/kubernetes/general/mounts_docker_socket.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV006
 
 import data.lib.kubernetes
+import data.lib.result
 
 name = input.metadata.name
 

--- a/checks/kubernetes/general/net_raw_capability.rego
+++ b/checks/kubernetes/general/net_raw_capability.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV119
 
 import data.lib.kubernetes
+import data.lib.result
 
 default failCapsNetRaw = false
 

--- a/checks/kubernetes/general/privilege_escalation_from_node_proxy.rego
+++ b/checks/kubernetes/general/privilege_escalation_from_node_proxy.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KSV047
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 readVerbs := ["get", "create"]

--- a/checks/kubernetes/general/runs_with_GID_le_10000.rego
+++ b/checks/kubernetes/general/runs_with_GID_le_10000.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV021
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 default failRunAsGroup = false

--- a/checks/kubernetes/general/runs_with_UID_le_10000.rego
+++ b/checks/kubernetes/general/runs_with_UID_le_10000.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV020
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 default failRunAsUser = false

--- a/checks/kubernetes/general/runs_with_a_root_primary_or_supplementary_GID.rego
+++ b/checks/kubernetes/general/runs_with_a_root_primary_or_supplementary_GID.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV116
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 default failRootGroupId = false

--- a/checks/kubernetes/general/tiller_is_deployed.rego
+++ b/checks/kubernetes/general/tiller_is_deployed.rego
@@ -16,6 +16,7 @@
 package builtin.kubernetes.KSV102
 
 import data.lib.kubernetes
+import data.lib.result
 
 # Get all containers and check kubernetes metadata for tiller
 tillerDeployed[container] {

--- a/checks/kubernetes/general/uses_image_tag_latest.rego
+++ b/checks/kubernetes/general/uses_image_tag_latest.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV013
 
 import data.lib.kubernetes
+import data.lib.result
 
 default checkUsingLatestTag = false
 

--- a/checks/kubernetes/pss/baseline/10_windows_host_process.rego
+++ b/checks/kubernetes/pss/baseline/10_windows_host_process.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV103
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 failHostProcess[spec] {

--- a/checks/kubernetes/pss/baseline/11_seccomp_profile_unconfined.rego
+++ b/checks/kubernetes/pss/baseline/11_seccomp_profile_unconfined.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV104
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 # getSeccompContainers returns all containers which have a seccomp

--- a/checks/kubernetes/pss/baseline/12_privileged_ports_binding.rego
+++ b/checks/kubernetes/pss/baseline/12_privileged_ports_binding.rego
@@ -28,6 +28,7 @@
 package builtin.kubernetes.KSV117
 
 import data.lib.kubernetes
+import data.lib.result
 
 default failPrivilegedPort = false
 

--- a/checks/kubernetes/pss/baseline/1_host_ipc.rego
+++ b/checks/kubernetes/pss/baseline/1_host_ipc.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV008
 
 import data.lib.kubernetes
+import data.lib.result
 
 default failHostIPC = false
 

--- a/checks/kubernetes/pss/baseline/1_host_network.rego
+++ b/checks/kubernetes/pss/baseline/1_host_network.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV009
 
 import data.lib.kubernetes
+import data.lib.result
 
 default failHostNetwork = false
 

--- a/checks/kubernetes/pss/baseline/1_host_pid.rego
+++ b/checks/kubernetes/pss/baseline/1_host_pid.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV010
 
 import data.lib.kubernetes
+import data.lib.result
 
 default failHostPID = false
 

--- a/checks/kubernetes/pss/baseline/2_privileged.rego
+++ b/checks/kubernetes/pss/baseline/2_privileged.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV017
 
 import data.lib.kubernetes
+import data.lib.result
 
 default failPrivileged = false
 

--- a/checks/kubernetes/pss/baseline/3_specific_capabilities_added.rego
+++ b/checks/kubernetes/pss/baseline/3_specific_capabilities_added.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV022
 
 import data.lib.kubernetes
+import data.lib.result
 
 default failAdditionalCaps = false
 

--- a/checks/kubernetes/pss/baseline/4_hostpath_volumes_mounted.rego
+++ b/checks/kubernetes/pss/baseline/4_hostpath_volumes_mounted.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV023
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 default failHostPathVolume = false

--- a/checks/kubernetes/pss/baseline/5_access_to_host_ports.rego
+++ b/checks/kubernetes/pss/baseline/5_access_to_host_ports.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV024
 
 import data.lib.kubernetes
+import data.lib.result
 
 default failHostPorts = false
 

--- a/checks/kubernetes/pss/baseline/6_apparmor_policy_disabled.rego
+++ b/checks/kubernetes/pss/baseline/6_apparmor_policy_disabled.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV002
 
 import data.lib.kubernetes
+import data.lib.result
 
 default failAppArmor = false
 

--- a/checks/kubernetes/pss/baseline/6_apparmor_policy_disabled_test.rego
+++ b/checks/kubernetes/pss/baseline/6_apparmor_policy_disabled_test.rego
@@ -1,6 +1,7 @@
 package builtin.kubernetes.KSV002
 
 import data.lib.kubernetes
+import data.lib.result
 
 test_custom_deny {
 	r := deny with input as {

--- a/checks/kubernetes/pss/baseline/7_selinux_custom_options_set.rego
+++ b/checks/kubernetes/pss/baseline/7_selinux_custom_options_set.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV025
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 default failSELinux = false

--- a/checks/kubernetes/pss/baseline/8_non_default_proc_masks_set.rego
+++ b/checks/kubernetes/pss/baseline/8_non_default_proc_masks_set.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV027
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 default failProcMount = false

--- a/checks/kubernetes/pss/baseline/9_unsafe_sysctl_options_set.rego
+++ b/checks/kubernetes/pss/baseline/9_unsafe_sysctl_options_set.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV026
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 default failSysctls = false

--- a/checks/kubernetes/pss/restricted/1_non_core_volume_types.rego
+++ b/checks/kubernetes/pss/restricted/1_non_core_volume_types.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV028
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 # Add disallowed volume type

--- a/checks/kubernetes/pss/restricted/2_can_elevate_its_own_privileges.rego
+++ b/checks/kubernetes/pss/restricted/2_can_elevate_its_own_privileges.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV001
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 default checkAllowPrivilegeEscalation = false

--- a/checks/kubernetes/pss/restricted/3_runs_as_root.rego
+++ b/checks/kubernetes/pss/restricted/3_runs_as_root.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV012
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 default checkRunAsNonRoot = false

--- a/checks/kubernetes/pss/restricted/4_runs_with_a_root_uid.rego
+++ b/checks/kubernetes/pss/restricted/4_runs_with_a_root_uid.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KSV105
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 failRootUserId[securityContext] {

--- a/checks/kubernetes/pss/restricted/5_runtime_default_seccomp_profile_not_set.rego
+++ b/checks/kubernetes/pss/restricted/5_runtime_default_seccomp_profile_not_set.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV030
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 getType(target) = type {

--- a/checks/kubernetes/pss/restricted/5_runtime_default_seccomp_profile_not_set_test.rego
+++ b/checks/kubernetes/pss/restricted/5_runtime_default_seccomp_profile_not_set_test.rego
@@ -1,6 +1,7 @@
 package builtin.kubernetes.KSV030
 
 import data.lib.kubernetes
+import data.lib.result
 
 test_pod_context_custom_profile_denied {
 	r := deny with input as {

--- a/checks/kubernetes/pss/restricted/6_drop_all_capabilities_only_add_net_bind_service.rego
+++ b/checks/kubernetes/pss/restricted/6_drop_all_capabilities_only_add_net_bind_service.rego
@@ -18,6 +18,7 @@
 package builtin.kubernetes.KSV106
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 hasDropAll(container) {

--- a/checks/kubernetes/pss/restricted/6_drop_all_capabilities_only_add_net_bind_service_test.rego
+++ b/checks/kubernetes/pss/restricted/6_drop_all_capabilities_only_add_net_bind_service_test.rego
@@ -1,6 +1,7 @@
 package builtin.kubernetes.KSV106
 
 import data.lib.kubernetes
+import data.lib.result
 
 test_drop_all_allowed {
 	r := deny with input as {

--- a/checks/kubernetes/pss/restricted/7_Kubernetes_resource_with_disallowed_volumes_mounted.rego
+++ b/checks/kubernetes/pss/restricted/7_Kubernetes_resource_with_disallowed_volumes_mounted.rego
@@ -27,6 +27,7 @@
 package builtin.kubernetes.KSV121
 
 import data.lib.kubernetes
+import data.lib.result
 import data.lib.utils
 
 # Add disallowed volume type

--- a/checks/kubernetes/rolebinding/cluster_admin_role_is_only_used_where_required.rego
+++ b/checks/kubernetes/rolebinding/cluster_admin_role_is_only_used_where_required.rego
@@ -21,6 +21,7 @@
 package builtin.kubernetes.KSV111
 
 import data.lib.kubernetes
+import data.lib.result
 
 readRoleRefs := ["cluster-admin", "admin", "edit"]
 

--- a/lib/result/result.rego
+++ b/lib/result/result.rego
@@ -3,18 +3,11 @@
 #   library: true
 package lib.result
 
-new(message, metadata) = result {
-	result := {
-		"metadata": metadata,
-		"msg": message,
-	}
+new(message, metadata) := {
+	"metadata": metadata,
+	"msg": message,
 }
 
-is_managed(cause) = res {
-	metadata := get_metadata(cause)
-	res := metadata.managed
-}
+is_managed(cause) := get_metadata(cause).managed
 
-get_metadata(cause) = metadata {
-	metadata := object.get(cause, "__defsec_metadata", cause)
-}
+get_metadata(cause) := object.get(cause, "__defsec_metadata", cause)

--- a/lib/result/result.rego
+++ b/lib/result/result.rego
@@ -1,0 +1,20 @@
+# METADATA
+# custom:
+#   library: true
+package lib.result
+
+new(message, metadata) = result {
+	result := {
+		"metadata": metadata,
+		"msg": message,
+	}
+}
+
+is_managed(cause) = res {
+	metadata := get_metadata(cause)
+	res := metadata.managed
+}
+
+get_metadata(cause) = metadata {
+	metadata := object.get(cause, "__defsec_metadata", cause)
+}


### PR DESCRIPTION
The purpose of this change is to improve testing of REGO policies by removing the dependency on `trivy-iac` and adding a new `result` package to the library.

Currently, it is not possible to test REGO policies because the `result.new` function that is used in all policies is declared in `trivy-iac` using the OPA sdk. This PR adds a new `result` package to the library, thus removing the dependency on `trivy-iac`.

Two functions have been moved: 
- `is_managed` - checks that the metadata is managed
- `new` - returns structured result, which is needed for further analysis by the REGO policy scanner.

The `new` function signature remains the same, which ensures backward compatibility. The `isManaged` function has been renamed to `is_managed`.