### PR TITLE
fix: cis checks validate (api-server, controller-manager, scheduler and etcd) args

### DIFF
--- a/checks/kubernetes/cisbenchmarks/apiserver/always_admit_plugin_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/always_admit_plugin_test.rego
@@ -64,6 +64,28 @@ test_always_admit_plugin_is_not_enabled {
 	count(r) == 0
 }
 
+test_always_admit_plugin_is_not_enabled_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--enable-admission-plugins=NamespaceLifecycle,ServiceAccount"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_always_admit_plugin_is_enabled_with_others {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/apiserver/anonymous_auth.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/anonymous_auth.rego
@@ -19,16 +19,20 @@ package builtin.kubernetes.KCV0001
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
-	some i
-	flag := container.command[i]
-	not kubernetes.command_has_flag(container.command, "--anonymous-auth=false")
+check_flag(container) {
+	arg := kubernetes.containers[_].args[_]
+	contains(arg, "--anonymous-auth=false")
+}
+
+check_flag(container) {
+	cmd := kubernetes.containers[_].command[_]
+	contains(cmd, "--anonymous-auth=false")
 }
 
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not check_flag(container)
 	msg := "Ensure that the --anonymous-auth argument is set to false"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/anonymous_auth_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/anonymous_auth_test.rego
@@ -64,3 +64,47 @@ test_anonymous_requests_false {
 
 	count(r) == 0
 }
