### PR TITLE
Cleanup AWS CloudFormation checks examples

### DIFF
--- a/avd_docs/aws/cloudtrail/AVD-AWS-0014/CloudFormation.md
+++ b/avd_docs/aws/cloudtrail/AVD-AWS-0014/CloudFormation.md
@@ -3,7 +3,7 @@ Enable Cloudtrail in all regions
 
 ```yaml---
 Resources:
-  BadExample:
+  GoodExample:
     Type: AWS::CloudTrail::Trail
     Properties:
       IsLogging: true

--- a/avd_docs/aws/cloudtrail/AVD-AWS-0015/CloudFormation.md
+++ b/avd_docs/aws/cloudtrail/AVD-AWS-0015/CloudFormation.md
@@ -3,7 +3,7 @@ Use Customer managed key
 
 ```yaml---
 Resources:
-  BadExample:
+  GoodExample:
     Type: AWS::CloudTrail::Trail
     Properties:
       IsLogging: true

--- a/avd_docs/aws/cloudtrail/AVD-AWS-0016/CloudFormation.md
+++ b/avd_docs/aws/cloudtrail/AVD-AWS-0016/CloudFormation.md
@@ -3,7 +3,7 @@ Turn on log validation for Cloudtrail
 
 ```yaml---
 Resources:
-  BadExample:
+  GoodExample:
     Type: AWS::CloudTrail::Trail
     Properties:
       IsLogging: true

--- a/avd_docs/aws/dynamodb/AVD-AWS-0023/CloudFormation.md
+++ b/avd_docs/aws/dynamodb/AVD-AWS-0023/CloudFormation.md
@@ -3,14 +3,14 @@ Enable encryption at rest for DAX Cluster
 
 ```yaml---
 Resources:
-  daxCluster:
+  GoodExample:
     Type: AWS::DAX::Cluster
     Properties:
       ClusterName: "MyDAXCluster"
       NodeType: "dax.r3.large"
       ReplicationFactor: 1
       IAMRoleARN: "arn:aws:iam::111122223333:role/DaxAccess"
-      Description: "DAX cluster created with CloudFormation"
+      Description: "DAX cluster with encryption at rest"
       SSESpecification:
         SSEEnabled: true
 

--- a/avd_docs/aws/ec2/AVD-AWS-0099/CloudFormation.md
+++ b/avd_docs/aws/ec2/AVD-AWS-0099/CloudFormation.md
@@ -2,8 +2,6 @@
 Add descriptions for all security groups
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of group description
 Resources:
   GoodSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/avd_docs/aws/ec2/AVD-AWS-0107/CloudFormation.md
+++ b/avd_docs/aws/ec2/AVD-AWS-0107/CloudFormation.md
@@ -2,10 +2,8 @@
 Set a more restrictive cidr range
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of ingress rule
 Resources:
-  BadSecurityGroup:
+  GoodSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Limits security group egress traffic

--- a/avd_docs/aws/ec2/AVD-AWS-0124/CloudFormation.md
+++ b/avd_docs/aws/ec2/AVD-AWS-0124/CloudFormation.md
@@ -2,8 +2,6 @@
 Add descriptions for all security groups rules
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of SGR description
 Resources:
   GoodSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/avd_docs/aws/iam/AVD-AWS-0057/CloudFormation.md
+++ b/avd_docs/aws/iam/AVD-AWS-0057/CloudFormation.md
@@ -2,8 +2,6 @@
 Specify the exact permissions required, and to which resources they should apply instead of using wildcards.
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of policy
 Resources:
   GoodPolicy:
     Type: 'AWS::IAM::Policy'

--- a/avd_docs/aws/lambda/AVD-AWS-0066/CloudFormation.md
+++ b/avd_docs/aws/lambda/AVD-AWS-0066/CloudFormation.md
@@ -3,7 +3,7 @@ Enable tracing
 
 ```yaml---
 Resources:
-  Function:
+  GoodExample:
     Type: AWS::Lambda::Function
     Properties:
       Handler: index.handler

--- a/avd_docs/aws/lambda/AVD-AWS-0067/CloudFormation.md
+++ b/avd_docs/aws/lambda/AVD-AWS-0067/CloudFormation.md
@@ -28,7 +28,6 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: s3.amazonaws.com
       SourceArn: "lambda.amazonaws.com"
-  
 
 ```
 

--- a/avd_docs/aws/mq/AVD-AWS-0070/CloudFormation.md
+++ b/avd_docs/aws/mq/AVD-AWS-0070/CloudFormation.md
@@ -2,15 +2,12 @@
 Enable audit logging
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Broker:
+  GoodBroker:
     Type: AWS::AmazonMQ::Broker
     Properties:
       Logs:
         Audit: true
-
 
 ```
 

--- a/avd_docs/aws/mq/AVD-AWS-0071/CloudFormation.md
+++ b/avd_docs/aws/mq/AVD-AWS-0071/CloudFormation.md
@@ -2,15 +2,12 @@
 Enable general logging
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Broker:
+  GoodBroker:
     Type: AWS::AmazonMQ::Broker
     Properties:
       Logs:
         General: true
-
 
 ```
 

--- a/avd_docs/aws/mq/AVD-AWS-0072/CloudFormation.md
+++ b/avd_docs/aws/mq/AVD-AWS-0072/CloudFormation.md
@@ -2,14 +2,11 @@
 Disable public access when not required
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Broker:
+  GoodBroker:
     Type: AWS::AmazonMQ::Broker
     Properties:
       PubliclyAccessible: false
-
 
 ```
 

--- a/avd_docs/aws/msk/AVD-AWS-0073/CloudFormation.md
+++ b/avd_docs/aws/msk/AVD-AWS-0073/CloudFormation.md
@@ -2,10 +2,8 @@
 Enable in transit encryption
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Cluster:
+  GoodCluster:
     Type: AWS::MSK::Cluster
     Properties:
       EncryptionInfo:

--- a/avd_docs/aws/msk/AVD-AWS-0074/CloudFormation.md
+++ b/avd_docs/aws/msk/AVD-AWS-0074/CloudFormation.md
@@ -2,10 +2,8 @@
 Enable logging
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Cluster:
+  GoodCluster:
     Type: AWS::MSK::Cluster
     Properties:
       LoggingInfo:

--- a/avd_docs/aws/msk/AVD-AWS-0179/CloudFormation.md
+++ b/avd_docs/aws/msk/AVD-AWS-0179/CloudFormation.md
@@ -2,10 +2,8 @@
 Enable at rest encryption
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Cluster:
+  GoodCluster:
     Type: AWS::MSK::Cluster
     Properties:
       EncryptionInfo:

--- a/avd_docs/aws/neptune/AVD-AWS-0075/CloudFormation.md
+++ b/avd_docs/aws/neptune/AVD-AWS-0075/CloudFormation.md
@@ -2,16 +2,12 @@
 Enable export logs
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Cluster:
+  GoodCluster:
     Type: AWS::Neptune::DBCluster
     Properties:
       EnableCloudwatchLogsExports:
         - audit
-
-
 
 ```
 

--- a/avd_docs/aws/neptune/AVD-AWS-0076/CloudFormation.md
+++ b/avd_docs/aws/neptune/AVD-AWS-0076/CloudFormation.md
@@ -2,15 +2,12 @@
 Enable encryption of Neptune storage
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Cluster:
+  GoodCluster:
     Type: AWS::Neptune::DBCluster
     Properties:
       StorageEncrypted: true
       KmsKeyId: "something"
-
 
 ```
 

--- a/avd_docs/aws/neptune/AVD-AWS-0128/CloudFormation.md
+++ b/avd_docs/aws/neptune/AVD-AWS-0128/CloudFormation.md
@@ -2,15 +2,12 @@
 Enable encryption using customer managed keys
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Cluster:
+  GoodCluster:
     Type: AWS::Neptune::DBCluster
     Properties:
       StorageEncrypted: true
       KmsKeyId: "something"
-
 
 ```
 

--- a/avd_docs/aws/rds/AVD-AWS-0077/CloudFormation.md
+++ b/avd_docs/aws/rds/AVD-AWS-0077/CloudFormation.md
@@ -2,8 +2,6 @@
 Explicitly set the retention period to greater than the default
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
   Queue:
     Type: AWS::RDS::DBInstance

--- a/avd_docs/aws/rds/AVD-AWS-0077/CloudFormation.md
+++ b/avd_docs/aws/rds/AVD-AWS-0077/CloudFormation.md
@@ -3,11 +3,10 @@ Explicitly set the retention period to greater than the default
 
 ```yaml---
 Resources:
-  Queue:
+  GoodExample:
     Type: AWS::RDS::DBInstance
     Properties:
       BackupRetentionPeriod: 30
-
 
 ```
 

--- a/avd_docs/aws/rds/AVD-AWS-0078/CloudFormation.md
+++ b/avd_docs/aws/rds/AVD-AWS-0078/CloudFormation.md
@@ -2,15 +2,12 @@
 Use Customer Managed Keys to encrypt Performance Insights data
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Queue:
+  GoodExample:
     Type: AWS::RDS::DBInstance
     Properties:
       EnablePerformanceInsights: true
       PerformanceInsightsKMSKeyId: "something"
