### PR TITLE
fix(checks): Use correct metadata for libs

### DIFF
--- a/lib/cloud/metadata.rego
+++ b/lib/cloud/metadata.rego
@@ -1,6 +1,9 @@
 # METADATA
 # custom:
 #   library: true
+#   input:
+#     selector:
+#     - type: cloud
 package lib.cloud.metadata
 
 import rego.v1

--- a/lib/test/lib_test.rego
+++ b/lib/test/lib_test.rego
@@ -1,6 +1,3 @@
-# METADATA
-# custom:
-#   library: true
 package lib.test
 
 import rego.v1

--- a/scripts/verify-bundle.go
+++ b/scripts/verify-bundle.go
@@ -73,7 +73,7 @@ func createTrivyContainer(ctx context.Context, trivyVersion string, regIP string
 	reqTrivy := testcontainers.ContainerRequest{
 		Image:           fmt.Sprintf("aquasec/trivy:%s", trivyVersion),
 		AlwaysPullImage: true,
-		Cmd:             []string{"--debug", "config", "--include-deprecated-checks=false", fmt.Sprintf("--checks-bundle-repository=%s:5111/defsec-test:latest", regIP), "/testdata"},
+		Cmd:             []string{"--debug", "config", "--include-deprecated-checks=false", !fmt.Sprintf("--checks-bundle-repository=%s:5111/defsec-test:latest", regIP), "/testdata"},
 		HostConfigModifier: func(config *container.HostConfig) {
 			config.NetworkMode = "host"
 			config.Mounts = []mount.Mount{


### PR DESCRIPTION
To avoid errors like:

```shell

2024-10-02T18:14:50-06:00       WARN    [rego] Module has no input selectors - it will be loaded for all inputs!        file_path="Library/Caches/trivy/policy/content/policies/test/lib/test.rego" module="Caches/trivy/policy/content/policies/test/lib/test.rego"2024-10-02T18:14:50-06:00       WARN    [rego] Module has no input selectors - it will be loaded for all inputs!        file_path="Caches/trivy/policy/content/policies/cloud/lib/metadata.rego" module="Caches/trivy/policy/content/policies/cloud/lib/metadata.rego"
```