### PR TITLE
fix(docs): generate multiple examples from Rego

### DIFF
--- a/avd_docs/aws/s3/AVD-AWS-0089/CloudFormation.md
+++ b/avd_docs/aws/s3/AVD-AWS-0089/CloudFormation.md
@@ -11,5 +11,22 @@ Resources:
         LogFilePrefix: accesslogs/
 
 ```
+```yaml---
+Resources:
+  GoodExample:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub my-s3-bucket-${BucketSuffix}
+      LoggingConfiguration:
+        DestinationBucketName: !FindInMap [EnvironmentMapping, s3, logging]
+        LogFilePrefix: !Sub s3-logs/AWSLogs/${AWS::AccountId}/my-s3-bucket-${BucketSuffix}
+      AccessControl: Private
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+
+```
 
 

--- a/avd_docs/aws/s3/AVD-AWS-0089/Terraform.md
+++ b/avd_docs/aws/s3/AVD-AWS-0089/Terraform.md
@@ -9,6 +9,20 @@ resource "aws_s3_bucket" "good_example" {
 }
 
 ```
+```hcl
+resource "aws_s3_bucket" "example" {
+  bucket = "yournamehere"
+
+  # ... other configuration ...
+}
+
+resource "aws_s3_bucket_logging" "example" {
+  bucket        = aws_s3_bucket.example.id
+  target_bucket = aws_s3_bucket.log_bucket.id
+  target_prefix = "log/"
+}
+
+```
 
 #### Remediation Links
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket


### PR DESCRIPTION
A check may contain a few good or bad examples. But the `avd-generator` command generates only the first example.