-
 
 ```
 

--- a/avd_docs/aws/rds/AVD-AWS-0079/CloudFormation.md
+++ b/avd_docs/aws/rds/AVD-AWS-0079/CloudFormation.md
@@ -2,15 +2,12 @@
 Enable encryption for RDS clusters
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of rds sgr
 Resources:
-  Cluster:
+  GoodExample:
     Type: AWS::RDS::DBCluster
     Properties:
       StorageEncrypted: true
       KmsKeyId: "something"
-
 
 ```
 

--- a/avd_docs/aws/rds/AVD-AWS-0080/CloudFormation.md
+++ b/avd_docs/aws/rds/AVD-AWS-0080/CloudFormation.md
@@ -2,10 +2,8 @@
 Enable encryption for RDS instances
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of rds sgr
 Resources:
-  Instance:
+  GoodExample:
     Type: AWS::RDS::DBInstance
     Properties:
       StorageEncrypted: true

--- a/avd_docs/aws/rds/AVD-AWS-0133/CloudFormation.md
+++ b/avd_docs/aws/rds/AVD-AWS-0133/CloudFormation.md
@@ -2,10 +2,8 @@
 Enable performance insights
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Queue:
+  GoodExample:
     Type: AWS::RDS::DBInstance
     Properties:
       EnablePerformanceInsights: true

--- a/avd_docs/aws/rds/AVD-AWS-0180/CloudFormation.md
+++ b/avd_docs/aws/rds/AVD-AWS-0180/CloudFormation.md
@@ -2,14 +2,11 @@
 Remove the public endpoint from the RDS instance.
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Queue:
+  GoodExample:
     Type: AWS::RDS::DBInstance
     Properties:
       PubliclyAccessible: false
-
 
 ```
 

--- a/avd_docs/aws/redshift/AVD-AWS-0083/CloudFormation.md
+++ b/avd_docs/aws/redshift/AVD-AWS-0083/CloudFormation.md
@@ -2,14 +2,11 @@
 Add descriptions for all security groups and rules
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of redshift sgr
 Resources:
-  Queue:
+  GoodExample:
     Type: AWS::Redshift::ClusterSecurityGroup
     Properties:
       Description: "Disallow bad stuff"
-
 
 ```
 

--- a/avd_docs/aws/redshift/AVD-AWS-0084/CloudFormation.md
+++ b/avd_docs/aws/redshift/AVD-AWS-0084/CloudFormation.md
@@ -2,15 +2,12 @@
 Enable encryption using CMK
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of redshift cluster
 Resources:
-  Queue:
+  GoodExample:
     Type: AWS::Redshift::Cluster
     Properties:
       Encrypted: true
       KmsKeyId: "something"
-
 
 ```
 

--- a/avd_docs/aws/redshift/AVD-AWS-0127/CloudFormation.md
+++ b/avd_docs/aws/redshift/AVD-AWS-0127/CloudFormation.md
@@ -2,14 +2,11 @@
 Deploy Redshift cluster into a non default VPC
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of redshift cluster
 Resources:
-  Queue:
+  GoodCluster:
     Type: AWS::Redshift::Cluster
     Properties:
       ClusterSubnetGroupName: "my-subnet-group"
-
 
 ```
 

--- a/avd_docs/aws/s3/AVD-AWS-0088/CloudFormation.md
+++ b/avd_docs/aws/s3/AVD-AWS-0088/CloudFormation.md
@@ -4,13 +4,13 @@ Configure bucket encryption
 ```yaml
 Resources:
   GoodExample:
+    Type: AWS::S3::Bucket
     Properties:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - BucketKeyEnabled: true
             ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
-    Type: AWS::S3::Bucket
 
 ```
 

--- a/avd_docs/aws/s3/AVD-AWS-0089/CloudFormation.md
+++ b/avd_docs/aws/s3/AVD-AWS-0089/CloudFormation.md
@@ -4,11 +4,11 @@ Add a logging block to the resource to enable access logging
 ```yaml---
 Resources:
   GoodExample:
+    Type: AWS::S3::Bucket
     Properties:
       LoggingConfiguration:
         DestinationBucketName: logging-bucket
         LogFilePrefix: accesslogs/
-    Type: AWS::S3::Bucket
 
 ```
 

--- a/avd_docs/aws/s3/AVD-AWS-0090/CloudFormation.md
+++ b/avd_docs/aws/s3/AVD-AWS-0090/CloudFormation.md
@@ -4,10 +4,10 @@ Enable versioning to protect against accidental/malicious removal or modificatio
 ```yaml---
 Resources:
   GoodExample:
+    Type: AWS::S3::Bucket
     Properties:
       VersioningConfiguration:
         Status: Enabled
-    Type: AWS::S3::Bucket
 
 ```
 

--- a/avd_docs/aws/s3/AVD-AWS-0091/CloudFormation.md
+++ b/avd_docs/aws/s3/AVD-AWS-0091/CloudFormation.md
@@ -4,6 +4,7 @@ Enable ignoring the application of public ACLs in PUT calls
 ```yaml---
 Resources:
   GoodExample:
+    Type: AWS::S3::Bucket
     Properties:
       AccessControl: Private
       PublicAccessBlockConfiguration:
@@ -11,7 +12,6 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
-    Type: AWS::S3::Bucket
 
 ```
 

--- a/avd_docs/aws/s3/AVD-AWS-0092/CloudFormation.md
+++ b/avd_docs/aws/s3/AVD-AWS-0092/CloudFormation.md
@@ -4,9 +4,9 @@ Don't use canned ACLs or switch to private acl
 ```yaml---
 Resources:
   GoodExample:
+    Type: AWS::S3::Bucket
     Properties:
       AccessControl: Private
-    Type: AWS::S3::Bucket
 
 ```
 

