### PR TITLE
Use ssl_mode instead of legacy require_ssl

### DIFF
--- a/avd_docs/google/sql/AVD-GCP-0015/Terraform.md
+++ b/avd_docs/google/sql/AVD-GCP-0015/Terraform.md
@@ -15,7 +15,7 @@ Enforce SSL for all connections
  				value           = "108.12.12.0/24"
  				name            = "internal"
  			}
- 			require_ssl = true
+ 			ssl_mode = "ENCRYPTED_ONLY"
  		}
  	}
  }

--- a/checks/cloud/google/sql/encrypt_in_transit_data.tf.go
+++ b/checks/cloud/google/sql/encrypt_in_transit_data.tf.go
@@ -15,7 +15,7 @@ var terraformEncryptInTransitDataGoodExamples = []string{
  				value           = "108.12.12.0/24"
  				name            = "internal"
  			}
- 			require_ssl = true
+			ssl_mode = "ENCRYPTED_ONLY"
  		}
  	}
  }
@@ -42,6 +42,25 @@ var terraformEncryptInTransitDataBadExamples = []string{
  	}
  }
  			`,
+`
+ resource "google_sql_database_instance" "postgres" {
+ 	name             = "postgres-instance-a"
+ 	database_version = "POSTGRES_11"
+ 	
+ 	settings {
+ 		tier = "db-f1-micro"
+ 	
+ 		ip_configuration {
+ 			ipv4_enabled = false
+ 			authorized_networks {
+ 				value           = "108.12.12.0/24"
+ 				name            = "internal"
+ 			}
+			ssl_mode = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
+ 		}
+ 	}
+ }
+`,
 }
 
 var terraformEncryptInTransitDataLinks = []string{


### PR DESCRIPTION
The Google docs recommend to use ssl_mode instead of the legacy require_ssl attribute.

See:
* https://cloud.google.com/sql/docs/postgres/admin-api/rest/v1beta4/instances#ipconfiguration
* https://cloud.google.com/sql/docs/postgres/admin-api/rest/v1beta4/instances#sslmode