### PR TITLE
Ignore casing in CIDR wildcards

### DIFF
--- a/checks/cloud/azure/network/no_public_ingress_test.go
+++ b/checks/cloud/azure/network/no_public_ingress_test.go
@@ -20,7 +20,7 @@ func TestCheckNoPublicIngress(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "Security group inbound rule with wildcard source address",
+			name: "Security group inbound rule with asterisk wildcard source address",
 			input: network.Network{
 				SecurityGroups: []network.SecurityGroup{
 					{
@@ -32,6 +32,48 @@ func TestCheckNoPublicIngress(t *testing.T) {
 								Outbound: trivyTypes.Bool(false, trivyTypes.NewTestMetadata()),
 								SourceAddresses: []trivyTypes.StringValue{
 									trivyTypes.String("*", trivyTypes.NewTestMetadata()),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Security group inbound rule with lower case internet wildcard source address",
+			input: network.Network{
+				SecurityGroups: []network.SecurityGroup{
+					{
+						Metadata: trivyTypes.NewTestMetadata(),
+						Rules: []network.SecurityGroupRule{
+							{
+								Metadata: trivyTypes.NewTestMetadata(),
+								Allow:    trivyTypes.Bool(true, trivyTypes.NewTestMetadata()),
+								Outbound: trivyTypes.Bool(false, trivyTypes.NewTestMetadata()),
+								SourceAddresses: []trivyTypes.StringValue{
+									trivyTypes.String("internet", trivyTypes.NewTestMetadata()),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Security group inbound rule with upper case internet wildcard source address",
+			input: network.Network{
+				SecurityGroups: []network.SecurityGroup{
+					{
+						Metadata: trivyTypes.NewTestMetadata(),
+						Rules: []network.SecurityGroupRule{
+							{
+								Metadata: trivyTypes.NewTestMetadata(),
+								Allow:    trivyTypes.Bool(true, trivyTypes.NewTestMetadata()),
+								Outbound: trivyTypes.Bool(false, trivyTypes.NewTestMetadata()),
+								SourceAddresses: []trivyTypes.StringValue{
+									trivyTypes.String("Internet", trivyTypes.NewTestMetadata()),
 								},
 							},
 						},

--- a/internal/cidr/cidr.go
+++ b/internal/cidr/cidr.go
@@ -42,7 +42,7 @@ func isPrivate(ip net.IP) bool {
 // overflows an unsigned 64-bit int, the maximum value of an unsigned 64-bit int will be
 // returned.
 func CountAddresses(inputCIDR string) uint64 {
-	if inputCIDR == "*" || inputCIDR == "internet" || inputCIDR == "any" {
+	if inputCIDR == "*" || strings.EqualFold(inputCIDR, "internet") || strings.EqualFold(inputCIDR, "any") {
 		return 0xffffffffffffffff
 	}
 	if !strings.Contains(inputCIDR, "/") {
@@ -67,9 +67,8 @@ func CountAddresses(inputCIDR string) uint64 {
 // IsPublic returns true if a provided IP is outside of the designated public ranges, or
 // true if either of the min/max addresses of a provided CIDR are outside of these ranges.
 func IsPublic(cidr string) bool {
-
 	// some providers use wildcards etc. instead of "0.0.0.0/0" :/
-	if cidr == "*" || cidr == "internet" || cidr == "any" {
+	if cidr == "*" || strings.EqualFold(cidr, "internet") || strings.EqualFold(cidr, "any") {
 		return true
 	}
 

--- a/internal/cidr/cidr_test.go
+++ b/internal/cidr/cidr_test.go
@@ -98,6 +98,22 @@ func TestPublicDetection(t *testing.T) {
 			input:  "nonsense",
 			public: false,
 		},
+		{
+			input:  "internet",
+			public: true,
+		},
+		{
+			input:  "Internet",
+			public: true,
+		},
+		{
+			input:  "any",
+			public: true,
+		},
+		{
+			input:  "Any",
+			public: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -127,6 +143,22 @@ func TestCountCIDRAddresses(t *testing.T) {
 		},
 		{
 			cidr:     "::0/0",
+			expected: math.MaxUint64,
+		},
+		{
+			cidr:     "internet",
+			expected: math.MaxUint64,
+		},
+		{
+			cidr:     "Internet",
+			expected: math.MaxUint64,
+		},
+		{
+			cidr:     "any",
+			expected: math.MaxUint64,
+		},
+		{
+			cidr:     "Any",
 			expected: math.MaxUint64,
 		},
 	}


### PR DESCRIPTION
# Problem

Trivy doesn't detect any problem in the following Terraform file:
```terraform
resource "azurerm_network_security_group" "example" {
  security_rule {
    direction                  = "Inbound"
    access                     = "Allow"
    source_address_prefix      = "Internet"
  }
}
```

Changing it to this, however, results in a critical finding:

```terraform
resource "azurerm_network_security_group" "example" {
  security_rule {
    direction                  = "Inbound"
    access                     = "Allow"
    source_address_prefix      = "internet"
  }
}
```

Note the different casing of the `source_address_prefix`.

# Solution

I've adjusted the CIDR checks to include the wildcards regardless of their casing. `internet` and `Internet` should now be treated the same way.