--- a/avd_docs/aws/s3/AVD-AWS-0093/CloudFormation.md
+++ b/avd_docs/aws/s3/AVD-AWS-0093/CloudFormation.md
@@ -4,13 +4,13 @@ Limit the access to public buckets to only the owner or AWS Services (eg; CloudF
 ```yaml---
 Resources:
   GoodExample:
+    Type: AWS::S3::Bucket
     Properties:
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
-    Type: AWS::S3::Bucket
 
 ```
 

--- a/avd_docs/aws/s3/AVD-AWS-0094/CloudFormation.md
+++ b/avd_docs/aws/s3/AVD-AWS-0094/CloudFormation.md
@@ -4,6 +4,7 @@ Define a aws_s3_bucket_public_access_block for the given bucket to control publi
 ```yaml---
 Resources:
   GoodExample:
+    Type: AWS::S3::Bucket
     Properties:
       AccessControl: Private
       PublicAccessBlockConfiguration:
@@ -11,7 +12,6 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
-    Type: AWS::S3::Bucket
 
 ```
 

--- a/avd_docs/aws/s3/AVD-AWS-0132/CloudFormation.md
+++ b/avd_docs/aws/s3/AVD-AWS-0132/CloudFormation.md
@@ -4,6 +4,7 @@ Enable encryption using customer managed keys
 ```yaml
 Resources:
   GoodExample:
+    Type: AWS::S3::Bucket
     Properties:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
@@ -11,7 +12,6 @@ Resources:
             ServerSideEncryptionByDefault:
               KMSMasterKeyID: kms-arn
               SSEAlgorithm: aws:kms
-    Type: AWS::S3::Bucket
 
 ```
 

--- a/avd_docs/aws/sam/AVD-AWS-0110/CloudFormation.md
+++ b/avd_docs/aws/sam/AVD-AWS-0110/CloudFormation.md
@@ -2,10 +2,8 @@
 Enable cache encryption
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM API
 Resources:
-  ApiGatewayApi:
+  GoodExample:
     Type: AWS::Serverless::Api
     Properties:
       Name: Good SAM API example

--- a/avd_docs/aws/sam/AVD-AWS-0111/CloudFormation.md
+++ b/avd_docs/aws/sam/AVD-AWS-0111/CloudFormation.md
@@ -2,10 +2,8 @@
 Enable tracing
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM API
 Resources:
-  ApiGatewayApi:
+  GoodExample:
     Type: AWS::Serverless::Api
     Properties:
       Name: Good SAM API example

--- a/avd_docs/aws/sam/AVD-AWS-0112/CloudFormation.md
+++ b/avd_docs/aws/sam/AVD-AWS-0112/CloudFormation.md
@@ -2,10 +2,8 @@
 Use the most modern TLS/SSL policies available
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM API
 Resources:
-  ApiGatewayApi:
+  GoodExample:
     Type: AWS::Serverless::Api
     Properties:
       Name: Good SAM API example

--- a/avd_docs/aws/sam/AVD-AWS-0113/CloudFormation.md
+++ b/avd_docs/aws/sam/AVD-AWS-0113/CloudFormation.md
@@ -2,10 +2,8 @@
 Enable logging for API Gateway stages
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM API
 Resources:
-  ApiGatewayApi:
+  GoodExample:
     Type: AWS::Serverless::Api
     Properties:
       Name: Good SAM API example

--- a/avd_docs/aws/sam/AVD-AWS-0114/CloudFormation.md
+++ b/avd_docs/aws/sam/AVD-AWS-0114/CloudFormation.md
@@ -2,8 +2,6 @@
 Specify the exact permissions required, and to which resources they should apply instead of using wildcards.
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM Function
 Resources:
   GoodFunction:
     Type: AWS::Serverless::Function

--- a/avd_docs/aws/sam/AVD-AWS-0116/CloudFormation.md
+++ b/avd_docs/aws/sam/AVD-AWS-0116/CloudFormation.md
@@ -2,10 +2,8 @@
 Enable logging for API Gateway stages
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM API
 Resources:
-  ApiGatewayApi:
+  GoodExample:
     Type: AWS::Serverless::HttpApi
     Properties:
       Name: Good SAM API example

--- a/avd_docs/aws/sam/AVD-AWS-0117/CloudFormation.md
+++ b/avd_docs/aws/sam/AVD-AWS-0117/CloudFormation.md
@@ -2,8 +2,6 @@
 Enable tracing
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM API
 Resources:
   GoodStateMachine:
     Type: AWS::Serverless::StateMachine

--- a/avd_docs/aws/sam/AVD-AWS-0120/CloudFormation.md
+++ b/avd_docs/aws/sam/AVD-AWS-0120/CloudFormation.md
@@ -2,8 +2,6 @@
 Specify the exact permissions required, and to which resources they should apply instead of using wildcards.
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM Function
 Resources:
   GoodFunction:
     Type: AWS::Serverless::StateMachine

--- a/avd_docs/aws/sam/AVD-AWS-0121/CloudFormation.md
+++ b/avd_docs/aws/sam/AVD-AWS-0121/CloudFormation.md
@@ -2,8 +2,6 @@
 Enable server side encryption
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM Table
 Resources:
   GoodFunction:
     Type: AWS::Serverless::SimpleTable

--- a/avd_docs/aws/sam/AVD-AWS-0125/CloudFormation.md
+++ b/avd_docs/aws/sam/AVD-AWS-0125/CloudFormation.md
@@ -2,8 +2,6 @@
 Enable tracing
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM Function
 Resources:
   GoodFunction:
     Type: AWS::Serverless::Function

--- a/avd_docs/aws/sns/AVD-AWS-0095/CloudFormation.md
+++ b/avd_docs/aws/sns/AVD-AWS-0095/CloudFormation.md
@@ -2,15 +2,12 @@
 Turn on SNS Topic encryption
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of topic
 Resources:
-  Queue:
+  GoodTopic:
     Type: AWS::SQS::Topic
     Properties:
       TopicName: blah
       KmsMasterKeyId: some-key
-
 
 ```
 

--- a/avd_docs/aws/sns/AVD-AWS-0136/CloudFormation.md
+++ b/avd_docs/aws/sns/AVD-AWS-0136/CloudFormation.md
@@ -2,15 +2,12 @@
 Use a CMK for SNS Topic encryption
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of topic
 Resources:
-  Queue:
+  GoodTopic:
     Type: AWS::SQS::Topic
     Properties:
       TopicName: blah
       KmsMasterKeyId: some-key
-
 
 ```
 

--- a/avd_docs/aws/sqs/AVD-AWS-0096/CloudFormation.md
+++ b/avd_docs/aws/sqs/AVD-AWS-0096/CloudFormation.md
@@ -2,15 +2,12 @@
 Turn on SQS Queue encryption
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of queue
 Resources:
-  Queue:
+  GoodQueue:
     Type: AWS::SQS::Queue
     Properties:
       KmsMasterKeyId: some-key
       QueueName: my-queue
-
 
 ```
 

--- a/avd_docs/aws/sqs/AVD-AWS-0097/CloudFormation.md
+++ b/avd_docs/aws/sqs/AVD-AWS-0097/CloudFormation.md
@@ -2,10 +2,8 @@
 Keep policy scope to the minimum that is required to be effective
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of queue policy
 Resources:
-  MyQueue:
+  GoodQueue:
     Type: AWS::SQS::Queue
     Properties:
       Name: something

--- a/avd_docs/aws/sqs/AVD-AWS-0135/CloudFormation.md
+++ b/avd_docs/aws/sqs/AVD-AWS-0135/CloudFormation.md
@@ -2,15 +2,12 @@
 Encrypt SQS Queue with a customer-managed key
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of queue
 Resources:
-  Queue:
+  GoodQueue:
     Type: AWS::SQS::Queue
     Properties:
       KmsMasterKeyId: some-key
       QueueName: my-queue
-
 
 ```
 

--- a/avd_docs/aws/ssm/AVD-AWS-0098/CloudFormation.md
+++ b/avd_docs/aws/ssm/AVD-AWS-0098/CloudFormation.md
@@ -2,10 +2,8 @@
 Use customer managed keys
 
 ```yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of ingress rule
 Resources:
-  Secret:
+  GoodSecret:
     Type: AWS::SecretsManager::Secret
     Properties:
       Description: "secret"

--- a/checks/cloud/aws/cloudtrail/enable_all_regions.cf.go
+++ b/checks/cloud/aws/cloudtrail/enable_all_regions.cf.go
@@ -3,7 +3,7 @@ package cloudtrail
 var cloudFormationEnableAllRegionsGoodExamples = []string{
 	`---
 Resources:
-  BadExample:
+  GoodExample:
     Type: AWS::CloudTrail::Trail
     Properties:
       IsLogging: true

--- a/checks/cloud/aws/cloudtrail/enable_log_validation.cf.go
+++ b/checks/cloud/aws/cloudtrail/enable_log_validation.cf.go
@@ -3,7 +3,7 @@ package cloudtrail
 var cloudFormationEnableLogValidationGoodExamples = []string{
 	`---
 Resources:
-  BadExample:
+  GoodExample:
     Type: AWS::CloudTrail::Trail
     Properties:
       IsLogging: true

--- a/checks/cloud/aws/cloudtrail/encryption_customer_key.cf.go
+++ b/checks/cloud/aws/cloudtrail/encryption_customer_key.cf.go
@@ -3,7 +3,7 @@ package cloudtrail
 var cloudFormationEncryptionCustomerManagedKeyGoodExamples = []string{
 	`---
 Resources:
-  BadExample:
+  GoodExample:
     Type: AWS::CloudTrail::Trail
     Properties:
       IsLogging: true

--- a/checks/cloud/aws/dynamodb/enable_at_rest_encryption.cf.go
+++ b/checks/cloud/aws/dynamodb/enable_at_rest_encryption.cf.go
@@ -3,14 +3,14 @@ package dynamodb
 var cloudFormationEnableAtRestEncryptionGoodExamples = []string{
 	`---
 Resources:
-  daxCluster:
+  GoodExample:
     Type: AWS::DAX::Cluster
     Properties:
       ClusterName: "MyDAXCluster"
       NodeType: "dax.r3.large"
       ReplicationFactor: 1
       IAMRoleARN: "arn:aws:iam::111122223333:role/DaxAccess"
-      Description: "DAX cluster created with CloudFormation"
+      Description: "DAX cluster with encryption at rest"
       SSESpecification:
         SSEEnabled: true
 `,
@@ -19,14 +19,14 @@ Resources:
 var cloudFormationEnableAtRestEncryptionBadExamples = []string{
 	`---
 Resources:
-  daxCluster:
+  BadExample:
     Type: AWS::DAX::Cluster
     Properties:
       ClusterName: "MyDAXCluster"
       NodeType: "dax.r3.large"
       ReplicationFactor: 1
       IAMRoleARN: "arn:aws:iam::111122223333:role/DaxAccess"
-      Description: "DAX cluster created with CloudFormation"
+      Description: "DAX cluster without encryption at rest"
       SubnetGroupName: !Ref subnetGroupClu
 `,
 }

--- a/checks/cloud/aws/ec2/add_description_to_security_group.cf.go
+++ b/checks/cloud/aws/ec2/add_description_to_security_group.cf.go
@@ -2,8 +2,6 @@ package ec2
 
 var cloudFormationAddDescriptionToSecurityGroupGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of group description
 Resources:
   GoodSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -17,8 +15,6 @@ Resources:
 
 var cloudFormationAddDescriptionToSecurityGroupBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example of group description
 Resources:
   BadSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/checks/cloud/aws/ec2/add_description_to_security_group_rule.cf.go
+++ b/checks/cloud/aws/ec2/add_description_to_security_group_rule.cf.go
@@ -2,8 +2,6 @@ package ec2
 
 var cloudFormationAddDescriptionToSecurityGroupRuleGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of SGR description
 Resources:
   GoodSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -18,8 +16,6 @@ Resources:
 
 var cloudFormationAddDescriptionToSecurityGroupRuleBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example of SGR description
 Resources:
   BadSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/checks/cloud/aws/ec2/no_public_ingress_sgr.cf.go
+++ b/checks/cloud/aws/ec2/no_public_ingress_sgr.cf.go
@@ -2,10 +2,8 @@ package ec2
 
 var cloudFormationNoPublicIngressSgrGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of ingress rule
 Resources:
-  BadSecurityGroup:
+  GoodSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Limits security group egress traffic
@@ -17,8 +15,6 @@ Resources:
 
 var cloudFormationNoPublicIngressSgrBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example of ingress rule
 Resources:
   BadSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/checks/cloud/aws/iam/no_policy_wildcards.cf.go
+++ b/checks/cloud/aws/iam/no_policy_wildcards.cf.go
@@ -2,8 +2,6 @@ package iam
 
 var cloudFormationNoPolicyWildcardsGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of policy
 Resources:
   GoodPolicy:
     Type: 'AWS::IAM::Policy'
@@ -21,8 +19,6 @@ Resources:
 
 var cloudFormationNoPolicyWildcardsBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example of policy
 Resources:
   BadPolicy:
     Type: 'AWS::IAM::Policy'

--- a/checks/cloud/aws/kinesis/enable_in_transit_encryption.cf.go
+++ b/checks/cloud/aws/kinesis/enable_in_transit_encryption.cf.go
@@ -32,7 +32,6 @@ Resources:
         -
           Key: Environment 
           Value: Production
-
 `,
 }
 

--- a/checks/cloud/aws/lambda/enable_tracing.cf.go
+++ b/checks/cloud/aws/lambda/enable_tracing.cf.go
@@ -3,7 +3,7 @@ package lambda
 var cloudFormationEnableTracingGoodExamples = []string{
 	`---
 Resources:
-  Function:
+  GoodExample:
     Type: AWS::Lambda::Function
     Properties:
       Handler: index.handler

--- a/checks/cloud/aws/lambda/restrict_source_arn.cf.go
+++ b/checks/cloud/aws/lambda/restrict_source_arn.cf.go
@@ -28,7 +28,6 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: s3.amazonaws.com
       SourceArn: "lambda.amazonaws.com"
-  
 `,
 }
 
@@ -59,7 +58,6 @@ Resources:
       FunctionName: !Ref BadExample
       Action: lambda:InvokeFunction
       Principal: s3.amazonaws.com
-
 `,
 }
 

--- a/checks/cloud/aws/mq/enable_audit_logging.cf.go
+++ b/checks/cloud/aws/mq/enable_audit_logging.cf.go
@@ -2,29 +2,23 @@ package mq
 
 var cloudFormationEnableAuditLoggingGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Broker:
+  GoodBroker:
     Type: AWS::AmazonMQ::Broker
     Properties:
       Logs:
         Audit: true
-
 `,
 }
 
 var cloudFormationEnableAuditLoggingBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example
 Resources:
-  Broker:
+  BadBroker:
     Type: AWS::AmazonMQ::Broker
     Properties:
       Logs:
         Audit: false
-
 `,
 }
 

--- a/checks/cloud/aws/mq/enable_general_logging.cf.go
+++ b/checks/cloud/aws/mq/enable_general_logging.cf.go
@@ -2,29 +2,23 @@ package mq
 
 var cloudFormationEnableGeneralLoggingGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Broker:
+  GoodBroker:
     Type: AWS::AmazonMQ::Broker
     Properties:
       Logs:
         General: true
-
 `,
 }
 
 var cloudFormationEnableGeneralLoggingBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example
 Resources:
-  Broker:
+  BadBroker:
     Type: AWS::AmazonMQ::Broker
     Properties:
       Logs:
         General: false
-
 `,
 }
 

