### PR TITLE
Fix typo in enforce_immutable_repository

### DIFF
--- a/avd_docs/aws/ecr/AVD-AWS-0031/docs.md
+++ b/avd_docs/aws/ecr/AVD-AWS-0031/docs.md
@@ -1,7 +1,7 @@
 
 ECR images should be set to IMMUTABLE to prevent code injection through image mutation.
 
-This can be done by setting <code>image_tab_mutability</code> to <code>IMMUTABLE</code>
+This can be done by setting <code>image_tag_mutability</code> to <code>IMMUTABLE</code>
 
 ### Impact
 Image tags could be overwritten with compromised images

--- a/checks/cloud/aws/ecr/enforce_immutable_repository.go
+++ b/checks/cloud/aws/ecr/enforce_immutable_repository.go
@@ -19,7 +19,7 @@ var CheckEnforceImmutableRepository = rules.Register(
 		Resolution: "Only use immutable images in ECR",
 		Explanation: `ECR images should be set to IMMUTABLE to prevent code injection through image mutation.
 
-This can be done by setting <code>image_tab_mutability</code> to <code>IMMUTABLE</code>`,
+This can be done by setting <code>image_tag_mutability</code> to <code>IMMUTABLE</code>`,
 		Links: []string{
 			"https://sysdig.com/blog/toctou-tag-mutability/",
 		},


### PR DESCRIPTION
I'm not sure if this is the correct location -- the same string seemed to show up in many different repos, but this seemed plausible.  If this should be in another location, let me know.  (This seemed to have the most complete information, including `<code>` tags...)
