### PR TITLE
fix(checks): add aliases to Rego checks

### DIFF
--- a/checks/cloud/aws/ec2/add_description_to_security_group.rego
+++ b/checks/cloud/aws/ec2/add_description_to_security_group.rego
@@ -12,6 +12,8 @@
 # custom:
 #   id: AVD-AWS-0099
 #   avd_id: AVD-AWS-0099
+#   aliases:
+#     - aws-vpc-add-description-to-security-group
 #   provider: aws
 #   service: ec2
 #   severity: LOW

--- a/checks/cloud/aws/ec2/add_description_to_security_group_rule.rego
+++ b/checks/cloud/aws/ec2/add_description_to_security_group_rule.rego
@@ -12,6 +12,8 @@
 # custom:
 #   id: AVD-AWS-0124
 #   avd_id: AVD-AWS-0124
+#   aliases:
+#     - aws-vpc-add-description-to-security-group-rule
 #   provider: aws
 #   service: ec2
 #   severity: LOW

--- a/checks/cloud/aws/ec2/as_enable_at_rest_encryption.rego
+++ b/checks/cloud/aws/ec2/as_enable_at_rest_encryption.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-AWS-0008
 #   avd_id: AVD-AWS-0008
+#   aliases:
+#     - aws-autoscaling-enable-at-rest-encryption
 #   provider: aws
 #   service: ec2
 #   severity: HIGH

--- a/checks/cloud/aws/ec2/as_enforce_http_token_imds.rego
+++ b/checks/cloud/aws/ec2/as_enforce_http_token_imds.rego
@@ -14,6 +14,8 @@
 # custom:
 #   id: AVD-AWS-0130
 #   avd_id: AVD-AWS-0130
+#   aliases:
+#     - aws-autoscaling-enforce-http-token-imds
 #   provider: aws
 #   service: ec2
 #   severity: HIGH

--- a/checks/cloud/aws/ec2/as_no_secrets_in_user_data.rego
+++ b/checks/cloud/aws/ec2/as_no_secrets_in_user_data.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-AWS-0129
 #   avd_id: AVD-AWS-0129
+#   aliases:
+#     - aws-autoscaling-no-secrets-in-user-data
 #   provider: aws
 #   service: ec2
 #   severity: CRITICAL

--- a/checks/cloud/aws/ec2/enable_volume_encryption.rego
+++ b/checks/cloud/aws/ec2/enable_volume_encryption.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-AWS-0026
 #   avd_id: AVD-AWS-0026
+#   aliases:
+#     - aws-ebs-enable-volume-encryption
 #   provider: aws
 #   service: ec2
 #   severity: HIGH

--- a/checks/cloud/aws/ec2/encryption_customer_key.rego
+++ b/checks/cloud/aws/ec2/encryption_customer_key.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-AWS-0027
 #   avd_id: AVD-AWS-0027
+#   aliases:
+#     - aws-ebs-encryption-customer-key
 #   provider: aws
 #   service: ec2
 #   severity: LOW

--- a/checks/cloud/aws/ec2/no_default_vpc.rego
+++ b/checks/cloud/aws/ec2/no_default_vpc.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-AWS-0101
 #   avd_id: AVD-AWS-0101
+#   aliases:
+#     - aws-vpc-no-default-vpc
 #   provider: aws
 #   service: ec2
 #   severity: HIGH

--- a/checks/cloud/aws/ec2/no_excessive_port_access.rego
+++ b/checks/cloud/aws/ec2/no_excessive_port_access.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-AWS-0102
 #   avd_id: AVD-AWS-0102
+#   aliases:
+#     - aws-vpc-no-excessive-port-access
 #   provider: aws
 #   service: ec2
 #   severity: CRITICAL

--- a/checks/cloud/aws/ec2/no_public_egress_sgr.rego
+++ b/checks/cloud/aws/ec2/no_public_egress_sgr.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-AWS-0104
 #   avd_id: AVD-AWS-0104
+#   aliases:
+#     - aws-vpc-no-public-egress-sgr
 #   provider: aws
 #   service: ec2
 #   severity: CRITICAL

--- a/checks/cloud/aws/ec2/no_public_ingress_acl.rego
+++ b/checks/cloud/aws/ec2/no_public_ingress_acl.rego
@@ -14,6 +14,8 @@
 # custom:
 #   id: AVD-AWS-0105
 #   avd_id: AVD-AWS-0105
+#   aliases:
+#     - aws-vpc-no-public-ingress-acl
 #   provider: aws
 #   service: ec2
 #   severity: MEDIUM

