### PR TITLE
ci: pin Go version

### DIFF
--- a/.github/workflows/test-bundle.yml
+++ b/.github/workflows/test-bundle.yml
@@ -2,18 +2,26 @@ name: test rego bundle
 on:
   pull_request:
   merge_group:
+
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: '1.22'
+
 jobs:
   opa-tests:
     name: OPA tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
       - name: Build bundle
         run: make bundle
+
       - name: Setup OPA
         uses: ./.github/actions/setup-opa
+
       - name: Check bundle
         run: opa inspect bundle.tar.gz

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -2,6 +2,10 @@ name: Test Go
 on:
   pull_request:
   merge_group:
+
+env:
+  GO_VERSION: '1.22'
+
 jobs:
   build:
     name: Test
@@ -11,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Run tests
       run: make test

--- a/.github/workflows/test-rego.yaml
+++ b/.github/workflows/test-rego.yaml
@@ -11,8 +11,10 @@ on:
       - "**/*.md"
       - "LICENSE"
   merge_group:
+
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.22"
+
 jobs:
   opa-tests:
     name: OPA tests
@@ -35,7 +37,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Test Rego checks
         run: make test-rego

--- a/.github/workflows/verify-docs.yaml
+++ b/.github/workflows/verify-docs.yaml
@@ -2,6 +2,10 @@ name: Verify Docs
 on:
   pull_request:
   merge_group:
+
+env:
+  GO_VERSION: '1.22'
+
 jobs:
   build:
     name: Verify Docs
@@ -9,10 +13,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-
     - uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        go-version: ${{ env.GO_VERSION }}
 
     - run: |
         make docs


### PR DESCRIPTION
Fixes the cache problem as in  https://github.com/aquasecurity/trivy-aws/pull/210 . The version in actions is bumped to 1.22 as in go.mod.

Before:
https://github.com/aquasecurity/trivy-checks/actions/runs/10385835515/job/28755821667

After:
https://github.com/aquasecurity/trivy-checks/actions/runs/10385999057/job/28756319104?pr=214