--- a/checks/cloud/aws/mq/no_public_access.cf.go
+++ b/checks/cloud/aws/mq/no_public_access.cf.go
@@ -2,27 +2,21 @@ package mq
 
 var cloudFormationNoPublicAccessGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Broker:
+  GoodBroker:
     Type: AWS::AmazonMQ::Broker
     Properties:
       PubliclyAccessible: false
-
 `,
 }
 
 var cloudFormationNoPublicAccessBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example
 Resources:
-  Broker:
+  BadBroker:
     Type: AWS::AmazonMQ::Broker
     Properties:
       PubliclyAccessible: true
-
 `,
 }
 

--- a/checks/cloud/aws/msk/enable_at_rest_encryption.cf.go
+++ b/checks/cloud/aws/msk/enable_at_rest_encryption.cf.go
@@ -2,10 +2,8 @@ package msk
 
 var cloudFormationEnableAtRestEncryptionGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Cluster:
+  GoodCluster:
     Type: AWS::MSK::Cluster
     Properties:
       EncryptionInfo:
@@ -16,10 +14,8 @@ Resources:
 
 var cloudFormationEnableAtRestEncryptionBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example
 Resources:
-  Cluster:
+  BadCluster:
     Type: AWS::MSK::Cluster
     Properties:
 `,

--- a/checks/cloud/aws/msk/enable_in_transit_encryption.cf.go
+++ b/checks/cloud/aws/msk/enable_in_transit_encryption.cf.go
@@ -2,10 +2,8 @@ package msk
 
 var cloudFormationEnableInTransitEncryptionGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Cluster:
+  GoodCluster:
     Type: AWS::MSK::Cluster
     Properties:
       EncryptionInfo:
@@ -16,10 +14,8 @@ Resources:
 
 var cloudFormationEnableInTransitEncryptionBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example
 Resources:
-  Cluster:
+  BadCluster:
     Type: AWS::MSK::Cluster
     Properties:
       EncryptionInfo:

--- a/checks/cloud/aws/msk/enable_logging.cf.go
+++ b/checks/cloud/aws/msk/enable_logging.cf.go
@@ -2,10 +2,8 @@ package msk
 
 var cloudFormationEnableLoggingGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Cluster:
+  GoodCluster:
     Type: AWS::MSK::Cluster
     Properties:
       LoggingInfo:
@@ -19,17 +17,14 @@ Resources:
 
 var cloudFormationEnableLoggingBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example
 Resources:
-  Cluster:
+  BadCluster:
     Type: AWS::MSK::Cluster
     Properties:
       LoggingInfo:
         BrokerLogs:
           CloudWatchLogs:
             Enabled: false
-
 `,
 }
 

--- a/checks/cloud/aws/neptune/enable_log_export.cf.go
+++ b/checks/cloud/aws/neptune/enable_log_export.cf.go
@@ -2,30 +2,23 @@ package neptune
 
 var cloudFormationEnableLogExportGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Cluster:
+  GoodCluster:
     Type: AWS::Neptune::DBCluster
     Properties:
       EnableCloudwatchLogsExports:
         - audit
-
-
 `,
 }
 
 var cloudFormationEnableLogExportBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example
 Resources:
-  Cluster:
+  BadCluster:
     Type: AWS::Neptune::DBCluster
     Properties:
       EnableCloudwatchLogsExports:
         - debug
-
 `,
 }
 

--- a/checks/cloud/aws/neptune/enable_storage_encryption.cf.go
+++ b/checks/cloud/aws/neptune/enable_storage_encryption.cf.go
@@ -2,15 +2,12 @@ package neptune
 
 var cloudFormationEnableStorageEncryptionGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Cluster:
+  GoodCluster:
     Type: AWS::Neptune::DBCluster
     Properties:
       StorageEncrypted: true
       KmsKeyId: "something"
-
 `,
 }
 
@@ -19,11 +16,10 @@ var cloudFormationEnableStorageEncryptionBadExamples = []string{
 AWSTemplateFormatVersion: 2010-09-09
 Description: Bad example
 Resources:
-  Cluster:
+  BadCluster:
     Type: AWS::Neptune::DBCluster
     Properties:
       StorageEncrypted: false
-
 `,
 }
 

--- a/checks/cloud/aws/neptune/encryption_customer_key.cf.go
+++ b/checks/cloud/aws/neptune/encryption_customer_key.cf.go
@@ -2,28 +2,22 @@ package neptune
 
 var cloudFormationCheckEncryptionCustomerKeyGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Cluster:
+  GoodCluster:
     Type: AWS::Neptune::DBCluster
     Properties:
       StorageEncrypted: true
       KmsKeyId: "something"
-
 `,
 }
 
 var cloudFormationCheckEncryptionCustomerKeyBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example
 Resources:
-  Cluster:
+  BadCluster:
     Type: AWS::Neptune::DBCluster
     Properties:
       StorageEncrypted: false
-
 `,
 }
 

--- a/checks/cloud/aws/rds/disable_public_access.cf.go
+++ b/checks/cloud/aws/rds/disable_public_access.cf.go
@@ -3,7 +3,7 @@ package rds
 var cloudFormationNoPublicDbAccessGoodExamples = []string{
 	`---
 Resources:
-  GoodQueue:
+  GoodExample:
     Type: AWS::RDS::DBInstance
     Properties:
       PubliclyAccessible: false
@@ -13,7 +13,7 @@ Resources:
 var cloudFormationNoPublicDbAccessBadExamples = []string{
 	`---
 Resources:
-  BadQueue:
+  BadExample:
     Type: AWS::RDS::DBInstance
     Properties:
       PubliclyAccessible: true

--- a/checks/cloud/aws/rds/disable_public_access.cf.go
+++ b/checks/cloud/aws/rds/disable_public_access.cf.go
@@ -2,27 +2,21 @@ package rds
 
 var cloudFormationNoPublicDbAccessGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Queue:
+  GoodQueue:
     Type: AWS::RDS::DBInstance
     Properties:
       PubliclyAccessible: false
-
 `,
 }
 
 var cloudFormationNoPublicDbAccessBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example
 Resources:
-  Queue:
+  BadQueue:
     Type: AWS::RDS::DBInstance
     Properties:
       PubliclyAccessible: true
-
 `,
 }
 

--- a/checks/cloud/aws/rds/enable_performance_insights.cf.go
+++ b/checks/cloud/aws/rds/enable_performance_insights.cf.go
@@ -2,10 +2,8 @@ package rds
 
 var cloudFormationEnablePerformanceInsightsGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Queue:
+  GoodExample:
     Type: AWS::RDS::DBInstance
     Properties:
       EnablePerformanceInsights: true
@@ -16,14 +14,11 @@ Resources:
 
 var cloudFormationEnablePerformanceInsightsBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example
 Resources:
