### PR TITLE
feat(checks): add secrets leak check in Dockerfile

### DIFF
--- a/avd_docs/dockerfile/general/AVD-DS-0031/docs.md
+++ b/avd_docs/dockerfile/general/AVD-DS-0031/docs.md
@@ -1,0 +1,13 @@
+
+Passing secrets via `build-args` or envs or copying secret files can leak them out
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://docs.docker.com/build/building/secrets/
+
+

--- a/checks/docker/README.md
+++ b/checks/docker/README.md
@@ -1,1 +1,1 @@
-Collection of docker policies
+Collection of Docker checks

--- a/checks/docker/leaked_secrets.rego
+++ b/checks/docker/leaked_secrets.rego
@@ -1,0 +1,162 @@
+# METADATA
+# title: Secrets passed via `build-args` or envs or copied secret files
+# description: Passing secrets via `build-args` or envs or copying secret files can leak them out
+# schemas:
+# - input: schema["dockerfile"]
+# related_resources:
+# - https://docs.docker.com/build/building/secrets/
+# custom:
+#   id: DS031
+#   avd_id: AVD-DS-0031
+#   severity: CRITICAL
+#   short_code: do-not-pass-secrets
+#   recommended_action: Use secret mount if secrets are needed during image build. Use volume mount if secret files are needed during container runtime.
+#   input:
+#     selector:
+#     - type: dockerfile
+package builtin.dockerfile.DS031
+
+import rego.v1
+
+import data.lib.docker
+
+final_stage := last(input.Stages)
+
+# check if env or arg contains secret env
+deny contains res if {
+	some instruction in final_stage.Commands
+	is_arg_or_env(instruction.Cmd)
+	[name, _] := retrive_name_and_default(instruction)
+	is_secret_env(name)
+	res := result.new(
+		sprintf("Possible exposure of secret env %q in %s", [name, upper(instruction.Cmd)]),
+		instruction,
+	)
+}
+
+# check if env or arg contains secret file env
+deny contains res if {
+	some instruction in final_stage.Commands
+	is_arg_or_env(instruction.Cmd)
+	[name, path] := retrive_name_and_default(instruction)
+	path != ""
+	name in secret_file_envs
+	is_secret_file_copied(path)
+	res := result.new(
+		sprintf("Possible exposure of the copied secret env file %q in %s", [name, upper(instruction.Cmd)]),
+		instruction,
+	)
+}
+
+# check if a secret file is copied
+deny contains res if {
+	some instruction in final_stage.Commands
+	instruction.Cmd == "copy"
+	count(instruction.Value) == 2
+	env := trim_prefix(instruction.Value[1], "$")
+	env in secret_file_envs
+	res := result.new(
+		sprintf("Possible exposure of secret file %q in COPY", [env]),
+		instruction,
+	)
+}
+
+check_args := true
+
+# TODO: Should arguments be checked?
+is_arg_or_env(cmd) if {
+	check_args
+	cmd == "arg"
+}
+
+is_arg_or_env(cmd) if cmd == "env"
+
+retrive_name_and_default(instruction) := [instruction.Value[0], ""] if {
+	instruction.Cmd == "env"
+	count(instruction.Value) == 1
+}
+
+retrive_name_and_default(instruction) := [instruction.Value[0], instruction.Value[1]] if {
+	instruction.Cmd == "env"
+	count(instruction.Value) > 1
+}
+
+retrive_name_and_default(instruction) := [parts[0], ""] if {
+	instruction.Cmd == "arg"
+	parts := split(instruction.Value[0], "=")
+	count(parts) == 1
+}
+
+retrive_name_and_default(instruction) := [parts[0], parts[1]] if {
+	instruction.Cmd == "arg"
+	parts := split(instruction.Value[0], "=")
+	count(parts) > 1
+}
+
+default_envs := {
+	"AWS_ACCESS_KEY_ID", # https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html
+	"AWS_SECRET_ACCESS_KEY",
+	"AWS_SESSION_TOKEN",
+	"AZURE_CLIENT_ID", # https://learn.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential?view=azure-dotnet
+	"AZURE_CLIENT_SECRET",
+	"GITHUB_TOKEN", # https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#about-the-github_token-secret
+	"OPENAI_API_KEY", # https://platform.openai.com/docs/quickstart/create-and-export-an-api-key
+	"HF_TOKEN", # https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables#hftoken
+}
+
+excluded_envs := set()
+
+included_envs := set()
+
+envs := (default_envs - excluded_envs) | included_envs
+
+is_secret_env(str) if str in envs
+
+env_prefixes := {
+	"VITE_", # https://v3.vitejs.dev/guide/env-and-mode.html#env-files
+	"REACT_APP_", # https://create-react-app.dev/docs/adding-custom-environment-variables/
+}
+
+is_secret_env(str) if {
+	some prefix in env_prefixes
+	trim_left(str, prefix) in envs
+}
+
+secret_file_envs := {
+	"AWS_CONFIG_FILE", # https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html
+	"HF_TOKEN_PATH", # https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables#hftokenpath
+	"GOOGLE_APPLICATION_CREDENTIALS", # https://cloud.google.com/docs/authentication/application-default-credentials#GAC
+}
+
+last(array) := array[count(array) - 1]
+
+# check only the simple case when the secret file from the copied directory is used
+# For example:
+# COPY /src /app
+# ENV GOOGLE_APPLICATION_CREDENTIALS="./app/google-storage-service.json"
+is_secret_file_copied(path) if {
+	some instruction in final_stage.Commands
+	instruction.Cmd == "copy"
+	dst := last(instruction.Value)
+	is_sub_path(path, dst)
+}
+
+is_sub_path(a, b) if startswith(clean_path(a), clean_path(b))
+
+clean_path(path) := remove_trailing_slash(remove_leading_slash(remove_leading_dot(unquote(path))))
+
+unquote(s) := cut_prefix(cut_suffix(s, "\""), "\"")
+
+remove_leading_dot(path) := cut_prefix(path, ".")
+
+remove_leading_slash(path) := cut_prefix(path, "/")
+
+remove_trailing_slash(path) := cut_suffix(path, "/")
+
+cut_prefix(s, prefix) := substring(s, 1, -1) if {
+	startswith(s, prefix)
+} else := s
+
+cut_suffix(s, suffix) := substring(s, 0, count(s) - 1) if {
+	endswith(s, suffix)
+} else := s

