### PR TITLE
Revert "test(bundle): Disable canary builds"

### DIFF
--- a/scripts/verify-bundle.go
+++ b/scripts/verify-bundle.go
@@ -15,7 +15,7 @@ import (
 
 var bundlePath = "bundle.tar.gz"
 var OrasPush = []string{"--artifact-type", "application/vnd.cncf.openpolicyagent.config.v1+json", fmt.Sprintf("%s:application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip", bundlePath)}
-var supportedTrivyVersions = []string{"latest"} // TODO: add more versions
+var supportedTrivyVersions = []string{"latest", "canary"} // TODO: add more versions
 
 func createRegistryContainer(ctx context.Context) (testcontainers.Container, string) {
 	reqReg := testcontainers.ContainerRequest{

--- a/scripts/verify-bundle.go
+++ b/scripts/verify-bundle.go
@@ -137,7 +137,7 @@ func LoadAndVerifyBundle() {
 		trivyC := createTrivyContainer(ctx, trivyVersion, regIP)
 		fmt.Println(debugLogsForContainer(ctx, trivyC))
 
-		if !assertInLogs(debugLogsForContainer(ctx, trivyC), `Tests: 1 (SUCCESSES: 0, FAILURES: 1, EXCEPTIONS: 0)`) {
+		if !assertInLogs(debugLogsForContainer(ctx, trivyC), `Tests: 1 (SUCCESSES: 0, FAILURES: 1)`) {
 			panic("asserting Trivy logs for misconfigurations failed, check Trivy log output")
 		}
 


### PR DESCRIPTION
Merge once Trivy v0.57.0 is released.

This reverts commit b9b40904c9b0e217aa8f7238a473ca3b006bff09.

This is due to: https://github.com/aquasecurity/trivy/issues/7314