### PR TITLE
Fix page title for AVD-AWS-0342 in vulnerability database documentation

### DIFF
--- a/checks/cloud/aws/iam/filter_iam_pass_role.rego
+++ b/checks/cloud/aws/iam/filter_iam_pass_role.rego
@@ -12,7 +12,7 @@
 #   provider: aws
 #   service: iam
 #   severity: MEDIUM
-#   short_code: filer-passrole-access
+#   short_code: filter-passrole-access
 #   recommended_action: "Resolve permission escalations by denying pass role'"
 #   input:
 #     selector:


### PR DESCRIPTION
The page title for AVD-AWS-0342 in the vulnerability database documentation seems to be incorrect. The correct title is likely "Filter Passrole Access". I wasn't sure of the exact way to fix this, but I suspect that the issue might be related to the `short_code`. I have attempted to correct it accordingly.
https://avd.aquasec.com/misconfig/aws/iam/avd-aws-0342/