-  Queue:
+  BadExample:
     Type: AWS::RDS::DBInstance
     Properties:
       EnablePerformanceInsights: false
-
 `,
 }
 

--- a/checks/cloud/aws/rds/encrypt_cluster_storage_data.cf.go
+++ b/checks/cloud/aws/rds/encrypt_cluster_storage_data.cf.go
@@ -2,28 +2,22 @@ package rds
 
 var cloudFormationEncryptClusterStorageDataGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of rds sgr
 Resources:
-  Cluster:
+  GoodExample:
     Type: AWS::RDS::DBCluster
     Properties:
       StorageEncrypted: true
       KmsKeyId: "something"
-
 `,
 }
 
 var cloudFormationEncryptClusterStorageDataBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example of rds sgr
 Resources:
-  Cluster:
+  BadExample:
     Type: AWS::RDS::DBCluster
     Properties:
       StorageEncrypted: false
-
 `,
 }
 

--- a/checks/cloud/aws/rds/encrypt_instance_storage_data.cf.go
+++ b/checks/cloud/aws/rds/encrypt_instance_storage_data.cf.go
@@ -2,10 +2,8 @@ package rds
 
 var cloudFormationEncryptInstanceStorageDataGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of rds sgr
 Resources:
-  Instance:
+  GoodExample:
     Type: AWS::RDS::DBInstance
     Properties:
       StorageEncrypted: true
@@ -16,14 +14,11 @@ Resources:
 
 var cloudFormationEncryptInstanceStorageDataBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example of rds sgr
 Resources:
-  Instance:
+  BadExample:
     Type: AWS::RDS::DBInstance
     Properties:
       StorageEncrypted: false
-
 `,
 }
 

--- a/checks/cloud/aws/rds/no_classic_resources.cf.go
+++ b/checks/cloud/aws/rds/no_classic_resources.cf.go
@@ -2,19 +2,11 @@ package rds
 
 var cloudFormationNoClassicResourcesGoodExamples = []string{
 	`---
-Resources:
-# TODO
 `,
 }
 
 var cloudFormationNoClassicResourcesBadExamples = []string{
 	`---
-Resources:
-  BadExample:
-    Type: AWS::RDS::DBSecurityGroup
-    Properties:
-      Description: ""
-      # TODO
 `,
 }
 

--- a/checks/cloud/aws/rds/no_classic_resources.cf.go
+++ b/checks/cloud/aws/rds/no_classic_resources.cf.go
@@ -2,11 +2,23 @@ package rds
 
 var cloudFormationNoClassicResourcesGoodExamples = []string{
 	`---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Good example of rds sgr
+Resources:
+
 `,
 }
 
 var cloudFormationNoClassicResourcesBadExamples = []string{
 	`---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Bad example of rds sgr
+Resources:
+  Queue:
+    Type: AWS::RDS::DBSecurityGroup
+    Properties:
+      Description: ""
+
 `,
 }
 

--- a/checks/cloud/aws/rds/no_classic_resources.cf.go
+++ b/checks/cloud/aws/rds/no_classic_resources.cf.go
@@ -2,23 +2,19 @@ package rds
 
 var cloudFormationNoClassicResourcesGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of rds sgr
 Resources:
-
+# TODO
 `,
 }
 
 var cloudFormationNoClassicResourcesBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example of rds sgr
 Resources:
-  Queue:
+  BadExample:
     Type: AWS::RDS::DBSecurityGroup
     Properties:
       Description: ""
-
+      # TODO
 `,
 }
 

--- a/checks/cloud/aws/rds/no_classic_resources.go
+++ b/checks/cloud/aws/rds/no_classic_resources.go
@@ -11,6 +11,7 @@ import (
 var CheckNoClassicResources = rules.Register(
 	scan.Rule{
 		AVDID:      "AVD-AWS-0081",
+		Deprecated: true,
 		Provider:   providers.AWSProvider,
 		Service:    "rds",
 		ShortCode:  "no-classic-resources",

--- a/checks/cloud/aws/rds/performance_insights_encryption_customer_key.cf.go
+++ b/checks/cloud/aws/rds/performance_insights_encryption_customer_key.cf.go
@@ -2,28 +2,22 @@ package rds
 
 var cloudFormationPerformanceInsightsEncryptionCustomerKeyGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Queue:
+  GoodExample:
     Type: AWS::RDS::DBInstance
     Properties:
       EnablePerformanceInsights: true
       PerformanceInsightsKMSKeyId: "something"
-
 `,
 }
 
 var cloudFormationPerformanceInsightsEncryptionCustomerKeyBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example
 Resources:
-  Queue:
+  BadExample:
     Type: AWS::RDS::DBInstance
     Properties:
       EnablePerformanceInsights: true
-
 `,
 }
 

--- a/checks/cloud/aws/rds/specify_backup_retention.cf.go
+++ b/checks/cloud/aws/rds/specify_backup_retention.cf.go
@@ -2,26 +2,20 @@ package rds
 
 var cloudFormationSpecifyBackupRetentionGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
 Resources:
-  Queue:
+  GoodExample:
     Type: AWS::RDS::DBInstance
     Properties:
       BackupRetentionPeriod: 30
-
 `,
 }
 
 var cloudFormationSpecifyBackupRetentionBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example
 Resources:
-  Queue:
+  BadExample:
     Type: AWS::RDS::DBInstance
     Properties:
-
 `,
 }
 

--- a/checks/cloud/aws/redshift/add_description_to_security_group.cf.go
+++ b/checks/cloud/aws/redshift/add_description_to_security_group.cf.go
@@ -2,27 +2,23 @@ package redshift
 
 var cloudFormationAddDescriptionToSecurityGroupGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of redshift sgr
 Resources:
-  Queue:
+  GoodExample:
     Type: AWS::Redshift::ClusterSecurityGroup
     Properties:
       Description: "Disallow bad stuff"
-
+      # TODO
 `,
 }
 
 var cloudFormationAddDescriptionToSecurityGroupBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example of redshift sgr
 Resources:
-  Queue:
+  BadExample:
     Type: AWS::Redshift::ClusterSecurityGroup
     Properties:
       Description: ""
-
+      # TODO
 `,
 }
 

--- a/checks/cloud/aws/redshift/add_description_to_security_group.cf.go
+++ b/checks/cloud/aws/redshift/add_description_to_security_group.cf.go
@@ -7,7 +7,6 @@ Resources:
     Type: AWS::Redshift::ClusterSecurityGroup
     Properties:
       Description: "Disallow bad stuff"
-      # TODO
 `,
 }
 
@@ -18,7 +17,6 @@ Resources:
     Type: AWS::Redshift::ClusterSecurityGroup
     Properties:
       Description: ""
-      # TODO
 `,
 }
 

--- a/checks/cloud/aws/redshift/encryption_customer_key.cf.go
+++ b/checks/cloud/aws/redshift/encryption_customer_key.cf.go
@@ -2,10 +2,8 @@ package redshift
 
 var cloudFormationEncryptionCustomerKeyGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of redshift cluster
 Resources:
-  Queue:
+  GoodExample:
     Type: AWS::Redshift::Cluster
     Properties:
       Encrypted: true
@@ -16,13 +14,11 @@ Resources:
 
 var cloudFormationEncryptionCustomerKeyBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example of redshift cluster
 Resources:
-  Queue:
+  BadExample:
     Type: AWS::Redshift::Cluster
     Properties:
-      Encrypted: true
+      Encrypted: false
 `,
 }
 

--- a/checks/cloud/aws/redshift/encryption_customer_key.cf.go
+++ b/checks/cloud/aws/redshift/encryption_customer_key.cf.go
@@ -8,7 +8,6 @@ Resources:
     Properties:
       Encrypted: true
       KmsKeyId: "something"
-
 `,
 }
 

--- a/checks/cloud/aws/redshift/no_classic_resources.cf.go
+++ b/checks/cloud/aws/redshift/no_classic_resources.cf.go
@@ -2,11 +2,23 @@ package redshift
 
 var cloudFormationNoClassicResourcesGoodExamples = []string{
 	`---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Good example of redshift sgr
+Resources:
+
 `,
 }
 
 var cloudFormationNoClassicResourcesBadExamples = []string{
 	`---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Bad example of redshift sgr
+Resources:
+  Queue:
+    Type: AWS::Redshift::ClusterSecurityGroup
+    Properties:
+      Description: ""
+
 `,
 }
 

--- a/checks/cloud/aws/redshift/no_classic_resources.cf.go
+++ b/checks/cloud/aws/redshift/no_classic_resources.cf.go
@@ -2,23 +2,11 @@ package redshift
 
 var cloudFormationNoClassicResourcesGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of redshift sgr
-Resources:
-# TODO
 `,
 }
 
 var cloudFormationNoClassicResourcesBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example of redshift sgr
-Resources:
-  Queue:
-    Type: AWS::Redshift::ClusterSecurityGroup
-    Properties:
-      Description: ""
-      # TODO
 `,
 }
 

--- a/checks/cloud/aws/redshift/no_classic_resources.cf.go
+++ b/checks/cloud/aws/redshift/no_classic_resources.cf.go
@@ -5,7 +5,7 @@ var cloudFormationNoClassicResourcesGoodExamples = []string{
 AWSTemplateFormatVersion: 2010-09-09
 Description: Good example of redshift sgr
 Resources:
-
+# TODO
 `,
 }
 
@@ -18,7 +18,7 @@ Resources:
     Type: AWS::Redshift::ClusterSecurityGroup
     Properties:
       Description: ""
-
+      # TODO
 `,
 }
 

