### PR TITLE
test: exclude deprecated checks when detecting duplicates

### DIFF
--- a/test/rules_test.go
+++ b/test/rules_test.go
@@ -19,6 +19,9 @@ func TestAVDIDs(t *testing.T) {
 				t.Errorf("Rule detected with duplicate AVD ID: %s", rule.GetRule().AVDID)
 			}
 		})
-		existing[rule.GetRule().AVDID] = struct{}{}
+
+		if !rule.IsDeprecated() {
+			existing[rule.GetRule().AVDID] = struct{}{}
+		}
 	}
 }


### PR DESCRIPTION
In the process of migrating Go to Rego, checks may be duplicated. So deprecated Go checks can be omitted from the tests