--- a/checks/cloud/aws/ec2/no_public_ip_subnet.rego
+++ b/checks/cloud/aws/ec2/no_public_ip_subnet.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-AWS-0164
 #   avd_id: AVD-AWS-0164
+#   aliases:
+#     - aws-vpc-no-public-ingress-sgr
 #   provider: aws
 #   service: ec2
 #   severity: HIGH

--- a/checks/cloud/aws/ec2/no_secrets_in_user_data.rego
+++ b/checks/cloud/aws/ec2/no_secrets_in_user_data.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-AWS-0029
 #   avd_id: AVD-AWS-0029
+#   aliases:
+#     - aws-autoscaling-no-public-ip
 #   provider: aws
 #   service: ec2
 #   severity: CRITICAL

--- a/checks/cloud/aws/ec2/no_sensitive_info.rego
+++ b/checks/cloud/aws/ec2/no_sensitive_info.rego
@@ -8,6 +8,8 @@
 # custom:
 #   id: AVD-AWS-0122
 #   avd_id: AVD-AWS-0122
+#   aliases:
+#     - aws-autoscaling-no-sensitive-info
 #   provider: aws
 #   service: ec2
 #   severity: HIGH

--- a/checks/cloud/aws/ec2/require_vpc_flow_logs_for_all_vpcs.rego
+++ b/checks/cloud/aws/ec2/require_vpc_flow_logs_for_all_vpcs.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-AWS-0178
 #   avd_id: AVD-AWS-0178
+#   aliases:
+#     - aws-autoscaling-enable-at-rest-encryption
 #   provider: aws
 #   service: ec2
 #   severity: MEDIUM