--- a/checks/cloud/aws/redshift/use_vpc.cf.go
+++ b/checks/cloud/aws/redshift/use_vpc.cf.go
@@ -2,27 +2,22 @@ package redshift
 
 var cloudFormationUseVpcGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of redshift cluster
 Resources:
-  Queue:
+  GoodCluster:
     Type: AWS::Redshift::Cluster
     Properties:
       ClusterSubnetGroupName: "my-subnet-group"
-
 `,
 }
 
 var cloudFormationUseVpcBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example of redshift cluster
 Resources:
-  Queue:
+  BadCluster:
     Type: AWS::Redshift::Cluster
     Properties:
-      ClusterSubnetGroupName: ""
-      # TODO
+      DBName: "mydb"
+      ClusterType: "single-node"
 `,
 }
 

--- a/checks/cloud/aws/redshift/use_vpc.cf.go
+++ b/checks/cloud/aws/redshift/use_vpc.cf.go
@@ -22,7 +22,7 @@ Resources:
     Type: AWS::Redshift::Cluster
     Properties:
       ClusterSubnetGroupName: ""
-
+      # TODO
 `,
 }
 

--- a/checks/cloud/aws/s3/enable_bucket_encryption.cf.go
+++ b/checks/cloud/aws/s3/enable_bucket_encryption.cf.go
@@ -24,8 +24,8 @@ Resources:
         ServerSideEncryptionConfiguration:
           - BucketKeyEnabled: false
             ServerSideEncryptionByDefault:
-              KMSMasterKeyID: asdf
-              SSEAlgorithm: asdf # TODO
+              KMSMasterKeyID: alias/alias-name
+              SSEAlgorithm: aws:kms
 `,
 }
 

--- a/checks/cloud/aws/s3/enable_bucket_encryption.cf.go
+++ b/checks/cloud/aws/s3/enable_bucket_encryption.cf.go
@@ -4,13 +4,13 @@ var cloudFormationEnableBucketEncryptionGoodExamples = []string{
 	`
 Resources:
   GoodExample:
+    Type: AWS::S3::Bucket
     Properties:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - BucketKeyEnabled: true
             ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
-    Type: AWS::S3::Bucket
 `,
 }
 
@@ -18,14 +18,14 @@ var cloudFormationEnableBucketEncryptionBadExamples = []string{
 	`---
 Resources:
   BadExample:
+    Type: AWS::S3::Bucket
     Properties:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - BucketKeyEnabled: false
             ServerSideEncryptionByDefault:
               KMSMasterKeyID: asdf
-              SSEAlgorithm: asdf
-    Type: AWS::S3::Bucket
+              SSEAlgorithm: asdf # TODO
 `,
 }
 

