### PR TITLE
Add OCI image annotations

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,8 @@ jobs:
           for tag in ${tags[@]}; do
               oras push ghcr.io/aquasecurity/trivy-policies:${tag} \
               --config /dev/null:application/vnd.cncf.openpolicyagent.config.v1+json \
+              --annotation "org.opencontainers.image.source=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+              --annotation "org.opencontainers.image.revision=$GITHUB_SHA" \
               bundle.tar.gz:application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip
           done
       - name: Deploy checks bundle to ghcr.io


### PR DESCRIPTION
These annotations are useful for tools (such as [Snyk uses them in its UI](https://snyk.io/blog/how-and-when-to-use-docker-labels-oci-container-annotations/) and [Renovate uses them to find release notes](https://github.com/renovatebot/renovate/blob/34.115.1/lib/modules/datasource/docker/readme.md)) to use as well as for manual use by individuals.

See: https://github.com/opencontainers/image-spec/blob/v1.1.0/annotations.md#pre-defined-annotation-keys

[The trivy images at ghcr.io/aquasecurity/trivy and elsewhere already have OCI annotations.](https://github.com/aquasecurity/trivy/blob/7f8868b7d83fddf251ebe6a4d37f2482ae1e8a8a/goreleaser.yml#L127-L136)