### PR TITLE
chore: update push-bundle command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,5 +64,5 @@ push-bundle: create-bundle
 	echo "Pushing to repository: $$REPO" ;\
 	docker run --rm -it --net=host -v $$PWD/${BUNDLE_FILE}:/${BUNDLE_FILE} bitnami/oras:latest push \
 		$$REPO \
-		--config "/dev/null:application/vnd.cncf.openpolicyagent.config.v1+json" \
+		 --artifact-type application/vnd.cncf.openpolicyagent.config.v1+json \
 		"$(BUNDLE_FILE):application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip"


### PR DESCRIPTION
The command must match the [command](https://github.com/aquasecurity/trivy-checks/blob/main/.github/workflows/release.yaml#L35-L41) in the release, otherwise the config digest will be different. 