### PR TITLE
test(bundle): use only canary Trivy

### DIFF
--- a/scripts/verify-bundle.go
+++ b/scripts/verify-bundle.go
@@ -15,7 +15,7 @@ import (
 
 var bundlePath = "bundle.tar.gz"
 var OrasPush = []string{"--config", "/dev/null:application/vnd.cncf.openpolicyagent.config.v1+json", fmt.Sprintf("%s:application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip", bundlePath)}
-var supportedTrivyVersions = []string{"latest", "canary"} // TODO: add more versions
+var supportedTrivyVersions = []string{"canary"} // TODO: add more versions
 
 func createRegistryContainer(ctx context.Context) (testcontainers.Container, string) {
 	reqReg := testcontainers.ContainerRequest{


### PR DESCRIPTION
Some tests contain custom Rego functions that we recently added, which the latest version of Trivy (published in the docker) does not support. This is temporary until a new version of Trivy is released.