### PR TITLE
Produce a manifest with a non-zero config

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
           tags=(latest ${{ env.RELEASE_VERSION}} ${{env.MINOR_VERSION }} ${{ env.MAJOR_VERSION }})
           for tag in ${tags[@]}; do
               oras push ghcr.io/aquasecurity/trivy-policies:${tag} \
-              --config /dev/null:application/vnd.cncf.openpolicyagent.config.v1+json \
+              --artifact-type application/vnd.cncf.openpolicyagent.config.v1+json \
               --annotation "org.opencontainers.image.source=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
               --annotation "org.opencontainers.image.revision=$GITHUB_SHA" \
               bundle.tar.gz:application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip
@@ -37,6 +37,6 @@ jobs:
           tags=(latest ${{ env.RELEASE_VERSION}} ${{env.MINOR_VERSION }} ${{ env.MAJOR_VERSION }})
           for tag in ${tags[@]}; do
               oras push ghcr.io/${{ github.repository }}:${tag} \
-              --config /dev/null:application/vnd.cncf.openpolicyagent.config.v1+json \
+              --artifact-type application/vnd.cncf.openpolicyagent.config.v1+json \
               bundle.tar.gz:application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip
           done

--- a/scripts/verify-bundle.go
+++ b/scripts/verify-bundle.go
@@ -14,7 +14,7 @@ import (
 )
 
 var bundlePath = "bundle.tar.gz"
-var OrasPush = []string{"--config", "/dev/null:application/vnd.cncf.openpolicyagent.config.v1+json", fmt.Sprintf("%s:application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip", bundlePath)}
+var OrasPush = []string{"--artifact-type", "application/vnd.cncf.openpolicyagent.config.v1+json", fmt.Sprintf("%s:application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip", bundlePath)}
 var supportedTrivyVersions = []string{"latest", "canary"} // TODO: add more versions
 
 func createRegistryContainer(ctx context.Context) (testcontainers.Container, string) {


### PR DESCRIPTION
I could not copy `trivy-checks` into Harbor today because Harbor does not understand a `"size":0` manifest config.

The OCI image spec calls out this case and recommends sending an empty JSON object instead: https://github.com/opencontainers/image-spec/blob/v1.1.0/manifest.md#guidance-for-an-empty-descriptor

ORAS knows what to do with these things, so this change uses it the same way as `trivy-db`: https://github.com/aquasecurity/trivy-db/blob/32c63a9af03ffd449a6ffb4471745b6ec9714875/.github/workflows/cron.yml#L73

```
            ./oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json \
```

Here's a discussion about the OPA bundle format showing similar: https://github.com/open-policy-agent/opa/issues/1413#issuecomment-491624560

```json
  "config": {
    "mediaType": "application/vnd.cncf.openpolicyagent.config.v1+json",
    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
    "size": 2
  },
```