--- a/checks/cloud/aws/iam/enforce_group_mfa.go
+++ b/checks/cloud/aws/iam/enforce_group_mfa.go
@@ -16,10 +16,8 @@ import (
 
 var CheckEnforceGroupMFA = rules.Register(
 	scan.Rule{
-		AVDID: "AVD-AWS-0123",
-		Aliases: []string{
-			"aws-iam-enforce-mfa",
-		},
+		AVDID:      "AVD-AWS-0123",
+		Aliases:    []string{"aws-iam-enforce-mfa"},
 		Provider:   providers.AWSProvider,
 		Service:    "iam",
 		ShortCode:  "enforce-group-mfa",

--- a/checks/cloud/aws/iam/enforce_group_mfa.rego
+++ b/checks/cloud/aws/iam/enforce_group_mfa.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-AWS-0123
 #   avd_id: AVD-AWS-0123
+#   aliases:
+#     - aws-iam-enforce-mfa
 #   provider: aws
 #   service: iam
 #   severity: MEDIUM

--- a/checks/cloud/nifcloud/computing/add_description_to_security_group.rego
+++ b/checks/cloud/nifcloud/computing/add_description_to_security_group.rego
@@ -12,6 +12,8 @@
 # custom:
 #   id: AVD-NIF-0002
 #   avd_id: AVD-NIF-0002
+#   aliases:
+#     - nifcloud-computing-add-description-to-security-group
 #   provider: nifcloud
 #   service: computing
 #   severity: LOW

--- a/checks/cloud/nifcloud/computing/add_description_to_security_group_rule.rego
+++ b/checks/cloud/nifcloud/computing/add_description_to_security_group_rule.rego
@@ -12,6 +12,8 @@
 # custom:
 #   id: AVD-NIF-0003
 #   avd_id: AVD-NIF-0003
+#   aliases:
+#     - nifcloud-computing-add-description-to-security-group-rule
 #   provider: nifcloud
 #   service: computing
 #   severity: LOW

--- a/checks/cloud/nifcloud/computing/add_security_group_to_instance.rego
+++ b/checks/cloud/nifcloud/computing/add_security_group_to_instance.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-NIF-0004
 #   avd_id: AVD-NIF-0004
+#   aliases:
+#     - nifcloud-computing-add-security-group-to-instance
 #   provider: nifcloud
 #   service: computing
 #   severity: CRITICAL

--- a/checks/cloud/nifcloud/computing/no_common_private_instance.rego
+++ b/checks/cloud/nifcloud/computing/no_common_private_instance.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-NIF-0005
 #   avd_id: AVD-NIF-0005
+#   aliases:
+#     - nifcloud-computing-no-common-private-instance
 #   provider: nifcloud
 #   service: computing
 #   severity: LOW

--- a/checks/cloud/nifcloud/computing/no_public_ingress_sgr.rego
+++ b/checks/cloud/nifcloud/computing/no_public_ingress_sgr.rego
@@ -12,6 +12,8 @@
 # custom:
 #   id: AVD-NIF-0001
 #   avd_id: AVD-NIF-0001
+#   aliases:
+#     - nifcloud-computing-no-public-ingress-sgr
 #   provider: nifcloud
 #   service: computing
 #   severity: CRITICAL

--- a/checks/cloud/nifcloud/nas/add_description_to_nas_security_group.rego
+++ b/checks/cloud/nifcloud/nas/add_description_to_nas_security_group.rego
@@ -12,6 +12,8 @@
 # custom:
 #   id: AVD-NIF-0015
 #   avd_id: AVD-NIF-0015
+#   aliases:
+#     - nifcloud-nas-add-description-to-nas-security-group
 #   provider: nifcloud
 #   service: nas
 #   severity: LOW

--- a/checks/cloud/nifcloud/nas/no_common_private_nas_instance.rego
+++ b/checks/cloud/nifcloud/nas/no_common_private_nas_instance.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-NIF-0013
 #   avd_id: AVD-NIF-0013
+#   aliases:
+#     - nifcloud-nas-no-common-private-nas-instance
 #   provider: nifcloud
 #   service: nas
 #   severity: LOW

--- a/checks/cloud/nifcloud/nas/no_public_ingress_nas_sgr.rego
+++ b/checks/cloud/nifcloud/nas/no_public_ingress_nas_sgr.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-NIF-0014
 #   avd_id: AVD-NIF-0014
+#   aliases:
+#     - nifcloud-nas-no-public-ingress-nas-sgr
 #   provider: nifcloud
 #   service: nas
 #   severity: CRITICAL

--- a/checks/cloud/nifcloud/network/add_security_group_to_router.rego
+++ b/checks/cloud/nifcloud/network/add_security_group_to_router.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-NIF-0016
 #   avd_id: AVD-NIF-0016
+#   aliases:
+#     - nifcloud-computing-add-security-group-to-router
 #   provider: nifcloud
 #   service: network
 #   severity: CRITICAL

--- a/checks/cloud/nifcloud/network/add_security_group_to_vpn_gateway.rego
+++ b/checks/cloud/nifcloud/network/add_security_group_to_vpn_gateway.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-NIF-0018
 #   avd_id: AVD-NIF-0018
+#   aliases:
+#     - nifcloud-computing-add-security-group-to-vpn-gateway
 #   provider: nifcloud
 #   service: network
 #   severity: CRITICAL

--- a/checks/cloud/nifcloud/network/no_common_private_elb.rego
+++ b/checks/cloud/nifcloud/network/no_common_private_elb.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-NIF-0019
 #   avd_id: AVD-NIF-0019
+#   aliases:
+#     - nifcloud-network-no-common-private-elb
 #   provider: nifcloud
 #   service: network
 #   severity: LOW

--- a/checks/cloud/nifcloud/network/no_common_private_router.rego
+++ b/checks/cloud/nifcloud/network/no_common_private_router.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-NIF-0017
 #   avd_id: AVD-NIF-0017
+#   aliases:
+#     - nifcloud-network-no-common-private-router
 #   provider: nifcloud
 #   service: network
 #   severity: LOW

--- a/checks/cloud/nifcloud/rdb/add_description_to_db_security_group.rego
+++ b/checks/cloud/nifcloud/rdb/add_description_to_db_security_group.rego
@@ -12,6 +12,8 @@
 # custom:
 #   id: AVD-NIF-0012
 #   avd_id: AVD-NIF-0012
+#   aliases:
+#     - nifcloud-rdb-add-description-to-db-security-group
 #   provider: nifcloud
 #   service: rdb
 #   severity: LOW

--- a/checks/cloud/nifcloud/rdb/no_common_private_db_instance.rego
+++ b/checks/cloud/nifcloud/rdb/no_common_private_db_instance.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-NIF-0010
 #   avd_id: AVD-NIF-0010
+#   aliases:
+#     - nifcloud-rdb-no-common-private-db-instance
 #   provider: nifcloud
 #   service: rdb
 #   severity: LOW

--- a/checks/cloud/nifcloud/rdb/no_public_ingress_db_sgr.rego
+++ b/checks/cloud/nifcloud/rdb/no_public_ingress_db_sgr.rego
@@ -10,6 +10,8 @@
 # custom:
 #   id: AVD-NIF-0011
 #   avd_id: AVD-NIF-0011
+#   aliases:
+#     - nifcloud-rdb-no-public-ingress-db-sgr
 #   provider: nifcloud
 #   service: rdb
 #   severity: CRITICAL


### PR DESCRIPTION
This PR only adds aliases to the Rego checks that the Go checks had

Fixes: https://github.com/aquasecurity/trivy/issues/7683