### PR TITLE
checks: add default framework to some Rego checks

### DIFF
--- a/checks/cloud/aws/cloudtrail/enable_all_regions.rego
+++ b/checks/cloud/aws/cloudtrail/enable_all_regions.rego
@@ -16,6 +16,8 @@
 #   short_code: enable-all-regions
 #   recommended_action: Enable Cloudtrail in all regions
 #   frameworks:
+#     default:
+#       - null
 #     cis-aws-1.2:
 #       - "2.5"
 #   input:

--- a/checks/cloud/aws/cloudtrail/ensure_cloudwatch_integration.rego
+++ b/checks/cloud/aws/cloudtrail/ensure_cloudwatch_integration.rego
@@ -22,6 +22,8 @@
 #   short_code: ensure-cloudwatch-integration
 #   recommended_action: Enable logging to CloudWatch
 #   frameworks:
+#     default:
+#       - null
 #     cis-aws-1.2:
 #       - "2.4"
 #     cis-aws-1.4:

--- a/checks/cloud/aws/cloudtrail/no_public_log_access.rego
+++ b/checks/cloud/aws/cloudtrail/no_public_log_access.rego
@@ -16,6 +16,8 @@
 #   short_code: no-public-log-access
 #   recommended_action: Restrict public access to the S3 bucket
 #   frameworks:
+#     default:
+#       - null
 #     cis-aws-1.2:
 #       - "2.3"
 #     cis-aws-1.4:

--- a/checks/cloud/aws/cloudtrail/require_bucket_access_logging.rego
+++ b/checks/cloud/aws/cloudtrail/require_bucket_access_logging.rego
@@ -18,6 +18,8 @@
 #   short_code: require-bucket-access-logging
 #   recommended_action: Enable access logging on the bucket
 #   frameworks:
+#     default:
+#       - null
 #     cis-aws-1.2:
 #       - "2.6"
 #     cis-aws-1.4:

--- a/checks/cloud/aws/ec2/no_public_ingress_sgr.rego
+++ b/checks/cloud/aws/ec2/no_public_ingress_sgr.rego
@@ -16,6 +16,8 @@
 #   short_code: no-public-ingress-sgr
 #   recommended_action: Set a more restrictive cidr range
 #   frameworks:
+#     default:
+#       - null
 #     cis-aws-1.2:
 #       - "4.1"
 #       - "4.2"

--- a/checks/cloud/aws/iam/limit_root_account_usage.rego
+++ b/checks/cloud/aws/iam/limit_root_account_usage.rego
@@ -16,6 +16,8 @@
 #   short_code: limit-root-account-usage
 #   recommended_action: Use lower privileged accounts instead, so only required privileges are available.
 #   frameworks:
+#     default:
+#       - null
 #     cis-aws-1.2:
 #       - "1.1"
 #     cis-aws-1.4:

--- a/checks/cloud/aws/iam/no_password_reuse.rego
+++ b/checks/cloud/aws/iam/no_password_reuse.rego
@@ -18,6 +18,8 @@
 #   short_code: no-password-reuse
 #   recommended_action: Prevent password reuse in the policy
 #   frameworks:
+#     default:
+#       - null
 #     cis-aws-1.2:
 #       - "1.10"
 #     cis-aws-1.4:

--- a/checks/cloud/aws/iam/no_root_access_keys.rego
+++ b/checks/cloud/aws/iam/no_root_access_keys.rego
@@ -16,6 +16,8 @@
 #   short_code: no-root-access-keys
 #   recommended_action: Use lower privileged accounts instead, so only required privileges are available.
 #   frameworks:
+#     default:
+#       - null
 #     cis-aws-1.2:
 #       - "1.12"
 #     cis-aws-1.4:

--- a/checks/cloud/aws/iam/no_user_attached_policies.rego
+++ b/checks/cloud/aws/iam/no_user_attached_policies.rego
@@ -16,6 +16,8 @@
 #   short_code: no-user-attached-policies
 #   recommended_action: Grant policies at the group level instead.
 #   frameworks:
+#     default:
+#       - null
 #     cis-aws-1.4:
 #       - "1.15"
 #     cis-aws-1.2:

--- a/checks/cloud/aws/iam/require_lowercase_in_passwords.rego
+++ b/checks/cloud/aws/iam/require_lowercase_in_passwords.rego
@@ -16,6 +16,8 @@
 #   short_code: require-lowercase-in-passwords
 #   recommended_action: Enforce longer, more complex passwords in the policy
 #   frameworks:
+#     default:
+#       - null
 #     cis-aws-1.2:
 #       - "1.6"
 #   input:

--- a/checks/cloud/aws/iam/require_numbers_in_passwords.rego
+++ b/checks/cloud/aws/iam/require_numbers_in_passwords.rego
@@ -16,6 +16,8 @@
 #   short_code: require-numbers-in-passwords
 #   recommended_action: Enforce longer, more complex passwords in the policy
 #   frameworks:
+#     default:
+#       - null
 #     cis-aws-1.2:
 #       - "1.8"
 #   input:

--- a/checks/cloud/aws/iam/require_symbols_in_passwords.rego
+++ b/checks/cloud/aws/iam/require_symbols_in_passwords.rego
@@ -16,6 +16,8 @@
 #   short_code: require-symbols-in-passwords
 #   recommended_action: Enforce longer, more complex passwords in the policy
 #   frameworks:
+#     default:
+#       - null
 #     cis-aws-1.2:
 #       - "1.7"
 #   input:

--- a/checks/cloud/aws/iam/require_uppercase_in_passwords.rego
+++ b/checks/cloud/aws/iam/require_uppercase_in_passwords.rego
@@ -18,6 +18,8 @@
 #   short_code: require-uppercase-in-passwords
 #   recommended_action: Enforce longer, more complex passwords in the policy
 #   frameworks:
+#     default:
+#       - null
 #     cis-aws-1.2:
 #       - "1.5"
 #   input:

--- a/checks/cloud/aws/iam/set_max_password_age.rego
+++ b/checks/cloud/aws/iam/set_max_password_age.rego
@@ -18,6 +18,8 @@
 #   short_code: set-max-password-age
 #   recommended_action: Limit the password duration with an expiry in the policy
 #   frameworks:
+#     default:
+#       - null
 #     cis-aws-1.2:
 #       - "1.11"
 #   input:

--- a/checks/cloud/aws/iam/set_minimum_password_length.rego
+++ b/checks/cloud/aws/iam/set_minimum_password_length.rego
@@ -18,6 +18,8 @@
 #   short_code: set-minimum-password-length
 #   recommended_action: Enforce longer, more complex passwords in the policy
 #   frameworks:
+#     default:
+#       - null
 #     cis-aws-1.2:
 #       - "1.9"
 #     cis-aws-1.4:


### PR DESCRIPTION
The default frameworks that Go checks have were missed in the migration.