### PR TITLE
fix(checks): correctly check the addresses count in the AVD-NIF-0001 rule

### DIFF
--- a/checks/cloud/nifcloud/computing/no_public_ingress_sgr.rego
+++ b/checks/cloud/nifcloud/computing/no_public_ingress_sgr.rego
@@ -36,6 +36,6 @@ deny contains res if {
 	some sg in input.nifcloud.computing.securitygroups
 	some rule in sg.ingressrules
 	cidr.is_public(rule.cidr.value)
-	cidr.count_addresses(rule.cidr.value) > 0
+	cidr.count_addresses(rule.cidr.value) > 1
 	res := result.new("Security group rule allows ingress from public internet.", rule.cidr)
 }


### PR DESCRIPTION
The nifcloud computing rules were migrated to Rego at #185, but I found a difference with original Go rule.

Go: https://github.com/aquasecurity/trivy-checks/blob/v1.1.0/checks/cloud/nifcloud/computing/no_public_ingress_sgr.go#L40
```go
if cidr.IsPublic(rule.CIDR.Value()) && cidr.CountAddresses(rule.CIDR.Value()) > 1 {
```

Rego: https://github.com/aquasecurity/trivy-checks/blob/v1.1.0/checks/cloud/nifcloud/computing/no_public_ingress_sgr.rego#L39
```rego
cidr.is_public(rule.cidr.value)
cidr.count_addresses(rule.cidr.value) > 0
```

In Golang, it was an error if the address count was more than 1 (`> 1`), But in Rego, it is an error if the count is greater than 0 (`> 0`).  
I think it is correct to follow the Go code and use `> 1` as the condition.