--- a/checks/docker/leaked_secrets.rego
+++ b/checks/docker/leaked_secrets.rego
@@ -93,9 +93,20 @@ default_envs := {
 	"AWS_SESSION_TOKEN",
 	"AZURE_CLIENT_ID", # https://learn.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential?view=azure-dotnet
 	"AZURE_CLIENT_SECRET",
-	"GITHUB_TOKEN", # https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#about-the-github_token-secret
+	"GITHUB_TOKEN", # https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#about-the-github_token-secret,
+	"GH_TOKEN", # https://cli.github.com/manual/gh_help_environment
+	"GH_ENTERPRISE_TOKEN",
+	"GITHUB_ENTERPRISE_TOKEN",
 	"OPENAI_API_KEY", # https://platform.openai.com/docs/quickstart/create-and-export-an-api-key
 	"HF_TOKEN", # https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables#hftoken
+	"DIGITALOCEAN_ACCESS_TOKEN", # https://github.com/digitalocean/doctl?tab=readme-ov-file#authenticating-with-digitalocean
+	"DOCKERHUB_PASSWORD", # https://circleci.com/docs/private-images/
+	"FIREBASE_TOKEN", # https://firebase.google.com/docs/cli,
+	"CI_DEPLOY_PASSWORD", # https://docs.gitlab.com/ee/user/project/deploy_tokens/
+	"GOOGLE_API_KEY", # https://python.langchain.com/docs/integrations/tools/google_search/
+	"LANGSMITH_API_KEY", # https://docs.smith.langchain.com/how_to_guides/setup/create_account_api_key
+	"LANGCHAIN_API_KEY",
+	"HEROKU_API_KEY", # https://devcenter.heroku.com/articles/authentication
 }
 
 included_envs := included if {

--- a/checks/docker/leaked_secrets.rego
+++ b/checks/docker/leaked_secrets.rego
@@ -98,14 +98,12 @@ default_envs := {
 	"HF_TOKEN", # https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables#hftoken
 }
 
-excluded_envs := set()
-
 included_envs := included if {
 	is_array(ds031.included_envs)
 	included := {e | some e in ds031.included_envs}
 } else := set()
 
-envs := (default_envs - excluded_envs) | included_envs
+envs := default_envs | included_envs
 
 is_secret_env(str) if str in envs
 

--- a/checks/docker/leaked_secrets.rego
+++ b/checks/docker/leaked_secrets.rego
@@ -222,6 +222,7 @@ deny_secrets_tokens := {
 	"apikey", "auth", "credential",
 	"credentials", "key", "password",
 	"pword", "passwd", "secret", "token",
+	"usr", "psw",
 }
 
 deny_secrets_pattern := build_secrets_pattern(deny_secrets_tokens)

--- a/checks/docker/leaked_secrets.rego
+++ b/checks/docker/leaked_secrets.rego
@@ -18,6 +18,7 @@ package builtin.dockerfile.DS031
 
 import rego.v1
 
+import data.ds031
 import data.lib.docker
 import data.lib.path
 
@@ -99,7 +100,10 @@ default_envs := {
 
 excluded_envs := set()
 
-included_envs := set()
+included_envs := included if {
+	is_array(ds031.included_envs)
+	included := {e | some e in ds031.included_envs}
+} else := set()
 
 envs := (default_envs - excluded_envs) | included_envs
 

--- a/checks/docker/leaked_secrets.rego
+++ b/checks/docker/leaked_secrets.rego
@@ -152,15 +152,16 @@ has_secret_mount_arg(instruction) if {
 	startswith(flag, "--mount=type=secret")
 }
 
-setup_creds_commands := {
+cred_setup_commands := {
 	"aws configure set aws_access_key_id", # https://docs.aws.amazon.com/cli/latest/reference/configure/set.html
 	"aws configure set aws_secret_access_key",
 	"gcloud auth activate-service-account", # https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account
-	"az login", # TODO: check flags
+	`az login.*(-p|--password|--federated-token)\s`, # https://learn.microsoft.com/en-us/cli/azure/reference-index?view=azure-cli-latest#az-login
+	`doctl auth init.*(-t|--access-token)\s`, # https://docs.digitalocean.com/reference/doctl/reference/auth/init/
 }
 
 use_command_to_setup_credentials(instruction) if {
 	some val in instruction.Value
-	some cmd in setup_creds_commands
-	contains(val, cmd)
+	some cmd in cred_setup_commands
+	regex.match(cmd, val)
 }

--- a/checks/docker/leaked_secrets.rego
+++ b/checks/docker/leaked_secrets.rego
@@ -62,15 +62,7 @@ deny contains res if {
 	)
 }
 
-check_args := true
-
-# TODO: Should arguments be checked?
-is_arg_or_env(cmd) if {
-	check_args
-	cmd == "arg"
-}
-
-is_arg_or_env(cmd) if cmd == "env"
+is_arg_or_env(cmd) if cmd in {"env", "arg"}
 
 retrive_name_and_default(instruction) := [instruction.Value[0], ""] if {
 	instruction.Cmd == "env"

--- a/checks/docker/leaked_secrets_test.rego
+++ b/checks/docker/leaked_secrets_test.rego
@@ -24,12 +24,6 @@ test_deny_secret_arg if {
 	count(res) = 1
 }
 
-test_allow_secret_arg_but_argument_checking_disabled if {
-	inp := build_simple_input("arg", ["GITHUB_TOKEN"])
-	res := check.deny with input as inp with check.check_args as false
-	count(res) = 0
-}
-
 test_allow_secret_github_env_but_this_env_excluded if {
 	inp := build_simple_input("env", ["GITHUB_TOKEN"])
 	res := check.deny with input as inp with check.excluded_envs as {"GITHUB_TOKEN"}

--- a/checks/docker/leaked_secrets_test.rego
+++ b/checks/docker/leaked_secrets_test.rego
@@ -24,15 +24,9 @@ test_deny_secret_arg if {
 	count(res) = 1
 }
 
-test_allow_secret_github_env_but_this_env_excluded if {
-	inp := build_simple_input("env", ["GITHUB_TOKEN"])
-	res := check.deny with input as inp with check.excluded_envs as {"GITHUB_TOKEN"}
-	count(res) = 0
-}
-
 test_deny_custom_secret_env if {
 	inp := build_simple_input("env", ["MY_SECRET"])
-	res := check.deny with input as inp with data.ds031.included_envs as {"MY_SECRET"}
+	res := check.deny with input as inp with data.ds031.included_envs as ["MY_SECRET"]
 	count(res) = 1
 }
 

--- a/checks/docker/leaked_secrets_test.rego
+++ b/checks/docker/leaked_secrets_test.rego
@@ -86,10 +86,10 @@ test_deny_secret_file_in_arg if {
 
 test_deny_secret_in_set_command if {
 	inp := {"Stages": [{
-		"Name": "amazon/aws-cli:latest",
+		"Name": "ubuntu:22.04",
 		"Commands": [instruction(
 			"run",
-			["aws configure set aws_access_key_id test-id &&     aws configure set aws_secret_access_key test-key"],
+			[`if [[-z "$GOOGLE_APPLICATION_CREDENTIALS"]]; then gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}; fi`],
 		)],
 	}]}
 

--- a/checks/docker/leaked_secrets_test.rego
+++ b/checks/docker/leaked_secrets_test.rego
@@ -32,7 +32,7 @@ test_allow_secret_github_env_but_this_env_excluded if {
 
 test_deny_custom_secret_env if {
 	inp := build_simple_input("env", ["MY_SECRET"])
-	res := check.deny with input as inp with check.included_envs as {"MY_SECRET"}
+	res := check.deny with input as inp with data.ds031.included_envs as {"MY_SECRET"}
 	count(res) = 1
 }
 

--- a/checks/docker/leaked_secrets_test.rego
+++ b/checks/docker/leaked_secrets_test.rego
@@ -139,6 +139,12 @@ test_deny_secret_key if {
 	# contains uppercase secret token after underscore
 	case3 := check.deny with input as build_simple_input("arg", ["AWS_SECRET_ACCESS_KEY"])
 	count(case3) = 1
+
+	case4 := check.deny with input as build_simple_input("arg", ["ARTIFACTORY_USR"])
+	count(case4) = 1
+
+	case5 := check.deny with input as build_simple_input("arg", ["ARTIFACTORY_PSW"])
+	count(case5) = 1
 }
 
 test_allow_secret_key if {

--- a/checks/docker/leaked_secrets_test.rego
+++ b/checks/docker/leaked_secrets_test.rego
@@ -97,34 +97,30 @@ test_deny_secret_file_in_arg if {
 }
 
 test_deny_secret_in_set_command if {
-	inp := {
-		"Stages": [{
-			"Name": "amazon/aws-cli:latest",
-			"Commands": [instruction(
-				"run",
-				["aws configure set aws_access_key_id test-id &&     aws configure set aws_secret_access_key test-key"],
-			)]
-		}]
-	}
+	inp := {"Stages": [{
+		"Name": "amazon/aws-cli:latest",
+		"Commands": [instruction(
+			"run",
+			["aws configure set aws_access_key_id test-id &&     aws configure set aws_secret_access_key test-key"],
+		)],
+	}]}
 
 	res := check.deny with input as inp
 	count(res) = 1
 }
 
 test_allow_secret_in_set_command_with_secret_mount if {
-	inp := {
-		"Stages": [{
-			"Name": "amazon/aws-cli:latest",
-			"Commands": [{
-				"Cmd": "run",
-				"Value": ["aws configure set aws_access_key_id $(cat /run/secrets/aws-key-id) &&     aws configure set aws_secret_access_key $(cat /run/secrets/aws-secret-key)"],
-				"Flags": [
-					"--mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID",
-					"--mount=type=secret,id=aws-secret-key,env=AWS_SECRET_ACCESS_KEY"
-				]
-			}]
-		}]
-	}
+	inp := {"Stages": [{
+		"Name": "amazon/aws-cli:latest",
+		"Commands": [{
+			"Cmd": "run",
+			"Value": ["aws configure set aws_access_key_id $(cat /run/secrets/aws-key-id) &&     aws configure set aws_secret_access_key $(cat /run/secrets/aws-secret-key)"],
+			"Flags": [
+				"--mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID",
+				"--mount=type=secret,id=aws-secret-key,env=AWS_SECRET_ACCESS_KEY",
+			],
+		}],
+	}]}
 
 	res := check.deny with input as inp
 	count(res) = 0

--- a/checks/docker/leaked_secrets_test.rego
+++ b/checks/docker/leaked_secrets_test.rego
@@ -114,6 +114,30 @@ test_allow_secret_in_set_command_with_secret_mount if {
 	count(res) = 0
 }
 
+test_deny_secret_key if {
+	# starts with uppercase secret token
+	case1 := check.deny with input as build_simple_input("env", ["SECRET_PASSPHRASE"])
+	count(case1) = 1
+
+	# starts with lowercase secret token
+	case2 := check.deny with input as build_simple_input("env", ["password"])
+	count(case2) = 1
+
+	# contains uppercase secret token after underscore
+	case3 := check.deny with input as build_simple_input("arg", ["AWS_SECRET_ACCESS_KEY"])
+	count(case3) = 1
+}
+
+test_allow_secret_key if {
+	# starts with uppercase secret token
+	case1 := check.deny with input as build_simple_input("env", ["PUBLIC_KEY"])
+	count(case1) = 0
+
+	# starts with lowercase secret token
+	case2 := check.deny with input as build_simple_input("arg", ["public_token"])
+	count(case2) = 0
+}
+
 instruction(cmd, val) := {
 	"Cmd": cmd,
 	"Value": val,

--- a/cmd/id/main.go
+++ b/cmd/id/main.go
@@ -8,12 +8,15 @@ import (
 	"strings"
 
 	"github.com/aquasecurity/trivy/pkg/iac/framework"
+	"github.com/aquasecurity/trivy/pkg/iac/rego"
 	_ "github.com/aquasecurity/trivy/pkg/iac/rego"
 	"github.com/aquasecurity/trivy/pkg/iac/rules"
 )
 
 func main() {
 
+	rules.Reset()
+	rego.LoadAndRegister()
 	// organise existing rules by provider
 	keyMap := make(map[string][]string)
 	for _, rule := range rules.GetRegistered(framework.ALL) {

--- a/lib/docker/path.rego
+++ b/lib/docker/path.rego
@@ -1,0 +1,29 @@
+# METADATA
+# custom:
+#   library: true
+#   input:
+#     selector:
+#     - type: dockerfile
+package lib.path
+
+import rego.v1
+
+is_sub_path(a, b) if startswith(clean_path(a), clean_path(b))
+
+clean_path(p) := remove_trailing_slash(remove_leading_slash(remove_leading_dot(unquote(p))))
+
+unquote(s) := cut_prefix(cut_suffix(s, "\""), "\"")
+
+remove_leading_dot(p) := cut_prefix(p, ".")
+
+remove_leading_slash(p) := cut_prefix(p, "/")
+
+remove_trailing_slash(p) := cut_suffix(p, "/")
+
+cut_prefix(s, prefix) := substring(s, 1, -1) if {
+	startswith(s, prefix)
+} else := s
+
+cut_suffix(s, suffix) := substring(s, 0, count(s) - 1) if {
+	endswith(s, suffix)
+} else := s


### PR DESCRIPTION
Close https://github.com/aquasecurity/trivy/issues/7639

The check is triggered in the following cases:
1. Using a secret environment variable in the argument (ARG) or environment variable (ENV).

Dockerfile:
```Dockerfile
FROM alpine
ARG GITHUB_TOKEN
```
Output:
```bash
CRITICAL: Possible exposure of secret env "GITHUB_TOKEN" in ARG
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Passing secrets via `build-args` or envs or copying secret files can leak them out

See https://avd.aquasec.com/misconfig/ds031
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Dockerfile:4
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   4 [ ARG GITHUB_TOKEN
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```
2. Copying a secret file, such as an AWS credential file, to an image.

Dockerfile:
```Dockerfile
FROM alpine
ENV AWS_CONFIG_FILE=/.aws/config
COPY ./config $AWS_CONFIG_FILE
```

Output:
```bash
CRITICAL: Possible exposure of secret file "AWS_CONFIG_FILE" in COPY
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Passing secrets via `build-args` or envs or copying secret files can leak them out

See https://avd.aquasec.com/misconfig/ds031
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Dockerfile.dev1:3
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   3 [ COPY ./config $AWS_CONFIG_FILE
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

Or

```Dockerfile
FROM alpine
COPY . .
ENV GOOGLE_APPLICATION_CREDENTIALS="./news-extraction.json"
```

3. Setting credentials via the setup command.
Dockerfile:
```Dockerfile
FROM amazon/aws-cli:latest

RUN aws configure set aws_access_key_id test-id && \
    aws configure set aws_secret_access_key test-key
```

Output:
```bash
CRITICAL: Possible exposure of secret in RUN
═══════════════════════════════════════════════════════════════════════════════════════════════════════════
Passing secrets via `build-args` or envs or copying secret files can leak them out

See https://avd.aquasec.com/misconfig/ds031
───────────────────────────────────────────────────────────────────────────────────────────────────────────
 Dockerfile.dev5:3-4
───────────────────────────────────────────────────────────────────────────────────────────────────────────
   3 ┌ RUN aws configure set aws_access_key_id test-id && \
   4 └     aws configure set aws_secret_access_key test-key
───────────────────────────────────────────────────────────────────────────────────────────────────────────
```

This ignores the instructions that the secret mount uses:
```Dockerfile
# syntax=docker/dockerfile:1

FROM python:3.9-slim

RUN apt-get update && apt-get install -y curl unzip \
    && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
    && unzip awscliv2.zip \
    && ./aws/install

RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
    --mount=type=secret,id=aws-secret-key,env=AWS_SECRET_ACCESS_KEY \
    aws configure set aws_access_key_id $(cat /run/secrets/aws-key-id) && \
    aws configure set aws_secret_access_key $(cat /run/secrets/aws-secret-key)
```