### PR TITLE
Allow the ADD instruction with HTTP, HTTPS and Git URLs

### DIFF
--- a/checks/docker/add_instead_of_copy.rego
+++ b/checks/docker/add_instead_of_copy.rego
@@ -24,6 +24,9 @@ get_add[output] {
 	args := concat(" ", add.Value)
 
 	not contains(args, ".tar")
+	not contains(args, "http://")
+	not contains(args, "https://")
+	not contains(args, "git@")
 
 	not is_command_with_hash(add.Value, "file:")
 	not is_command_with_hash(add.Value, "multi:")

--- a/checks/docker/add_instead_of_copy_test.rego
+++ b/checks/docker/add_instead_of_copy_test.rego
@@ -70,3 +70,30 @@ test_add_tar_allowed {
 
 	count(r) == 0
 }
+
+test_add_http_url_allowed {
+	r := deny with input as {"Stages": [{
+		"Name": "alpine:3.13",
+		"Commands": [{"Cmd": "add", "Value": ["http://example.com/foo.txt", "bar.txt"]}],
+	}]}
+
+	count(r) == 0
+}
+
+test_add_https_url_allowed {
+	r := deny with input as {"Stages": [{
+		"Name": "alpine:3.13",
+		"Commands": [{"Cmd": "add", "Value": ["https://example.com/foo.txt", "bar.txt"]}],
+	}]}
+
+	count(r) == 0
+}
+
+test_add_git_url_allowed {
+	r := deny with input as {"Stages": [{
+		"Name": "alpine:3.13",
+		"Commands": [{"Cmd": "add", "Value": ["git@github.com:user/repo.git", "/usr/src/things/"]}],
+	}]}
+
+	count(r) == 0
+}


### PR DESCRIPTION
`COPY` should be preferred over `ADD` when simply copying a file from the build context to the container. However, `ADD` supports additional features such as fetching files from remote HTTP(S) and Git URLS and extracting tar files.

See https://docs.docker.com/build/building/best-practices/#add-or-copy, https://github.com/aquasecurity/trivy/issues/7806 and https://github.com/aquasecurity/trivy/discussions/7791.