### PR TITLE
refactor(checks): use isManaged fn to check managed data

### DIFF
--- a/checks/cloud/aws/config/aggregate_all_regions.rego
+++ b/checks/cloud/aws/config/aggregate_all_regions.rego
@@ -36,7 +36,7 @@ import rego.v1
 
 deny contains res if {
 	cfg_aggregator := input.aws.config.configurationaggregrator
-	cfg_aggregator.__defsec_metadata.managed
+	isManaged(cfg_aggregator)
 	not cfg_aggregator.sourceallregions.value
 	res := result.new("Configuration aggregation is not set to source from all regions.", cfg_aggregator.sourceallregions)
 }


### PR DESCRIPTION
Metadata in Trivy was added not too long ago, which may cause an error when used in checks in older versions of Trivy when validating the schema, so using the `isManaged` function is a safe option.