+
+test_anonymous_requests_args_false {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2"],
+			"args": ["--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_anonymous_requests_args_no_apiserver {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "test",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["test", "--advertise-address=192.168.49.2"],
+			"args": ["--anonymous-auth=true"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/checks/kubernetes/cisbenchmarks/apiserver/audit_log_maxage.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/audit_log_maxage.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0020
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
-	not kubernetes.command_has_flag(container.command, "--audit-log-maxage")
+check_flag(container) {
+	kubernetes.command_has_flag(container.command, "--audit-log-maxage")
+}
+
+check_flag(container) {
+	kubernetes.command_has_flag(container.args, "--audit-log-maxage")
 }
 
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not check_flag(container)
 	msg := "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/audit_log_maxage_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/audit_log_maxage_test.rego
@@ -63,3 +63,25 @@ test_audit_log_maxage_is_not_set {
 	count(r) == 1
 	r[_].msg == "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate"
 }
+
+test_audit_log_maxage_is_set_10_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--advertise-address=192.168.49.2", "--audit-log-maxage=30", "--secure-port=10"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/checks/kubernetes/cisbenchmarks/apiserver/audit_log_maxbackup.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/audit_log_maxbackup.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0021
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
-	not kubernetes.command_has_flag(container.command, "--audit-log-maxbackup")
+check_flag(container) {
+	kubernetes.command_has_flag(container.command, "--audit-log-maxbackup")
+}
+
+check_flag(container) {
+	kubernetes.command_has_flag(container.args, "--audit-log-maxbackup")
 }
 
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not check_flag(container)
 	msg := "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/audit_log_maxbackup_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/audit_log_maxbackup_test.rego
@@ -63,3 +63,25 @@ test_audit_log_maxbackup_is_not_set {
 	count(r) == 1
 	r[_].msg == "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate"
 }
+
+test_audit_log_maxbackup_is_set_10_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--advertise-address=192.168.49.2", "--audit-log-maxbackup=30", "--secure-port=10"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/checks/kubernetes/cisbenchmarks/apiserver/audit_log_maxsize.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/audit_log_maxsize.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0022
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
-	not kubernetes.command_has_flag(container.command, "--audit-log-maxsize")
+check_flag(container) {
+	kubernetes.command_has_flag(container.command, "--audit-log-maxsize")
+}
+
+check_flag(container) {
+	kubernetes.command_has_flag(container.args, "--audit-log-maxsize")
 }
 
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not check_flag(container)
 	msg := "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/audit_log_maxsize_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/audit_log_maxsize_test.rego
@@ -42,6 +42,28 @@ test_audit_log_maxsize_is_set_10 {
 	count(r) == 0
 }
 
+test_audit_log_maxsize_is_set_10_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--advertise-address=192.168.49.2", "--audit-log-maxsize=10", "--secure-port=10"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_audit_log_maxsize_is_not_set {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/apiserver/audit_log_path.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/audit_log_path.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0019
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
-	not kubernetes.command_has_flag(container.command, "--audit-log-path")
+check_flag(container) {
+	kubernetes.command_has_flag(container.command, "--audit-log-path")
+}
+
+check_flag(container) {
+	kubernetes.command_has_flag(container.args, "--audit-log-path")
 }
 
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not check_flag(container)
 	msg := "Ensure that the --audit-log-path argument is set"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/audit_log_path_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/audit_log_path_test.rego
@@ -42,3 +42,25 @@ test_audit_log_path_is_not_set {
 	count(r) == 1
 	r[_].msg == "Ensure that the --audit-log-path argument is set"
 }
+
+test_audit_log_path_is_set_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--advertise-address=192.168.49.2", "--audit-log-path=<path>", "--secure-port=0"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/checks/kubernetes/cisbenchmarks/apiserver/authorization_mode.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/authorization_mode.rego
@@ -19,16 +19,16 @@ package builtin.kubernetes.KCV0007
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
+check_flag(container) {
 	some i
 	output := regex.find_all_string_submatch_n(`--authorization-mode=([^\s]+)`, container.command[i], -1)
 	regex.match("AlwaysAllow", output[0][1])
 }
 
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	check_flag(container)
 	msg := "Ensure that the --authorization-mode argument is not set to AlwaysAllow"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/authorization_mode_includes_node.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/authorization_mode_includes_node.rego
@@ -19,21 +19,24 @@ package builtin.kubernetes.KCV0008
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
-	not kubernetes.command_has_flag(container.command, "--authorization-mode")
-}
-
-check_flag[container] {
-	container := kubernetes.containers[_]
+check_flag(container) {
+	kubernetes.command_has_flag(container.command, "--authorization-mode")
 	some i
 	output := regex.find_all_string_submatch_n(`--authorization-mode=([^\s]+)`, container.command[i], -1)
-	not regex.match("Node", output[0][1])
+	regex.match("Node", output[0][1])
+}
+
+check_flag(container) {
+	kubernetes.command_has_flag(container.args, "--authorization-mode")
+	some i
+	output := regex.find_all_string_submatch_n(`--authorization-mode=([^\s]+)`, container.args[i], -1)
+	regex.match("Node", output[0][1])
 }
 
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not check_flag(container)
 	msg := "Ensure that the --authorization-mode argument includes Node"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/authorization_mode_includes_node_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/authorization_mode_includes_node_test.rego
@@ -42,6 +42,28 @@ test_authorization_mode_includes_node {
 	count(r) == 0
 }
 
+test_authorization_mode_includes_node_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--authorization-mode=RBAC,Node", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_authorization_mode_default_value {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/apiserver/authorization_mode_includes_rbac.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/authorization_mode_includes_rbac.rego
@@ -19,21 +19,24 @@ package builtin.kubernetes.KCV0009
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
-	not kubernetes.command_has_flag(container.command, "--authorization-mode")
-}
-
-check_flag[container] {
-	container := kubernetes.containers[_]
+check_flag(container) {
+	kubernetes.command_has_flag(container.command, "--authorization-mode")
 	some i
 	output := regex.find_all_string_submatch_n(`--authorization-mode=([^\s]+)`, container.command[i], -1)
-	not regex.match("RBAC", output[0][1])
+	regex.match("RBAC", output[0][1])
+}
+
+check_flag(container) {
+	kubernetes.command_has_flag(container.args, "--authorization-mode")
+	some i
+	output := regex.find_all_string_submatch_n(`--authorization-mode=([^\s]+)`, container.args[i], -1)
+	regex.match("RBAC", output[0][1])
 }
 
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not check_flag(container)
 	msg := "Ensure that the --authorization-mode argument includes RBAC"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/authorization_mode_includes_rbac_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/authorization_mode_includes_rbac_test.rego
@@ -42,6 +42,28 @@ test_authorization_mode_includes_rbac {
 	count(r) == 0
 }
 
+test_authorization_mode_includes_rbac_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--authorization-mode=Node,RBAC", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_authorization_mode_default_value {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/apiserver/authorization_mode_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/authorization_mode_test.rego
@@ -43,6 +43,28 @@ test_authorization_mode_is_set_rbac {
 	count(r) == 0
 }
 
+test_authorization_mode_is_set_rbac_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--authorization-mode=RBAC", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_authorization_mode_with_multiple_values {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/apiserver/client_ca_file.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/client_ca_file.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0028
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
-	not kubernetes.command_has_flag(container.command, "--client-ca-file")
+check_flag(container) {
+	kubernetes.command_has_flag(container.command, "--client-ca-file")
+}
+
+check_flag(container) {
+	kubernetes.command_has_flag(container.args, "--client-ca-file")
 }
 
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not check_flag(container)
 	msg := "Ensure that the --client-ca-file argument is set as appropriate"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/client_ca_file_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/client_ca_file_test.rego
@@ -21,6 +21,28 @@ test_client_ca_file_is_set {
 	count(r) == 0
 }
 
+test_client_ca_file_is_set_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--advertise-address=192.168.49.2", "--client-ca-file=<filename>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_client_ca_file_is_not_set {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/apiserver/deny_service_external_ips_plugin.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/deny_service_external_ips_plugin.rego
@@ -19,15 +19,21 @@ package builtin.kubernetes.KCV0003
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
+check_flag(container) {
 	some i
 	output := regex.find_all_string_submatch_n(`--enable-admission-plugins=([^\s]+)`, container.command[i], -1)
 	regex.match("DenyServiceExternalIPs", output[0][1])
 }
 
+check_flag(container) {
+	some i
+	output := regex.find_all_string_submatch_n(`--enable-admission-plugins=([^\s]+)`, container.args[i], -1)
+	regex.match("DenyServiceExternalIPs", output[0][1])
+}
+
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	check_flag(container)
 	msg := "Ensure that the --DenyServiceExternalIPs is not set"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/deny_service_external_ips_plugin_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/deny_service_external_ips_plugin_test.rego
@@ -43,6 +43,28 @@ test_enable_admission_plugins_is_not_configured {
 	count(r) == 0
 }
 
+test_enable_admission_plugins_is_not_configured_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--authorization-mode=Node,RBAC", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_deny_service_external_ips_is_not_enabled {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/apiserver/encryption_provider_config.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/encryption_provider_config.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0030
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
+check_flag(container) {
 	kubernetes.command_has_flag(container.command, "--encryption-provider-config")
 }
 
+check_flag(container) {
+	kubernetes.command_has_flag(container.args, "--encryption-provider-config")
+}
+
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	check_flag(container)
 	msg := "Ensure that the --encryption-provider-config argument is set as appropriate"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/encryption_provider_config_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/encryption_provider_config_test.rego
@@ -42,3 +42,25 @@ test_encryption_provider_config_is_not_set {
 
 	count(r) == 0
 }
+
+test_encryption_provider_config_is_not_set_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--advertise-address=192.168.49.2", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/checks/kubernetes/cisbenchmarks/apiserver/etcd_cafile.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/etcd_cafile.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0029
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
-	not kubernetes.command_has_flag(container.command, "--etcd-cafile")
+check_flag(container) {
+	kubernetes.command_has_flag(container.command, "--etcd-cafile")
+}
+
+check_flag(container) {
+	kubernetes.command_has_flag(container.args, "--etcd-cafile")
 }
 
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not check_flag(container)
 	msg := "Ensure that the --etcd-cafile argument is set as appropriate"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/etcd_cafile_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/etcd_cafile_test.rego
@@ -21,6 +21,28 @@ test_etcd_cafile_is_set {
 	count(r) == 0
 }
 
+test_etcd_cafile_is_set_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--advertise-address=192.168.49.2", "--etcd-cafile=<filename>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_etcd_cafile_is_not_set {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/apiserver/etcd_certfile_and_keyfile.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/etcd_certfile_and_keyfile.rego
@@ -19,20 +19,20 @@ package builtin.kubernetes.KCV0026
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
-	not kubernetes.command_has_flag(container.command, "--etcd-certfile")
+check_flag(container) {
+	kubernetes.command_has_flag(container.command, "--etcd-certfile")
+	kubernetes.command_has_flag(container.command, "--etcd-keyfile")
 }
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
-	not kubernetes.command_has_flag(container.command, "--etcd-keyfile")
+check_flag(container) {
+	kubernetes.command_has_flag(container.args, "--etcd-certfile")
+	kubernetes.command_has_flag(container.args, "--etcd-certfile")
 }
 
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not check_flag(container)
 	msg := "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/etcd_certfile_and_keyfile_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/etcd_certfile_and_keyfile_test.rego
@@ -86,3 +86,25 @@ test_etcd_certfile_and_keyfile_are_not_set {
 	count(r) == 1
 	r[_].msg == "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate"
 }
+
+test_etcd_certfile_and_keyfile_are_set_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--advertise-address=192.168.49.2", "--etcd-certfile=<file>", "--etcd-keyfile=<file>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/checks/kubernetes/cisbenchmarks/apiserver/event_rate_limit_plugin_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/event_rate_limit_plugin_test.rego
@@ -85,3 +85,25 @@ test_event_rate_limit_plugin_is_enabled_with_others {
 
 	count(r) == 0
 }
+
+test_event_rate_limit_plugin_is_enabled_with_others_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--enable-admission-plugins=NamespaceLifecycle,EventRateLimit,ServiceAccount"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/checks/kubernetes/cisbenchmarks/apiserver/kubelet_certificate_authority.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/kubelet_certificate_authority.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0006
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
-	not kubernetes.command_has_flag(container.command, "--kubelet-certificate-authority")
+check_flag(container) {
+	kubernetes.command_has_flag(container.command, "--kubelet-certificate-authority")
+}
+
+check_flag(container) {
+	kubernetes.command_has_flag(container.args, "--kubelet-certificate-authority")
 }
 
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not check_flag(container)
 	msg := "Ensure that the --kubelet-certificate-authority argument is set as appropriate"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/kubelet_certificate_authority_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/kubelet_certificate_authority_test.rego
@@ -21,6 +21,28 @@ test_kubelet_certificate_authority_is_set {
 	count(r) == 0
 }
 
+test_kubelet_certificate_authority_is_set_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--advertise-address=192.168.49.2", "--kubelet-certificate-authority=<ca-string>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_kubelet_certificate_authority_is_not_set {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/apiserver/kubelet_client_certificate_and_key.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/kubelet_client_certificate_and_key.rego
@@ -19,20 +19,20 @@ package builtin.kubernetes.KCV0005
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
-	not kubernetes.command_has_flag(container.command, "--kubelet-client-certificate")
+check_flag(container) {
+	kubernetes.command_has_flag(container.command, "--kubelet-client-certificate")
+	kubernetes.command_has_flag(container.command, "--kubelet-client-key")
 }
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
-	not kubernetes.command_has_flag(container.command, "--kubelet-client-key")
+check_flag(container) {
+	kubernetes.command_has_flag(container.args, "--kubelet-client-certificate")
+	kubernetes.command_has_flag(container.args, "--kubelet-client-key")
 }
 
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not check_flag(container)
 	msg := "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/kubelet_client_certificate_and_key_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/kubelet_client_certificate_and_key_test.rego
@@ -65,6 +65,28 @@ test_kubelet_client_key_and_certificate_are_set {
 	count(r) == 0
 }
 
+test_kubelet_client_key_and_certificate_are_set_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--advertise-address=192.168.49.2", "--kubelet-client-certificate=<file>", "--kubelet-client-key=<file>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_kubelet_client_key_and_certificate_are_not_set {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/apiserver/kubelet_https.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/kubelet_https.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0004
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
+check_flag(container) {
+	kubernetes.command_has_flag(container.command, "--kubelet-https=false")
+}
+
+check_flag(container) {
 	kubernetes.command_has_flag(container.command, "--kubelet-https=false")
 }
 
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	check_flag(container)
 	msg := "Ensure that the --kubelet-https argument is set to true"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/kubelet_https_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/kubelet_https_test.rego
@@ -43,6 +43,28 @@ test_kubelet_https_is_true {
 	count(r) == 0
 }
 
+test_kubelet_https_is_true_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--authorization-mode=AlwaysAllow", "--kubelet-https=true", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_kubelet_https_is_not_configured {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/apiserver/namespace_lifecycle_plugin.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/namespace_lifecycle_plugin.rego
@@ -19,16 +19,22 @@ package builtin.kubernetes.KCV0015
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
+check_flag(container) {
 	some i
 	output := regex.find_all_string_submatch_n(`--disable-admission-plugins=([^\s]+)`, container.command[i], -1)
 	regex.match("NamespaceLifecycle", output[0][1])
 }
 
+check_flag(container) {
+	some i
+	output := regex.find_all_string_submatch_n(`--disable-admission-plugins=([^\s]+)`, container.args[i], -1)
+	regex.match("NamespaceLifecycle", output[0][1])
+}
+
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	check_flag(container)
 	msg := "Ensure that the admission control plugin NamespaceLifecycle is set"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/namespace_lifecycle_plugin_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/namespace_lifecycle_plugin_test.rego
@@ -42,3 +42,25 @@ test_namespace_lifecycle_plugin_is_not_disabled {
 
 	count(r) == 0
 }
+
+test_namespace_lifecycle_plugin_is_not_disabled_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--disable-admission-plugins=AlwaysAdmit"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/checks/kubernetes/cisbenchmarks/apiserver/node_restriction_plugin.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/node_restriction_plugin.rego
@@ -19,21 +19,24 @@ package builtin.kubernetes.KCV0016
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
-	not kubernetes.command_has_flag(container.command, "--enable-admission-plugins")
-}
-
-check_flag[container] {
-	container := kubernetes.containers[_]
+check_flag(container) {
+	kubernetes.command_has_flag(container.command, "--enable-admission-plugins")
 	some i
 	output := regex.find_all_string_submatch_n(`--enable-admission-plugins=([^\s]+)`, container.command[i], -1)
-	not regex.match("NodeRestriction", output[0][1])
+	regex.match("NodeRestriction", output[0][1])
+}
+
+check_flag(container) {
+	kubernetes.command_has_flag(container.args, "--enable-admission-plugins")
+	some i
+	output := regex.find_all_string_submatch_n(`--enable-admission-plugins=([^\s]+)`, container.args[i], -1)
+	regex.match("NodeRestriction", output[0][1])
 }
 
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not check_flag(container)
 	msg := "Ensure that the admission control plugin NodeRestriction is set"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/node_restriction_plugin_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/node_restriction_plugin_test.rego
@@ -85,3 +85,25 @@ test_node_restriction_plugin_is_enabled_with_others {
 
 	count(r) == 0
 }
+
+test_node_restriction_plugin_is_enabled_with_others_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--enable-admission-plugins=NamespaceLifecycle,NodeRestriction,ServiceAccount"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/checks/kubernetes/cisbenchmarks/apiserver/profiling.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/profiling.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0018
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
-	not kubernetes.command_has_flag(container.command, "--profiling=false")
+check_flag(container) {
+	kubernetes.command_has_flag(container.command, "--profiling=false")
+}
+
+check_flag(container) {
+	kubernetes.command_has_flag(container.args, "--profiling=false")
 }
 
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not check_flag(container)
 	msg := "Ensure that the --profiling argument is set to false"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/profiling_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/profiling_test.rego
@@ -21,6 +21,28 @@ test_profiling_is_set_to_false {
 	count(r) == 0
 }
 
+test_profiling_is_set_to_false_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--advertise-address=192.168.49.2", "--profiling=false", "--secure-port=0"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_profiling_is_set_to_true {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/apiserver/secure_port.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/secure_port.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0017
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
+check_flag(container) {
 	kubernetes.command_has_flag(container.command, "--secure-port=0")
 }
 
+check_flag(container) {
+	kubernetes.command_has_flag(container.args, "--secure-port=0")
+}
+
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	check_flag(container)
 	msg := "Ensure that the --secure-port argument is not set to 0"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/secure_port_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/secure_port_test.rego
@@ -43,6 +43,28 @@ test_secure_port_is_not_set_to_zero {
 	count(r) == 0
 }
 
+test_secure_port_is_not_set_to_zero_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--advertise-address=192.168.49.2", "--secure-port=2", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_secure_port_is_not_configured {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/apiserver/security_context_deny_plugin_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/security_context_deny_plugin_test.rego
@@ -21,6 +21,28 @@ test_pod_security_policy_is_set {
 	count(r) == 0
 }
 
+test_pod_security_policy_is_set_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--enable-admission-plugins=AlwaysPullImages,PodSecurityPolicy"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_pod_security_policy_is_not_set {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/apiserver/service_account_key_file.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/service_account_key_file.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0025
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
-	not kubernetes.command_has_flag(container.command, "--service-account-key-file")
+check_flag(container) {
+	kubernetes.command_has_flag(container.command, "--service-account-key-file")
+}
+
+check_flag(container) {
+	kubernetes.command_has_flag(container.args, "--service-account-key-file")
 }
 
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not check_flag(container)
 	msg := "Ensure that the --service-account-key-file argument is set as appropriate"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/service_account_key_file_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/service_account_key_file_test.rego
@@ -21,6 +21,28 @@ test_service_account_key_file_is_set {
 	count(r) == 0
 }
 
+test_service_account_key_file_is_set_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--authorization-mode=AlwaysAllow", "--service-account-key-file=<file>", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_service_account_key_file_is_not_set {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/apiserver/service_account_lookup.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/service_account_lookup.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0024
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
+check_flag(container) {
 	kubernetes.command_has_flag(container.command, "--service-account-lookup=false")
 }
 
+check_flag(container) {
+	kubernetes.command_has_flag(container.args, "--service-account-lookup=false")
+}
+
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	check_flag(container)
 	msg := "Ensure that the --service-account-lookup argument is set to true"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/service_account_lookup_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/service_account_lookup_test.rego
@@ -43,6 +43,28 @@ test_service_account_lookup_is_true {
 	count(r) == 0
 }
 
+test_service_account_lookup_is_true_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--authorization-mode=AlwaysAllow", "--service-account-lookup=true", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_service_account_lookup_is_not_configured {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/apiserver/service_account_plugin.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/service_account_plugin.rego
@@ -19,16 +19,22 @@ package builtin.kubernetes.KCV0014
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
+check_flag(container) {
 	some i
 	output := regex.find_all_string_submatch_n(`--disable-admission-plugins=([^\s]+)`, container.command[i], -1)
 	regex.match("ServiceAccount", output[0][1])
 }
 
+check_flag(container) {
+	some i
+	output := regex.find_all_string_submatch_n(`--disable-admission-plugins=([^\s]+)`, container.args[i], -1)
+	regex.match("ServiceAccount", output[0][1])
+}
+
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	check_flag(container)
 	msg := "Ensure that the admission control plugin ServiceAccount is set"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/service_account_plugin_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/service_account_plugin_test.rego
@@ -42,3 +42,25 @@ test_service_account_plugin_is_not_disabled {
 
 	count(r) == 0
 }
+
+test_service_account_plugin_is_not_disabled_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--disable-admission-plugins=AlwaysAdmit"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/checks/kubernetes/cisbenchmarks/apiserver/tls_cert_file_and_private_key_file.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/tls_cert_file_and_private_key_file.rego
@@ -19,20 +19,20 @@ package builtin.kubernetes.KCV0027
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
-	not kubernetes.command_has_flag(container.command, "--tls-cert-file")
+check_flag(container) {
+	kubernetes.command_has_flag(container.command, "--tls-cert-file")
+	kubernetes.command_has_flag(container.command, "--tls-private-key-file")
 }
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
-	not kubernetes.command_has_flag(container.command, "--tls-private-key-file")
+check_flag(container) {
+	kubernetes.command_has_flag(container.args, "--tls-cert-file")
+	kubernetes.command_has_flag(container.args, "--tls-private-key-file")
 }
 
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not check_flag(container)
 	msg := "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/tls_cert_file_and_private_key_file_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/tls_cert_file_and_private_key_file_test.rego
@@ -65,6 +65,28 @@ test_tls_cert_file_and_private_key_file_are_set {
 	count(r) == 0
 }
 
+test_tls_cert_file_and_private_key_file_are_set_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--advertise-address=192.168.49.2", "--tls-cert-file=<file>", "--tls-private-key-file=<file>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_tls_cert_file_and_private_key_file_are_not_set {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/apiserver/token_auth_file.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/token_auth_file.rego
@@ -19,15 +19,20 @@ package builtin.kubernetes.KCV0002
 
 import data.lib.kubernetes
 
-check_flag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_apiserver(container)
+check_flag(container) {
 	some i
 	regex.match("--token-auth-file", container.command[i])
 }
 
+check_flag(container) {
+	some i
+	regex.match("--token-auth-file", container.args[i])
+}
+
 deny[res] {
-	output := check_flag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	check_flag(container)
 	msg := "Ensure that the --token-auth-file parameter is not set"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/token_auth_file_test.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/token_auth_file_test.rego
@@ -42,3 +42,25 @@ test_token_auth_file_is_not_set {
 
 	count(r) == 0
 }
+
+test_token_auth_file_is_not_set_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver"],
+			"args": ["--advertise-address=192.168.49.2", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/checks/kubernetes/cisbenchmarks/controllermamager/bind_address.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/bind_address.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0039
 
 import data.lib.kubernetes
 
-checkFlag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_controllermanager(container)
-	not kubernetes.command_has_flag(container.command, "--bind-address=127.0.0.1")
+checkFlag(container) {
+	kubernetes.command_has_flag(container.command, "--bind-address=127.0.0.1")
+}
+
+checkFlag(container) {
+	kubernetes.command_has_flag(container.args, "--bind-address=127.0.0.1")
 }
 
 deny[res] {
-	output := checkFlag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_controllermanager(container)
+	not checkFlag(container)
 	msg := "Ensure that the --bind-address argument is set to 127.0.0.1"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/controllermamager/bind_address_test.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/bind_address_test.rego
@@ -21,6 +21,28 @@ test_bind_address_is_set_to_localhost_ip {
 	count(r) == 0
 }
 
+test_bind_address_is_set_to_localhost_ip_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "controller-manager",
+			"labels": {
+				"component": "kube-controller-manager",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-controller-manager"],
+			"args": ["--bind-address=127.0.0.1"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_bind_address_is_set_to_different_ip {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/controllermamager/profiling.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/profiling.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0034
 
 import data.lib.kubernetes
 
-checkFlag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_controllermanager(container)
-	not kubernetes.command_has_flag(container.command, "--profiling=false")
+checkFlag(container) {
+	kubernetes.command_has_flag(container.command, "--profiling=false")
+}
+
+checkFlag(container) {
+	kubernetes.command_has_flag(container.args, "--profiling=false")
 }
 
 deny[res] {
-	output := checkFlag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_controllermanager(container)
+	not checkFlag(container)
 	msg := "Ensure that the --profiling argument is set to false"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/controllermamager/profiling_test.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/profiling_test.rego
@@ -21,6 +21,28 @@ test_profiling_is_set_to_false {
 	count(r) == 0
 }
 
+test_profiling_is_set_to_false_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "controller-manager",
+			"labels": {
+				"component": "kube-controller-manager",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-controller-manager"],
+			"args": ["--allocate-node-cidrs=true", "--profiling=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_profiling_is_set_to_true {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/controllermamager/root_ca_file.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/root_ca_file.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0037
 
 import data.lib.kubernetes
 
-checkFlag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_controllermanager(container)
-	not kubernetes.command_has_flag(container.command, "--root-ca-file")
+checkFlag(container) {
+	kubernetes.command_has_flag(container.command, "--root-ca-file")
+}
+
+checkFlag(container) {
+	kubernetes.command_has_flag(container.args, "--root-ca-file")
 }
 
 deny[res] {
-	output := checkFlag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_controllermanager(container)
+	not checkFlag(container)
 	msg := "Ensure that the --root-ca-file argument is set as appropriate"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/controllermamager/root_ca_file_test.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/root_ca_file_test.rego
@@ -42,3 +42,25 @@ test_root_ca_file_is_set {
 
 	count(r) == 0
 }
+
+test_root_ca_file_is_set_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-controller-manager",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-controller-manager"],
+			"args": ["--allocate-node-cidrs=true", "--root-ca-file=<filename>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/checks/kubernetes/cisbenchmarks/controllermamager/rotate_kubelet_server_certificate.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/rotate_kubelet_server_certificate.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0038
 
 import data.lib.kubernetes
 
-checkFlag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_controllermanager(container)
-	not kubernetes.command_has_flag(container.command, "RotateKubeletServerCertificate=true")
+checkFlag(container) {
+	kubernetes.command_has_flag(container.command, "RotateKubeletServerCertificate=true")
+}
+
+checkFlag(container) {
+	kubernetes.command_has_flag(container.args, "RotateKubeletServerCertificate=true")
 }
 
 deny[res] {
-	output := checkFlag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_controllermanager(container)
+	not checkFlag(container)
 	msg := "Ensure that the RotateKubeletServerCertificate argument is set to true"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/controllermamager/rotate_kubelet_server_certificate_test.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/rotate_kubelet_server_certificate_test.rego
@@ -21,6 +21,28 @@ test_use_rotate_kubelet_server_certificate_is_set_to_true {
 	count(r) == 0
 }
 
+test_use_rotate_kubelet_server_certificate_is_set_to_true_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "controller-manager",
+			"labels": {
+				"component": "kube-controller-manager",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-controller-manager"],
+			"args": ["--feature-gates=RotateKubeletServerCertificate=true"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_use_rotate_kubelet_server_certificate_is_set_to_false {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/controllermamager/service_account_private_key_file.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/service_account_private_key_file.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0036
 
 import data.lib.kubernetes
 
-checkFlag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_controllermanager(container)
-	not kubernetes.command_has_flag(container.command, "--service-account-private-key-file")
+checkFlag(container) {
+	kubernetes.command_has_flag(container.command, "--service-account-private-key-file")
+}
+
+checkFlag(container) {
+	kubernetes.command_has_flag(container.args, "--service-account-private-key-file")
 }
 
 deny[res] {
-	output := checkFlag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_controllermanager(container)
+	not checkFlag(container)
 	msg := "Ensure that the --service-account-private-key-file argument is set as appropriate"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/controllermamager/terminated_pod_gc_threshold.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/terminated_pod_gc_threshold.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0033
 
 import data.lib.kubernetes
 
-checkFlag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_controllermanager(container)
-	not kubernetes.command_has_flag(container.command, "--terminated-pod-gc-threshold")
+checkFlag(container) {
+	kubernetes.command_has_flag(container.command, "--terminated-pod-gc-threshold")
+}
+
+checkFlag(container) {
+	kubernetes.command_has_flag(container.args, "--terminated-pod-gc-threshold")
 }
 
 deny[res] {
-	output := checkFlag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_controllermanager(container)
+	not checkFlag(container)
 	msg := "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/controllermamager/terminated_pod_gc_threshold_test.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/terminated_pod_gc_threshold_test.rego
@@ -42,3 +42,25 @@ test_terminated_pod_gc_threshold_is_not_set {
 
 	count(r) == 0
 }
+
+test_terminated_pod_gc_threshold_is_not_set_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-conrtoller-manager",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-controller-manager"],
+			"args": ["--allocate-node-cidrs=true", "--terminated-pod-gc-threshold=10"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/checks/kubernetes/cisbenchmarks/controllermamager/use_service_account_credentials.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/use_service_account_credentials.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0035
 
 import data.lib.kubernetes
 
-checkFlag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_controllermanager(container)
-	not kubernetes.command_has_flag(container.command, "--use-service-account-credentials=true")
+checkFlag(container) {
+	kubernetes.command_has_flag(container.command, "--use-service-account-credentials=true")
+}
+
+checkFlag(container) {
+	kubernetes.command_has_flag(container.args, "--use-service-account-credentials=true")
 }
 
 deny[res] {
-	output := checkFlag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_controllermanager(container)
+	not checkFlag(container)
 	msg := "Ensure that the --use-service-account-credentials argument is set to true"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/controllermamager/use_service_account_credentials_test.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/use_service_account_credentials_test.rego
@@ -21,6 +21,28 @@ test_use_service_account_credentials_is_set_to_true {
 	count(r) == 0
 }
 
+test_use_service_account_credentials_is_set_to_true_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "controller-manager",
+			"labels": {
+				"component": "kube-controller-manager",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-controller-manager"],
+			"args": ["--allocate-node-cidrs=true", "--use-service-account-credentials=true"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_use_service_account_credentials_is_set_to_false {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/etcd/auto_tls.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/auto_tls.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0044
 
 import data.lib.kubernetes
 
-checkFlag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_etcd(container)
+checkFlag(container) {
 	kubernetes.command_has_flag(container.command, "--auto-tls=true")
 }
 
+checkFlag(container) {
+	kubernetes.command_has_flag(container.args, "--auto-tls=true")
+}
+
 deny[res] {
-	output := checkFlag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_etcd(container)
+	checkFlag(container)
 	msg := "Ensure that the --auto-tls argument is not set to true"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/etcd/auto_tls_test.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/auto_tls_test.rego
@@ -21,6 +21,28 @@ test_auto_tls_is_set_to_false {
 	count(r) == 0
 }
 
+test_auto_tls_is_set_to_false_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "etcd",
+			"labels": {
+				"component": "etcd",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["etcd"],
+			"args": ["--advertise-client-urls=https://192.168.49.2:2379", "--auto-tls=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_auto_tls_is_set_to_true {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/etcd/cert_file_and_key_file.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/cert_file_and_key_file.rego
@@ -19,20 +19,20 @@ package builtin.kubernetes.KCV0042
 
 import data.lib.kubernetes
 
-checkFlag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_etcd(container)
-	not kubernetes.command_has_flag(container.command, "--cert-file")
+checkFlag(container) {
+	kubernetes.command_has_flag(container.command, "--cert-file")
+	kubernetes.command_has_flag(container.command, "--key-file")
 }
 
-checkFlag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_etcd(container)
-	not kubernetes.command_has_flag(container.command, "--key-file")
+checkFlag(container) {
+	kubernetes.command_has_flag(container.args, "--cert-file")
+	kubernetes.command_has_flag(container.args, "--key-file")
 }
 
 deny[res] {
-	output := checkFlag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_etcd(container)
+	not checkFlag(container)
 	msg := "Ensure that the --cert-file and --key-file arguments are set as appropriate"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/etcd/cert_file_and_key_file_test.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/cert_file_and_key_file_test.rego
@@ -65,6 +65,28 @@ test_etcd_cert_file_and_key_file_are_set {
 	count(r) == 0
 }
 
+test_etcd_cert_file_and_key_file_are_set_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "etcd",
+			"labels": {
+				"component": "etcd",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["etcd"],
+			"args": ["--advertise-client-urls=https://192.168.49.2:2379", "--cert-file=<filename>", "--key-file=<filename>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_etcd_cert_file_and_key_file_are_not_set {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/etcd/client_cert_auth.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/client_cert_auth.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0043
 
 import data.lib.kubernetes
 
-checkFlag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_etcd(container)
-	not kubernetes.command_has_flag(container.command, "--client-cert-auth=true")
+checkFlag(container) {
+	kubernetes.command_has_flag(container.command, "--client-cert-auth=true")
+}
+
+checkFlag(container) {
+	kubernetes.command_has_flag(container.args, "--client-cert-auth=true")
 }
 
 deny[res] {
-	output := checkFlag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_etcd(container)
+	not checkFlag(container)
 	msg := "Ensure that the --client-cert-auth argument is set to true"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/etcd/client_cert_auth_test.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/client_cert_auth_test.rego
@@ -21,6 +21,28 @@ test_client_cert_auth_is_set_to_true {
 	count(r) == 0
 }
 
+test_client_cert_auth_is_set_to_true_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "etcd",
+			"labels": {
+				"component": "etcd",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["etcd"],
+			"args": ["--advertise-client-urls=https://192.168.49.2:2379", "--client-cert-auth=true"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_client_cert_auth_is_set_to_false {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/etcd/peer_auto_tls.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/peer_auto_tls.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0047
 
 import data.lib.kubernetes
 
-checkFlag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_etcd(container)
+checkFlag(container) {
 	kubernetes.command_has_flag(container.command, "--peer-auto-tls=true")
 }
 
+checkFlag(container) {
+	kubernetes.command_has_flag(container.args, "--peer-auto-tls=true")
+}
+
 deny[res] {
-	output := checkFlag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_etcd(container)
+	checkFlag(container)
 	msg := "Ensure that the --peer-auto-tls argument is not set to true"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/etcd/peer_auto_tls_test.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/peer_auto_tls_test.rego
@@ -21,6 +21,28 @@ test_peer_auto_tls_is_set_to_false {
 	count(r) == 0
 }
 
+test_peer_auto_tls_is_set_to_false_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "etcd",
+			"labels": {
+				"component": "etcd",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["etcd"],
+			"args": ["--advertise-client-urls=https://192.168.49.2:2379", "--peer-auto-tls=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_peer_auto_tls_is_set_to_true {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/etcd/peer_cert_file_and_key_file.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/peer_cert_file_and_key_file.rego
@@ -19,20 +19,20 @@ package builtin.kubernetes.KCV0045
 
 import data.lib.kubernetes
 
-checkFlag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_etcd(container)
-	not kubernetes.command_has_flag(container.command, "--peer-cert-file")
+checkFlag(container) {
+	kubernetes.command_has_flag(container.command, "--peer-cert-file")
+	kubernetes.command_has_flag(container.command, "--peer-key-file")
 }
 
-checkFlag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_etcd(container)
-	not kubernetes.command_has_flag(container.command, "--peer-key-file")
+checkFlag(container) {
+	kubernetes.command_has_flag(container.args, "--peer-cert-file")
+	kubernetes.command_has_flag(container.args, "--peer-key-file")
 }
 
 deny[res] {
-	output := checkFlag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_etcd(container)
+	not checkFlag(container)
 	msg := "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/etcd/peer_cert_file_and_key_file_test.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/peer_cert_file_and_key_file_test.rego
@@ -65,6 +65,28 @@ test_etcd_peer_cert_file_and_peer_key_file_are_set {
 	count(r) == 0
 }
 
+test_etcd_peer_cert_file_and_peer_key_file_are_set_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "etcd",
+			"labels": {
+				"component": "etcd",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["etcd"],
+			"args": ["--peer-cert-file=<filename>", "--peer-key-file=<filename>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_etcd_peer_cert_file_and_peer_key_file_are_not_set {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/etcd/peer_client_cert_auth.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/peer_client_cert_auth.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0046
 
 import data.lib.kubernetes
 
-checkFlag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_etcd(container)
-	not kubernetes.command_has_flag(container.command, "--peer-client-cert-auth=true")
+checkFlag(container) {
+	kubernetes.command_has_flag(container.command, "--peer-client-cert-auth=true")
+}
+
+checkFlag(container) {
+	kubernetes.command_has_flag(container.command, "--peer-client-cert-auth=true")
 }
 
 deny[res] {
-	output := checkFlag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_etcd(container)
+	not checkFlag(container)
 	msg := "Ensure that the --peer-client-cert-auth argument is set to true"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/etcd/peer_client_cert_auth_test.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/peer_client_cert_auth_test.rego
@@ -21,6 +21,27 @@ test_peer_client_cert_auth_is_set_to_true {
 	count(r) == 0
 }
 
+test_peer_client_cert_auth_is_set_to_true_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "etcd",
+			"labels": {
+				"component": "etcd",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["--advertise-client-urls=https://192.168.49.2:2379", "--peer-client-cert-auth=true"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_peer_client_cert_auth_is_set_to_false {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/scheduler/bind_address.rego
+++ b/checks/kubernetes/cisbenchmarks/scheduler/bind_address.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0041
 
 import data.lib.kubernetes
 
-checkFlag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_scheduler(container)
-	not kubernetes.command_has_flag(container.command, "--bind-address=127.0.0.1")
+checkFlag(container) {
+	kubernetes.command_has_flag(container.command, "--bind-address=127.0.0.1")
+}
+
+checkFlag(container) {
+	kubernetes.command_has_flag(container.args, "--bind-address=127.0.0.1")
 }
 
 deny[res] {
-	output := checkFlag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_scheduler(container)
+	not checkFlag(container)
 	msg := "Ensure that the --bind-address argument is set to 127.0.0.1"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/scheduler/bind_address_test.rego
+++ b/checks/kubernetes/cisbenchmarks/scheduler/bind_address_test.rego
@@ -21,6 +21,28 @@ test_bind_address_is_set_to_localhost_ip {
 	count(r) == 0
 }
 
+test_bind_address_is_set_to_localhost_ip_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "scheduler",
+			"labels": {
+				"component": "kube-scheduler",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-scheduler"],
+			"args": ["--authentication-kubeconfig=<path/to/file>", "--bind-address=127.0.0.1"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_bind_address_is_set_to_different_ip {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/cisbenchmarks/scheduler/profiling.rego
+++ b/checks/kubernetes/cisbenchmarks/scheduler/profiling.rego
@@ -19,14 +19,18 @@ package builtin.kubernetes.KCV0040
 
 import data.lib.kubernetes
 
-checkFlag[container] {
-	container := kubernetes.containers[_]
-	kubernetes.is_scheduler(container)
-	not kubernetes.command_has_flag(container.command, "--profiling=false")
+checkFlag(container) {
+	kubernetes.command_has_flag(container.command, "--profiling=false")
+}
+
+checkFlag(container) {
+	kubernetes.command_has_flag(container.args, "--profiling=false")
 }
 
 deny[res] {
-	output := checkFlag[_]
+	container := kubernetes.containers[_]
+	kubernetes.is_scheduler(container)
+	not checkFlag(container)
 	msg := "Ensure that the --profiling argument is set to false"
-	res := result.new(msg, output)
+	res := result.new(msg, container)
 }

--- a/checks/kubernetes/cisbenchmarks/scheduler/profiling_test.rego
+++ b/checks/kubernetes/cisbenchmarks/scheduler/profiling_test.rego
@@ -21,6 +21,28 @@ test_profiling_is_set_to_false {
 	count(r) == 0
 }
 
+test_profiling_is_set_to_false_args {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "scheduler",
+			"labels": {
+				"component": "kube-scheduler",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-scheduler"],
+			"args": ["--authentication-kubeconfig=<path/to/file>", "--profiling=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
 test_profiling_is_set_to_true {
 	r := deny with input as {
 		"apiVersion": "v1",


### PR DESCRIPTION
### Description 
cis checks validate (api-server, controller-manager, scheduler and etcd) args
args might appear together with `command` or placed with the separate args field
this change check for args in both fields `command` and `args`

- Related https://github.com/aquasecurity/trivy/issues/6127 