### PR TITLE
ci: push bundle to Docker Hub registry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,8 +5,9 @@ on:
       - "v*"
 env:
   GH_USER: aqua-bot
+  AQUA_DOCKERHUB_REPO: aquasec
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -14,29 +15,52 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Create bundle
         run: make bundle
+
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ env.GH_USER }}
+          username: ${{ vars.GHCR_USER || env.GH_USER }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Deploy policy bundle to ghcr.io (for backwards compatibility)
         run: |
           tags=(latest ${{ env.RELEASE_VERSION}} ${{env.MINOR_VERSION }} ${{ env.MAJOR_VERSION }})
           for tag in ${tags[@]}; do
-              oras push ghcr.io/aquasecurity/trivy-policies:${tag} \
+              echo "Pushing artifact with tag: ${tag}"
+              oras push ghcr.io/${{ github.event.repository.owner.name }}/trivy-policies:${tag} \
               --artifact-type application/vnd.cncf.openpolicyagent.config.v1+json \
               --annotation "org.opencontainers.image.source=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
               --annotation "org.opencontainers.image.revision=$GITHUB_SHA" \
               bundle.tar.gz:application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip
           done
+
       - name: Deploy checks bundle to ghcr.io
         run: |
           tags=(latest ${{ env.RELEASE_VERSION}} ${{env.MINOR_VERSION }} ${{ env.MAJOR_VERSION }})
           for tag in ${tags[@]}; do
+              echo "Pushing artifact with tag: ${tag}"
               oras push ghcr.io/${{ github.repository }}:${tag} \
+              --artifact-type application/vnd.cncf.openpolicyagent.config.v1+json \
+              bundle.tar.gz:application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip
+          done
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Deploy checks bundle to Docker Hub
+        run: |
+          tags=(latest ${{ env.RELEASE_VERSION}} ${{env.MINOR_VERSION }} ${{ env.MAJOR_VERSION }})
+          repo="${{ vars.DOCKERHUB_REPOSITORY || env.AQUA_DOCKERHUB_REPO }}/${{ github.event.repository.name }}"
+          for tag in ${tags[@]}; do
+              echo "Pushing artifact with tag: ${tag}"
+               oras push docker.io/${repo}:${tag} \
               --artifact-type application/vnd.cncf.openpolicyagent.config.v1+json \
               bundle.tar.gz:application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip
           done


### PR DESCRIPTION
This PR adds a checks bundle release to Docker Hub to allow the use of [mirror.gcr.io](https://cloud.google.com/artifact-registry/docs/pull-cached-dockerhub-images).

Test run of the action: https://github.com/nikpivkin/trivy-checks/actions/runs/11852006001/job/33029492752
Image: https://hub.docker.com/repository/docker/nikpivkin/trivy-checks/general

The action requires the `DOCKERHUB_USER` and `DOCKERHUB_TOKEN` secrets and create a `trivy-checks` repository on Docker Hub.

The variables `GHCR_USER` and `DOCKERHUB_REPOSITORY` are added to run an action in the fork. The defaults are `aqua-bot` and `aquasec` respectively.

Use of a mirror:
```bash
trivy conf main.tf -d --cache-dir cache --checks-bundle-repository mirror.gcr.io/nikpivkin/trivy-checks:latest
2024-11-15T13:35:32+06:00       DEBUG   Default config file "file_path=trivy.yaml" not found, using built in values
2024-11-15T13:35:32+06:00       DEBUG   Cache dir       dir="cache"
2024-11-15T13:35:32+06:00       DEBUG   Cache dir       dir="cache"
2024-11-15T13:35:32+06:00       DEBUG   Parsed severities       severities=[UNKNOWN LOW MEDIUM HIGH CRITICAL]
2024-11-15T13:35:32+06:00       INFO    [misconfig] Misconfiguration scanning is enabled
2024-11-15T13:35:32+06:00       DEBUG   [misconfig] Failed to open the check metadata   err="open cache/policy/metadata.json: no such file or directory"
2024-11-15T13:35:32+06:00       INFO    [misconfig] Need to update the built-in checks
2024-11-15T13:35:32+06:00       INFO    [misconfig] Downloading the built-in checks...
2024-11-15T13:35:32+06:00       DEBUG   [misconfig] Loading check bundle        repository="mirror.gcr.io/nikpivkin/trivy-checks:latest"
2024-11-15T13:35:32+06:00       DEBUG   Credential error        err="docker-credential-gcr/helper: could not retrieve GCR's access token: google: could not find default credentials. See https://cloud.google.com/docs/authentication/external/set-up-adc for more information"
160.67 KiB / 160.67 KiB [--------------------------------------------------------------------------------------------] 100.00% 2.14 MiB p/s 300ms
2024-11-15T13:35:35+06:00       DEBUG   [misconfig] Digest of the built-in checks       digest="sha256:9a83fb3b2d9f154ba73717059e0f4e188e05c39d773abb2e2934e61abbbad6df"
2024-11-15T13:35:35+06:00       DEBUG   [misconfig] Checks successfully loaded from disk
```