### PR TITLE
fix(k8s): downgrade KSV117 severity from High to Medium

### DIFF
--- a/avd_docs/kubernetes/general/AVD-KSV-0117/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KSV-0117/docs.md
@@ -10,4 +10,6 @@ The ports which are lower than 1024 receive and transmit various sensitive and p
 ### Links
 - https://kubernetes.io/docs/concepts/security/pod-security-standards/
 
+- https://www.stigviewer.com/stig/kubernetes/2022-12-02/finding/V-242414
+
 

--- a/checks/kubernetes/pss/baseline/12_privileged_ports_binding.rego
+++ b/checks/kubernetes/pss/baseline/12_privileged_ports_binding.rego
@@ -6,10 +6,11 @@
 # - input: schema["kubernetes"]
 # related_resources:
 # - https://kubernetes.io/docs/concepts/security/pod-security-standards/
+# - https://www.stigviewer.com/stig/kubernetes/2022-12-02/finding/V-242414
 # custom:
 #   id: KSV117
 #   avd_id: AVD-KSV-0117
-#   severity: HIGH
+#   severity: MEDIUM
 #   short_code: no-privilege-port-binding
 #   recommended_action: "Do not map the container ports to privileged host ports when starting a container."
 #   input:


### PR DESCRIPTION
Fixes: https://github.com/aquasecurity/trivy/issues/7737

The [PR](https://github.com/kubernetes/kubernetes/issues/102612) for changing privileged ports has not been merged yet, so for now we downgrade the severity level from `High` to `Medium` according to the benchmark https://www.stigviewer.com/stig/kubernetes/2022-12-02/finding/V-242414 .