### PR TITLE
feat: add function to retrieve object by path

### DIFF
--- a/lib/cloud/metadata.rego
+++ b/lib/cloud/metadata.rego
@@ -1,0 +1,18 @@
+# METADATA
+# custom:
+#   library: true
+package lib.cloud.metadata
+
+import rego.v1
+
+# Returns the object found by the given path
+# if child object is not found, returns the last found object
+obj_by_path(obj, path) := res if {
+	occurrenses := {obj_path: child_object |
+		walk(obj, [obj_path, child_object])
+		child_object.__defsec_metadata
+		object.subset(path, obj_path)
+	}
+
+	res := occurrenses[max(object.keys(occurrenses))]
+} else := obj

--- a/lib/cloud/metadata.rego
+++ b/lib/cloud/metadata.rego
@@ -8,7 +8,7 @@ import rego.v1
 # Returns the object found by the given path
 # if child object is not found, returns the last found object
 obj_by_path(obj, path) := res if {
-	occurrenses := {obj_path: child_object |
+	occurrences := {obj_path: child_object |
 		walk(obj, [obj_path, child_object])
 		child_object.__defsec_metadata
 		object.subset(path, obj_path)

--- a/lib/cloud/metadata.rego
+++ b/lib/cloud/metadata.rego
@@ -14,5 +14,5 @@ obj_by_path(obj, path) := res if {
 		object.subset(path, obj_path)
 	}
 
-	res := occurrenses[max(object.keys(occurrenses))]
+	res := occurrences[max(object.keys(occurrences))]
 } else := obj

--- a/lib/cloud/metadata_test.rego
+++ b/lib/cloud/metadata_test.rego
@@ -1,0 +1,34 @@
+package lib.cloud.metadata_test
+
+import rego.v1
+
+import data.lib.cloud.metadata
+
+test_obj_by_path_happy if {
+	bar := with_meta({"value": 1})
+	obj := with_meta({"foo": with_meta({"bar": bar})})
+
+	metadata.obj_by_path(obj, ["foo", "bar"]) == bar
+}
+
+test_obj_by_path_when_target_not_found_then_return_last_found if {
+	foo := with_meta({"bar": with_meta({"value": 1})})
+	obj := with_meta({"foo": foo})
+
+	metadata.obj_by_path(obj, ["foo", "baz"]) == foo
+}
+
+test_obj_by_path_when_target_not_found_then_return_obj if {
+	foo := with_meta({"bar": with_meta({"value": 1})})
+	obj := with_meta({"foo": foo})
+
+	metadata.obj_by_path(obj, "baz") == obj
+}
+
+test_obj_by_path_skip_without_metadata if {
+	obj := with_meta({"foo": {"bar": with_meta({"value": 1})}})
+
+	metadata.obj_by_path(obj, ["foo", "baz"]) == obj
+}
+
+with_meta(obj) := object.union(obj, {"__defsec_metadata": {}})


### PR DESCRIPTION
Ideally, we should point to the location of the misconfiguration in the code as precisely as possible. To do this, the `result.new` funuction takes an object with its location metadata as the second parameter. But there may be problems with this if the passed input is incomplete. 

The following check safely checks for the absence of `bar` or its false value, but may fail if `bar` or the parent structure is missing, since the `input.provider.foo.bar` expression passed to the `result.new` function will be `undefined`. 

```rego
deny contains res if {
  not nput.provider.some_resource.block1.block2.some_attr.value
  result.new(
    "bar does not exist",
    nput.provider.some_resource.block1.block2.some_attr,
  )
}
```

To solve this problem, we could use the `object.get` function to safely get a nested object, for example `object.get(some_resource, ["block1", "block2", "some_attr"], resource)`,  but in that case the result will not contain the exact location of the misconfig. And calling `object.get` for each level of nesting is fraught with a lot of code.

This PR adds a function that solves the problem. It recursively searches for a child object along the given path and if it is not found, it returns the last found one.

Example of use:
```rego
import data.lib.metadata

deny contains res if {
  not input.provider.some_resource.block1.block2.some_attr
  result.new(
    "bar does not exist",
    metadata.obj_by_path(input.provider.some_resource, ["block1", "block2", "some_attr"]),
  )
}
```