### PR TITLE
chore(checks): deprecate some checks

### DIFF
--- a/checks/cloud/aws/iam/no_policy_wildcards.go
+++ b/checks/cloud/aws/iam/no_policy_wildcards.go
@@ -49,7 +49,8 @@ var CheckNoPolicyWildcards = rules.Register(
 			Links:               cloudFormationNoPolicyWildcardsLinks,
 			RemediationMarkdown: cloudFormationNoPolicyWildcardsRemediationMarkdown,
 		},
-		Severity: severity.High,
+		Severity:   severity.High,
+		Deprecated: true,
 	},
 	func(s *state.State) (results scan.Results) {
 		for _, policy := range s.AWS.IAM.Policies {

--- a/checks/cloud/aws/iam/require_support_role.go
+++ b/checks/cloud/aws/iam/require_support_role.go
@@ -34,7 +34,8 @@ IAM Policy to allow Support Center Access in order to manage Incidents with AWS 
 		Links: []string{
 			"https://console.aws.amazon.com/iam/",
 		},
-		Severity: severity.Low,
+		Severity:   severity.Low,
+		Deprecated: true,
 	},
 	func(s *state.State) (results scan.Results) {
 

--- a/checks/cloud/aws/sam/no_function_policy_wildcards.go
+++ b/checks/cloud/aws/sam/no_function_policy_wildcards.go
@@ -36,7 +36,8 @@ var CheckNoFunctionPolicyWildcards = rules.Register(
 			Links:               cloudFormationNoFunctionPolicyWildcardsLinks,
 			RemediationMarkdown: cloudFormationNoFunctionPolicyWildcardsRemediationMarkdown,
 		},
-		Severity: severity.High,
+		Severity:   severity.High,
+		Deprecated: true,
 	},
 	func(s *state.State) (results scan.Results) {
 

--- a/checks/cloud/aws/sam/no_state_machine_policy_wildcards.go
+++ b/checks/cloud/aws/sam/no_state_machine_policy_wildcards.go
@@ -27,7 +27,8 @@ var CheckNoStateMachinePolicyWildcards = rules.Register(
 			Links:               cloudFormationNoStateMachinePolicyWildcardsLinks,
 			RemediationMarkdown: cloudFormationNoStateMachinePolicyWildcardsRemediationMarkdown,
 		},
-		Severity: severity.High,
+		Severity:   severity.High,
+		Deprecated: true,
 	},
 	func(s *state.State) (results scan.Results) {
 

--- a/checks/cloud/aws/ssm/avoid_leaks_via_http.go
+++ b/checks/cloud/aws/ssm/avoid_leaks_via_http.go
@@ -45,7 +45,8 @@ var AvoidLeaksViaHTTP = rules.Register(
 				},
 			},
 		},
-		Severity: severity.Critical,
+		Severity:   severity.Critical,
+		Deprecated: true,
 	},
 	nil,
 )


### PR DESCRIPTION
1. [AVD-AWS-0134](https://github.com/aquasecurity/trivy-checks/blob/main/checks/cloud/aws/ssm/avoid_leaks_via_http.go#L13). This check uses a mechanism of custom checks, which are passed terraform blocks directly rather than general state. Because of this, this check cannot be ported to Rego.
2. [AVD-AWS-0175](https://github.com/aquasecurity/trivy-checks/blob/main/checks/cloud/aws/accessanalyzer/enable_access_analyzer.go) and [AVD-AWS-0169](https://github.com/aquasecurity/trivy-checks/blob/main/checks/cloud/aws/iam/require_support_role.go). These checks are triggered when there are no resources. The problem is that Trivy does not export empty structures for Rego. Because of this, filtering with selectors does not work and the check is not applied. If you remove the selectors, the check will always work, even when not scanning AWS. These checks are better evaluated in other ways as these resources can be configured in other ways.