--- a/checks/cloud/aws/s3/enable_bucket_logging.cf.go
+++ b/checks/cloud/aws/s3/enable_bucket_logging.cf.go
@@ -4,18 +4,16 @@ var cloudFormationEnableBucketLoggingGoodExamples = []string{
 	`---
 Resources:
   GoodExample:
+    Type: AWS::S3::Bucket
     Properties:
       LoggingConfiguration:
         DestinationBucketName: logging-bucket
         LogFilePrefix: accesslogs/
-    Type: AWS::S3::Bucket
 `,
 	`---
 Resources:
-  MyS3Bucket:
+  GoodExample:
     Type: AWS::S3::Bucket
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
     Properties:
       BucketName: !Sub my-s3-bucket-${BucketSuffix}
       LoggingConfiguration:
@@ -33,7 +31,7 @@ Resources:
 var cloudFormationEnableBucketLoggingBadExamples = []string{
 	`---
 Resources:
-  DisabledEncryptionBucket:
+  BadExample:
     Properties:
     Type: AWS::S3::Bucket
 `,

--- a/checks/cloud/aws/s3/enable_versioning.cf.go
+++ b/checks/cloud/aws/s3/enable_versioning.cf.go
@@ -4,10 +4,10 @@ var cloudFormationEnableVersioningGoodExamples = []string{
 	`---
 Resources:
   GoodExample:
+    Type: AWS::S3::Bucket
     Properties:
       VersioningConfiguration:
         Status: Enabled
-    Type: AWS::S3::Bucket
 `,
 }
 

--- a/checks/cloud/aws/s3/encryption_customer_key.cf.go
+++ b/checks/cloud/aws/s3/encryption_customer_key.cf.go
@@ -4,6 +4,7 @@ var cloudFormationCheckEncryptionCustomerKeyGoodExamples = []string{
 	`
 Resources:
   GoodExample:
+    Type: AWS::S3::Bucket
     Properties:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
@@ -11,21 +12,20 @@ Resources:
             ServerSideEncryptionByDefault:
               KMSMasterKeyID: kms-arn
               SSEAlgorithm: aws:kms
-    Type: AWS::S3::Bucket
 `,
 }
 
 var cloudFormationCheckEncryptionCustomerKeyBadExamples = []string{
 	`---
 Resources:
-  BadExample:
-    Properties:
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - BucketKeyEnabled: false
-            ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
-    Type: AWS::S3::Bucket
+BadExample:
+  Type: AWS::S3::Bucket
+  Properties:
+    BucketEncryption:
+      ServerSideEncryptionConfiguration:
+        - BucketKeyEnabled: false
+          ServerSideEncryptionByDefault:
+            SSEAlgorithm: AES256
 `,
 }
 

--- a/checks/cloud/aws/s3/encryption_customer_key.cf.go
+++ b/checks/cloud/aws/s3/encryption_customer_key.cf.go
@@ -18,14 +18,14 @@ Resources:
 var cloudFormationCheckEncryptionCustomerKeyBadExamples = []string{
 	`---
 Resources:
-BadExample:
-  Type: AWS::S3::Bucket
-  Properties:
-    BucketEncryption:
-      ServerSideEncryptionConfiguration:
-        - BucketKeyEnabled: false
-          ServerSideEncryptionByDefault:
-            SSEAlgorithm: AES256
+  BadExample:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - BucketKeyEnabled: false
+            ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
 `,
 }
 

--- a/checks/cloud/aws/s3/ignore_public_acls.cf.go
+++ b/checks/cloud/aws/s3/ignore_public_acls.cf.go
@@ -4,6 +4,7 @@ var cloudFormationIgnorePublicAclsGoodExamples = []string{
 	`---
 Resources:
   GoodExample:
+    Type: AWS::S3::Bucket
     Properties:
       AccessControl: Private
       PublicAccessBlockConfiguration:
@@ -11,7 +12,6 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
-    Type: AWS::S3::Bucket
 `,
 }
 
@@ -19,9 +19,9 @@ var cloudFormationIgnorePublicAclsBadExamples = []string{
 	`---
 Resources:
   BadExample:
+    Type: AWS::S3::Bucket
     Properties:
       AccessControl: AuthenticatedRead
-    Type: AWS::S3::Bucket
 `,
 }
 

--- a/checks/cloud/aws/s3/no_public_access_with_acl.cf.go
+++ b/checks/cloud/aws/s3/no_public_access_with_acl.cf.go
@@ -4,9 +4,9 @@ var cloudFormationNoPublicAccessWithAclGoodExamples = []string{
 	`---
 Resources:
   GoodExample:
+    Type: AWS::S3::Bucket
     Properties:
       AccessControl: Private
-    Type: AWS::S3::Bucket
 `,
 }
 
@@ -14,9 +14,9 @@ var cloudFormationNoPublicAccessWithAclBadExamples = []string{
 	`---
 Resources:
   BadExample:
+    Type: AWS::S3::Bucket
     Properties:
       AccessControl: AuthenticatedRead
-    Type: AWS::S3::Bucket
 `,
 }
 

--- a/checks/cloud/aws/s3/no_public_buckets.cf.go
+++ b/checks/cloud/aws/s3/no_public_buckets.cf.go
@@ -4,23 +4,23 @@ var cloudFormationNoPublicBucketsGoodExamples = []string{
 	`---
 Resources:
   GoodExample:
+    Type: AWS::S3::Bucket
     Properties:
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
-    Type: AWS::S3::Bucket
 `,
 }
 
 var cloudFormationNoPublicBucketsBadExamples = []string{
 	`---
 Resources:
+  Type: AWS::S3::Bucket
   BadExample:
     Properties:
       AccessControl: AuthenticatedRead
-    Type: AWS::S3::Bucket
 `,
 }
 

--- a/checks/cloud/aws/s3/specify_public_access_block.cf.go
+++ b/checks/cloud/aws/s3/specify_public_access_block.cf.go
@@ -4,6 +4,7 @@ var cloudFormationSpecifyPublicAccessBlockGoodExamples = []string{
 	`---
 Resources:
   GoodExample:
+    Type: AWS::S3::Bucket
     Properties:
       AccessControl: Private
       PublicAccessBlockConfiguration:
@@ -11,7 +12,6 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
-    Type: AWS::S3::Bucket
 `,
 }
 
@@ -19,9 +19,9 @@ var cloudFormationSpecifyPublicAccessBlockBadExamples = []string{
 	`---
 Resources:
   BadExample:
+    Type: AWS::S3::Bucket
     Properties:
       AccessControl: AuthenticatedRead
-    Type: AWS::S3::Bucket
 `,
 }
 

--- a/checks/cloud/aws/sam/api_use_secure_tls_policy.cf.go
+++ b/checks/cloud/aws/sam/api_use_secure_tls_policy.cf.go
@@ -2,10 +2,8 @@ package sam
 
 var cloudFormationApiUseSecureTlsPolicyGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM API
 Resources:
-  ApiGatewayApi:
+  GoodExample:
     Type: AWS::Serverless::Api
     Properties:
       Name: Good SAM API example
@@ -18,10 +16,8 @@ Resources:
 
 var cloudFormationApiUseSecureTlsPolicyBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad Example of SAM API
 Resources:
-  ApiGatewayApi:
+  BadExample:
     Type: AWS::Serverless::Api
     Properties:
       Name: Bad SAM API example

--- a/checks/cloud/aws/sam/enable_api_access_logging.cf.go
+++ b/checks/cloud/aws/sam/enable_api_access_logging.cf.go
@@ -2,10 +2,8 @@ package sam
 
 var cloudFormationEnableApiAccessLoggingGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM API
 Resources:
-  ApiGatewayApi:
+  GoodExample:
     Type: AWS::Serverless::Api
     Properties:
       Name: Good SAM API example
@@ -21,10 +19,8 @@ Resources:
 
 var cloudFormationEnableApiAccessLoggingBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad Example of SAM API
 Resources:
-  ApiGatewayApi:
+  BadExample:
     Type: AWS::Serverless::Api
     Properties:
       Name: Bad SAM API example

--- a/checks/cloud/aws/sam/enable_api_cache_encryption.cf.go
+++ b/checks/cloud/aws/sam/enable_api_cache_encryption.cf.go
@@ -2,10 +2,8 @@ package sam
 
 var cloudFormationEnableApiCacheEncryptionGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM API
 Resources:
-  ApiGatewayApi:
+  GoodExample:
     Type: AWS::Serverless::Api
     Properties:
       Name: Good SAM API example
@@ -20,20 +18,16 @@ Resources:
 
 var cloudFormationEnableApiCacheEncryptionBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad Example of SAM API
 Resources:
-  ApiGatewayApi:
+  BadExample:
     Type: AWS::Serverless::Api
     Properties:
       Name: Bad SAM API example
       StageName: Prod
       TracingEnabled: false
 `, `---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad Example of SAM API
 Resources:
-  ApiGatewayApi:
+  BadExample:
     Type: AWS::Serverless::Api
     Properties:
       Name: Bad SAM API example

--- a/checks/cloud/aws/sam/enable_api_tracing.cf.go
+++ b/checks/cloud/aws/sam/enable_api_tracing.cf.go
@@ -2,10 +2,8 @@ package sam
 
 var cloudFormationEnableApiTracingGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM API
 Resources:
-  ApiGatewayApi:
+  GoodExample:
     Type: AWS::Serverless::Api
     Properties:
       Name: Good SAM API example
@@ -16,20 +14,16 @@ Resources:
 
 var cloudFormationEnableApiTracingBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad Example of SAM API
 Resources:
-  ApiGatewayApi:
+  BadExample:
     Type: AWS::Serverless::Api
     Properties:
       Name: Bad SAM API example
       StageName: Prod
       TracingEnabled: false
 `, `---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad Example of SAM API
 Resources:
-  ApiGatewayApi:
+  BadExample:
     Type: AWS::Serverless::Api
     Properties:
       Name: Bad SAM API example

--- a/checks/cloud/aws/sam/enable_function_tracing.cf.go
+++ b/checks/cloud/aws/sam/enable_function_tracing.cf.go
@@ -2,8 +2,6 @@ package sam
 
 var cloudFormationEnableFunctionTracingGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM Function
 Resources:
   GoodFunction:
     Type: AWS::Serverless::Function
@@ -22,8 +20,6 @@ Resources:
 
 var cloudFormationEnableFunctionTracingBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad Example of SAM Function
 Resources:
   BadFunction:
     Type: AWS::Serverless::Function

--- a/checks/cloud/aws/sam/enable_http_api_access_logging.cf.go
+++ b/checks/cloud/aws/sam/enable_http_api_access_logging.cf.go
@@ -2,10 +2,8 @@ package sam
 
 var cloudFormationEnableHttpApiAccessLoggingGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM API
 Resources:
-  ApiGatewayApi:
+  GoodExample:
     Type: AWS::Serverless::HttpApi
     Properties:
       Name: Good SAM API example
@@ -19,10 +17,8 @@ Resources:
 
 var cloudFormationEnableHttpApiAccessLoggingBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad Example of SAM API
 Resources:
-  HttpApi:
+  BadExample:
     Type: AWS::Serverless::HttpApi
     Properties:
       Name: Good SAM API example

--- a/checks/cloud/aws/sam/enable_state_machine_tracing.cf.go
+++ b/checks/cloud/aws/sam/enable_state_machine_tracing.cf.go
@@ -2,8 +2,6 @@ package sam
 
 var cloudFormationEnableStateMachineTracingGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM API
 Resources:
   GoodStateMachine:
     Type: AWS::Serverless::StateMachine
@@ -23,8 +21,6 @@ Resources:
 
 var cloudFormationEnableStateMachineTracingBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad Example of SAM API
 Resources:
   BadStateMachine:
     Type: AWS::Serverless::StateMachine
@@ -40,8 +36,6 @@ Resources:
       Tracing:
         Enabled: false
 `, `---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad Example of SAM API
 Resources:
   BadStateMachine:
     Type: AWS::Serverless::StateMachine

--- a/checks/cloud/aws/sam/enable_table_encryption.cf.go
+++ b/checks/cloud/aws/sam/enable_table_encryption.cf.go
@@ -2,8 +2,6 @@ package sam
 
 var cloudFormationEnableTableEncryptionGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM Table
 Resources:
   GoodFunction:
     Type: AWS::Serverless::SimpleTable
@@ -16,8 +14,6 @@ Resources:
 
 var cloudFormationEnableTableEncryptionBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad Example of SAM Table
 Resources:
   BadFunction:
     Type: AWS::Serverless::SimpleTable
@@ -26,8 +22,6 @@ Resources:
       SSESpecification:
         SSEEnabled: false
 `, `---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad Example of SAM Table
 Resources:
   BadFunction:
     Type: AWS::Serverless::SimpleTable

--- a/checks/cloud/aws/sam/no_function_policy_wildcards.cf.go
+++ b/checks/cloud/aws/sam/no_function_policy_wildcards.cf.go
@@ -2,8 +2,6 @@ package sam
 
 var cloudFormationNoFunctionPolicyWildcardsGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM Function
 Resources:
   GoodFunction:
     Type: AWS::Serverless::Function
@@ -30,8 +28,6 @@ Resources:
 
 var cloudFormationNoFunctionPolicyWildcardsBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad Example of SAM Function
 Resources:
   BadFunction:
     Type: AWS::Serverless::Function

--- a/checks/cloud/aws/sam/no_state_machine_policy_wildcards.cf.go
+++ b/checks/cloud/aws/sam/no_state_machine_policy_wildcards.cf.go
@@ -2,8 +2,6 @@ package sam
 
 var cloudFormationNoStateMachinePolicyWildcardsGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good Example of SAM Function
 Resources:
   GoodFunction:
     Type: AWS::Serverless::StateMachine
@@ -32,8 +30,6 @@ Resources:
 
 var cloudFormationNoStateMachinePolicyWildcardsBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad Example of SAM Function
 Resources:
   BadFunction:
     Type: AWS::Serverless::StateMachine

--- a/checks/cloud/aws/sns/enable_topic_encryption.cf.go
+++ b/checks/cloud/aws/sns/enable_topic_encryption.cf.go
@@ -2,28 +2,22 @@ package sns
 
 var cloudFormationEnableTopicEncryptionGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of topic
 Resources:
-  Queue:
+  GoodTopic:
     Type: AWS::SQS::Topic
     Properties:
       TopicName: blah
       KmsMasterKeyId: some-key
-
 `,
 }
 
 var cloudFormationEnableTopicEncryptionBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example of topic
 Resources:
-  Queue:
+  BadTopic:
     Type: AWS::SNS::Topic
     Properties:
       TopicName: blah
-
 `,
 }
 

--- a/checks/cloud/aws/sns/topic_encryption_with_cmk.cf.go
+++ b/checks/cloud/aws/sns/topic_encryption_with_cmk.cf.go
@@ -2,29 +2,23 @@ package sns
 
 var cloudFormationTopicEncryptionUsesCMKGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of topic
 Resources:
-  Queue:
+  GoodTopic:
     Type: AWS::SQS::Topic
     Properties:
       TopicName: blah
       KmsMasterKeyId: some-key
-
 `,
 }
 
 var cloudFormationTopicEncryptionUsesCMKBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example of topic
 Resources:
-  Queue:
+  BadTopic:
     Type: AWS::SNS::Topic
     Properties:
       TopicName: blah
       KmsMasterKeyId: alias/aws/sns
