### PR TITLE
Fix check for public addresses

### DIFF
--- a/avd_docs/aws/ec2/AVD-AWS-0107/Terraform.md
+++ b/avd_docs/aws/ec2/AVD-AWS-0107/Terraform.md
@@ -9,6 +9,13 @@ Set a more restrictive cidr range
  
 ```
 ```hcl
+ resource "aws_security_group_rule" "another_good_example" {
+ 	type = "ingress"
+ 	cidr_blocks = ["1.2.3.4/24"]
+ }
+ 
+```
+```hcl
 resource "aws_security_group_rule" "allow_partner_rsync" {
   type              = "ingress"
   security_group_id = aws_security_group.….id

--- a/checks/cloud/aws/ec2/no_public_ingress_sgr.go
+++ b/checks/cloud/aws/ec2/no_public_ingress_sgr.go
@@ -47,7 +47,7 @@ var CheckNoPublicIngressSgr = rules.Register(
 			for _, rule := range group.IngressRules {
 				var failed bool
 				for _, block := range rule.CIDRs {
-					if cidr.IsPublic(block.Value()) && cidr.CountAddresses(block.Value()) == 255*255*255*255 {
+					if cidr.IsPublic(block.Value()) && (cidr.CountAddresses(block.Value()) == 255*255*255*255 || cidr.CountAddresses(block.Value()) == 0xffffffffffffffff) {
 						failed = true
 						results.Add(
 							"Security group rule allows ingress from public internet.",

--- a/checks/cloud/aws/ec2/no_public_ingress_sgr.go
+++ b/checks/cloud/aws/ec2/no_public_ingress_sgr.go
@@ -47,7 +47,7 @@ var CheckNoPublicIngressSgr = rules.Register(
 			for _, rule := range group.IngressRules {
 				var failed bool
 				for _, block := range rule.CIDRs {
-					if cidr.IsPublic(block.Value()) && cidr.CountAddresses(block.Value()) > 1 {
+					if cidr.IsPublic(block.Value()) && cidr.CountAddresses(block.Value()) == 255*255*255*255 {
 						failed = true
 						results.Add(
 							"Security group rule allows ingress from public internet.",

--- a/checks/cloud/aws/ec2/no_public_ingress_sgr.tf.go
+++ b/checks/cloud/aws/ec2/no_public_ingress_sgr.tf.go
@@ -8,6 +8,12 @@ var terraformNoPublicIngressSgrGoodExamples = []string{
  }
  `,
 	`
+ resource "aws_security_group_rule" "another_good_example" {
+ 	type = "ingress"
+ 	cidr_blocks = ["1.2.3.4/24"]
+ }
+ `,
+	`
 resource "aws_security_group_rule" "allow_partner_rsync" {
   type              = "ingress"
   security_group_id = aws_security_group.….id

--- a/checks/cloud/aws/ec2/no_public_ingress_sgr_test.go
+++ b/checks/cloud/aws/ec2/no_public_ingress_sgr_test.go
@@ -20,7 +20,7 @@ func TestCheckNoPublicIngressSgr(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "AWS VPC ingress security group rule with wildcard address",
+			name: "AWS VPC ingress security group rule with wildcard address (0.0.0.0/0)",
 			input: ec2.EC2{
 				SecurityGroups: []ec2.SecurityGroup{
 					{
@@ -37,6 +37,25 @@ func TestCheckNoPublicIngressSgr(t *testing.T) {
 				},
 			},
 			expected: true,
+		},
+		{
+			name: "AWS VPC ingress security group rule with public address (/24)",
+			input: ec2.EC2{
+				SecurityGroups: []ec2.SecurityGroup{
+					{
+						Metadata: trivyTypes.NewTestMetadata(),
+						IngressRules: []ec2.SecurityGroupRule{
+							{
+								Metadata: trivyTypes.NewTestMetadata(),
+								CIDRs: []trivyTypes.StringValue{
+									trivyTypes.String("1.2.3.4/24", trivyTypes.NewTestMetadata()),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
 		},
 		{
 			name: "AWS VPC ingress security group rule with private address",


### PR DESCRIPTION
According to the check documentation:

> Opening up ports to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that explicitly require it where possible

However, the check fails even if you try to set the cidr_blocks parameter to a more restrictive range, such as:

```
 resource "aws_security_group_rule" "another_good_example" {
  type = "ingress"
  cidr_blocks = ["1.2.3.4/24"]
 }
```

Running `trivy config .` with the configuration above yields:

```
CRITICAL: Security group rule allows ingress from public internet.
════════════════════════════════════════════════════════════════════════════════════════════════════
Opening up ports to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that explicitly require it where possible.

See https://avd.aquasec.com/misconfig/avd-aws-0107
────────────────────────────────────────────────────────────────────────────────────────────────────
 main.tf:3
   via main.tf:1-4 (aws_security_group_rule.another_good_example)
────────────────────────────────────────────────────────────────────────────────────────────────────
   1    resource "aws_security_group_rule" "another_good_example" {
   2     type = "ingress"
   3 [   cidr_blocks = ["1.2.3.4/24"]
   4    }

```
