### PR TITLE
ci: use OPA with custom built-in functions

### DIFF
--- a/.github/actions/setup-opa/action.yaml
+++ b/.github/actions/setup-opa/action.yaml
@@ -6,8 +6,5 @@ runs:
     - name: Setup OPA
       shell: bash
       run: |
-        curl --retry 3 -L -o opa_linux_amd64_static https://github.com/open-policy-agent/opa/releases/download/v0.65.0/opa_linux_amd64_static
-        curl -L -o checksum https://github.com/open-policy-agent/opa/releases/download/v0.65.0/opa_linux_amd64_static.sha256
-        sha256sum -c checksum
-        chmod 755 ./opa_linux_amd64_static
-        sudo mv ./opa_linux_amd64_static /usr/local/bin/opa
+        make build-opa
+        sudo mv ./opa /usr/local/bin/opa

--- a/.github/workflows/outdated-api-update.yaml
+++ b/.github/workflows/outdated-api-update.yaml
@@ -6,6 +6,9 @@ on:
 permissions:
   contents: write
 
+env:
+  GO_VERSION: '1.22'
+
 jobs:
   outdated:
     runs-on: ubuntu-latest
@@ -14,6 +17,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.AUTO_COMMIT_TOKEN }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
       - name: Fetch outdated API data from trivy-db-data repo
         id: outdatedapi
         uses: fjogeleit/http-request-action@v1
@@ -25,8 +33,10 @@ jobs:
           OUTDATE_API_DATA: ${{ toJson(steps.outdatedapi.outputs.response) }}
         run: |
           make outdated-api-updated
+      
       - name: Setup OPA
         uses: ./.github/actions/setup-opa
+
       - name: OPA Format
         run: |
           opa fmt -w . | grep -v vendor || true

--- a/.github/workflows/test-rego.yaml
+++ b/.github/workflows/test-rego.yaml
@@ -11,6 +11,7 @@ on:
       - "**/*.md"
       - "LICENSE"
   merge_group:
+  workflow_dispatch:
 
 env:
   GO_VERSION: "1.22"
@@ -23,6 +24,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
       - name: Setup OPA
         uses: ./.github/actions/setup-opa
 
@@ -34,10 +39,6 @@ jobs:
             echo "$files"
             exit 1
           fi
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
 
       - name: Test Rego checks
         run: make test-rego

--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,6 @@ verify-bundle:
 	cp bundle.tar.gz scripts/bundle.tar.gz
 	go run ./scripts/verify-bundle.go
 	rm scripts/bundle.tar.gz
+
+build-opa:
+	go build ./cmd/opa

--- a/cmd/opa/main.go
+++ b/cmd/opa/main.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"os"
 
-	// register Built-in Functions from defsec
-	"github.com/aquasecurity/trivy-checks/pkg/rego"
-	_ "github.com/aquasecurity/trivy/pkg/iac/rego"
 	"github.com/open-policy-agent/opa/cmd"
+
+	"github.com/aquasecurity/trivy-checks/pkg/rego"
+	_ "github.com/aquasecurity/trivy/pkg/iac/rego" // register Built-in Functions from Trivy
 )
 
 func main() {


### PR DESCRIPTION
While writing Rego checks, I encountered an [error](https://github.com/aquasecurity/trivy-checks/actions/runs/10483588564/job/29036542565) of using an undefined function when inspecting our bundle. This is because we use custom functions in Rego checks, so we have to use the OPA binary we build with these functions.  I think it is a bug that the error was not detected before. https://github.com/open-policy-agent/opa/issues/6946