-
 `,
 }
 

--- a/checks/cloud/aws/sqs/enable_queue_encryption.cf.go
+++ b/checks/cloud/aws/sqs/enable_queue_encryption.cf.go
@@ -2,24 +2,19 @@ package sqs
 
 var cloudFormationEnableQueueEncryptionGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of queue
 Resources:
-  Queue:
+  GoodQueue:
     Type: AWS::SQS::Queue
     Properties:
       KmsMasterKeyId: some-key
       QueueName: my-queue
-
 `,
 }
 
 var cloudFormationEnableQueueEncryptionBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example of queue
 Resources:
-  Queue:
+  BadQueue:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: my-queue

--- a/checks/cloud/aws/sqs/no_wildcards_in_policy_documents.cf.go
+++ b/checks/cloud/aws/sqs/no_wildcards_in_policy_documents.cf.go
@@ -2,10 +2,8 @@ package sqs
 
 var cloudFormationNoWildcardsInPolicyDocumentsGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of queue policy
 Resources:
-  MyQueue:
+  GoodQueue:
     Type: AWS::SQS::Queue
     Properties:
       Name: something
@@ -30,10 +28,8 @@ Resources:
 
 var cloudFormationNoWildcardsInPolicyDocumentsBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example of queue policy
 Resources:
-  MyQueue:
+  BadQueue:
     Type: AWS::SQS::Queue
     Properties:
       Name: something

--- a/checks/cloud/aws/sqs/queue_encryption_with_cmk.cf.go
+++ b/checks/cloud/aws/sqs/queue_encryption_with_cmk.cf.go
@@ -2,29 +2,23 @@ package sqs
 
 var cloudFormationQueueEncryptionUsesCMKGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of queue
 Resources:
-  Queue:
+  GoodQueue:
     Type: AWS::SQS::Queue
     Properties:
       KmsMasterKeyId: some-key
       QueueName: my-queue
-
 `,
 }
 
 var cloudFormationQueueEncryptionUsesCMKBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example of queue
 Resources:
-  Queue:
+  BadQueue:
     Type: AWS::SQS::Queue
     Properties:
       KmsMasterKeyId: alias/aws/sqs
       QueueName: my-queue
-
 `,
 }
 

--- a/checks/cloud/aws/ssm/secret_use_customer_key.cf.go
+++ b/checks/cloud/aws/ssm/secret_use_customer_key.cf.go
@@ -2,10 +2,8 @@ package ssm
 
 var cloudFormationSecretUseCustomerKeyGoodExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example of ingress rule
 Resources:
-  Secret:
+  GoodSecret:
     Type: AWS::SecretsManager::Secret
     Properties:
       Description: "secret"
@@ -17,8 +15,6 @@ Resources:
 
 var cloudFormationSecretUseCustomerKeyBadExamples = []string{
 	`---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example of secret
 Resources:
   BadSecret:
     Type: AWS::SecretsManager::Secret

--- a/cmd/avd_generator/main_test.go
+++ b/cmd/avd_generator/main_test.go
@@ -54,13 +54,13 @@ func Test_AVDPageGeneration(t *testing.T) {
 
 	b, err = os.ReadFile(filepath.Join(tmpDir, "aws/rds/AVD-AWS-0077", "CloudFormation.md"))
 	require.NoError(t, err)
-  assert.Contains(t, string(b), `---
-  Resources:
-    GoodExample:
-      Type: AWS::RDS::DBInstance
-      Properties:
-        BackupRetentionPeriod: 30
-  `)
+	assert.Contains(t, string(b), `---
+Resources:
+  GoodExample:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      BackupRetentionPeriod: 30
+`)
 
 	// check rego policies
 	b, err = os.ReadFile(filepath.Join(tmpDir, "aws/rds/AVD-AWS-0180", "Terraform.md"))
@@ -72,11 +72,11 @@ func Test_AVDPageGeneration(t *testing.T) {
 
 	b, err = os.ReadFile(filepath.Join(tmpDir, "aws/rds/AVD-AWS-0180", "CloudFormation.md"))
 	require.NoError(t, err)
-  assert.Contains(t, string(b), `---
-  Resources:
-    GoodExample:
-      Type: AWS::RDS::DBInstance
-      Properties:
-        PubliclyAccessible: false
-  `)
+	assert.Contains(t, string(b), `---
+Resources:
+  GoodExample:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      PubliclyAccessible: false
+`)
 }

--- a/cmd/avd_generator/main_test.go
+++ b/cmd/avd_generator/main_test.go
@@ -54,15 +54,13 @@ func Test_AVDPageGeneration(t *testing.T) {
 
 	b, err = os.ReadFile(filepath.Join(tmpDir, "aws/rds/AVD-AWS-0077", "CloudFormation.md"))
 	require.NoError(t, err)
-	assert.Contains(t, string(b), `yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
-Resources:
-  Queue:
-    Type: AWS::RDS::DBInstance
-    Properties:
-      BackupRetentionPeriod: 30
-`)
+	assert.Contains(t, string(b), `---
+	Resources:
+		GoodExample:
+			Type: AWS::RDS::DBInstance
+			Properties:
+				BackupRetentionPeriod: 30
+	`)
 
 	// check rego policies
 	b, err = os.ReadFile(filepath.Join(tmpDir, "aws/rds/AVD-AWS-0180", "Terraform.md"))
@@ -74,12 +72,11 @@ Resources:
 
 	b, err = os.ReadFile(filepath.Join(tmpDir, "aws/rds/AVD-AWS-0180", "CloudFormation.md"))
 	require.NoError(t, err)
-	assert.Contains(t, string(b), `yaml---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Good example
-Resources:
-  Queue:
-    Type: AWS::RDS::DBInstance
-    Properties:
-      PubliclyAccessible: false`)
+	assert.Contains(t, string(b), `---
+	Resources:
+		GoodExample:
+			Type: AWS::RDS::DBInstance
+			Properties:
+				PubliclyAccessible: false
+	`)
 }

--- a/cmd/avd_generator/main_test.go
+++ b/cmd/avd_generator/main_test.go
@@ -54,13 +54,13 @@ func Test_AVDPageGeneration(t *testing.T) {
 
 	b, err = os.ReadFile(filepath.Join(tmpDir, "aws/rds/AVD-AWS-0077", "CloudFormation.md"))
 	require.NoError(t, err)
-	assert.Contains(t, string(b), `---
-	Resources:
-		GoodExample:
-			Type: AWS::RDS::DBInstance
-			Properties:
-				BackupRetentionPeriod: 30
-	`)
+  assert.Contains(t, string(b), `---
+  Resources:
+    GoodExample:
+      Type: AWS::RDS::DBInstance
+      Properties:
+        BackupRetentionPeriod: 30
+  `)
 
 	// check rego policies
 	b, err = os.ReadFile(filepath.Join(tmpDir, "aws/rds/AVD-AWS-0180", "Terraform.md"))
@@ -72,11 +72,11 @@ func Test_AVDPageGeneration(t *testing.T) {
 
 	b, err = os.ReadFile(filepath.Join(tmpDir, "aws/rds/AVD-AWS-0180", "CloudFormation.md"))
 	require.NoError(t, err)
-	assert.Contains(t, string(b), `---
-	Resources:
-		GoodExample:
-			Type: AWS::RDS::DBInstance
-			Properties:
-				PubliclyAccessible: false
-	`)
+  assert.Contains(t, string(b), `---
+  Resources:
+    GoodExample:
+      Type: AWS::RDS::DBInstance
+      Properties:
+        PubliclyAccessible: false
+  `)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22
 toolchain go1.22.0
 
 require (
-	github.com/aquasecurity/trivy v0.51.2-0.20240514170658-7c22ee3df5ee
+	github.com/aquasecurity/trivy v0.51.2-0.20240516011451-88702cfd5918
 	github.com/docker/docker v26.0.2+incompatible
 	github.com/liamg/iamgo v0.0.9
 	github.com/liamg/memoryfs v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492 h1:rcEG5HI490FF0a7zuvxOxen52ddygCfNVjP0XOCMl+M=
 github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492/go.mod h1:9Beu8XsUNNfzml7WBf3QmyPToP1wm1Gj/Vc5UJKqTzU=
-github.com/aquasecurity/trivy v0.51.2-0.20240514170658-7c22ee3df5ee h1:Cs0OQO/ldEv1R9wPGhr5DemUJ18lk05Ly71zlaBDM88=
-github.com/aquasecurity/trivy v0.51.2-0.20240514170658-7c22ee3df5ee/go.mod h1:7UhbpzvSN7Ack4D4cX9X9XC5qFX4KP5O1xSskdZxGQY=
+github.com/aquasecurity/trivy v0.51.2-0.20240516011451-88702cfd5918 h1:ErW4tRpUVRnihE7hrAc9U1bVGMrK7pfkZH068kcj3sM=
+github.com/aquasecurity/trivy v0.51.2-0.20240516011451-88702cfd5918/go.mod h1:eTi5J7nzhtHI6GogE3v0BXI0Qeeb8MkjA7vrhGNZTjs=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=


### PR DESCRIPTION
This PR fixes a number of minor issues with the examples provided for AWS CloudFormation checks, including:

- There were "good" examples with "bad" in the title, which was confusing
- There were examples with titles that didn't match the resource type, like "Queue" when describing an RDS Instance
- There was some odd placeholder text
- There were some incomplete examples
- Some examples included extraneous info that distracted from their purpose, like the CF template version

I've been using trivy lately and ran into a bunch of these, so I wanted to help fix them.