### PR TITLE
chore: mark Rego libs as libs

### DIFF
--- a/lib/cloud/aws_trails.rego
+++ b/lib/cloud/aws_trails.rego
@@ -1,3 +1,9 @@
+# METADATA
+# custom:
+#   library: true
+#   input:
+#     selector:
+#     - type: cloud
 package lib.aws.trails
 
 import rego.v1

--- a/lib/docker/docker.rego
+++ b/lib/docker/docker.rego
@@ -1,5 +1,6 @@
 # METADATA
 # custom:
+#   library: true
 #   input:
 #     selector:
 #     - type: dockerfile


### PR DESCRIPTION
Fixes: https://github.com/aquasecurity/trivy/issues/7426