### PR TITLE
chore: disable ryuk

### DIFF
--- a/scripts/verify-bundle.go
+++ b/scripts/verify-bundle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -153,5 +154,6 @@ func assertInLogs(containerLogs, assertion string) bool {
 }
 
 func main() {
+	os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
 	LoadAndVerifyBundle()
 }


### PR DESCRIPTION
I recently migrated to the [colima](https://github.com/abiosoft/colima) container runtime and ran into the problem of running a test for a bundle:

```bash
2024/11/13 13:42:57 🚧 Waiting for container id 903598b9eaf7 image: testcontainers/ryuk:0.7.0. Waiting for: &{Port:8080/tcp timeout:<nil> PollInterval:100ms}
2024/11/13 13:42:57 failed accessing container logs: Error response from daemon: No such container: 903598b9eaf774df6452fe0c3d277731915c9a6d41730c3a83fa73e5bd4c99fd
panic: unexpected container status "removing": could not start container: creating reaper failed: failed to create container

goroutine 1 [running]:
main.createRegistryContainer({0x1055697c0, 0x1058aff20})
        /Users/nikita/projects/trivy-policies/scripts/verify-bundle.go:32 +0x1d8
main.LoadAndVerifyBundle()
        /Users/nikita/projects/trivy-policies/scripts/verify-bundle.go:118 +0x64
main.main()
        /Users/nikita/projects/trivy-policies/scripts/verify-bundle.go:157 +0x1c
exit status 2
make: *** [verify-bundle] Error 1
```

Since we manually manage the lifecycle of containers, we can [disable](https://java.testcontainers.org/features/configuration/#disabling-ryuk) Ryuk. 