### PR TITLE
fix checks related to security groups

### DIFF
--- a/checks/cloud/aws/elasticache/add_description_for_security_group.rego
+++ b/checks/cloud/aws/elasticache/add_description_for_security_group.rego
@@ -39,10 +39,21 @@ import data.lib.cloud.value
 
 deny contains res if {
 	some secgroup in input.aws.elasticache.securitygroups
+	isManaged(secgroup)
 	without_description(secgroup)
 	res := result.new(
 		"Security group does not have a description.",
 		metadata.obj_by_path(secgroup, ["description"]),
+	)
+}
+
+deny contains res if {
+	some secgroup in input.aws.elasticache.securitygroups
+	isManaged(secgroup)
+	secgroup.description.value == "Managed by Terraform"
+	res := result.new(
+		"Security group explicitly uses the default description.",
+		secgroup.description,
 	)
 }
 

--- a/checks/cloud/aws/redshift/add_description_to_security_group.rego
+++ b/checks/cloud/aws/redshift/add_description_to_security_group.rego
@@ -29,14 +29,26 @@ package builtin.aws.redshift.aws0083
 
 import rego.v1
 
+import data.lib.cloud.metadata
 import data.lib.cloud.value
 
 deny contains res if {
 	some group in input.aws.redshift.securitygroups
+	isManaged(group)
 	without_description(group)
 	res := result.new(
 		"Security group has no description.",
-		object.get(group, "description", group),
+		metadata.obj_by_path(group, ["description"]),
+	)
+}
+
+deny contains res if {
+	some group in input.aws.redshift.securitygroups
+	isManaged(group)
+	group.description.value == "Managed by Terraform"
+	res := result.new(
+		"Security group explicitly uses the default description.",
+		group.description,
 	)
 }
 

--- a/checks/cloud/nifcloud/computing/add_description_to_security_group.rego
+++ b/checks/cloud/nifcloud/computing/add_description_to_security_group.rego
@@ -34,16 +34,22 @@ package builtin.nifcloud.computing.nifcloud0002
 
 import rego.v1
 
+import data.lib.cloud.metadata
 import data.lib.cloud.value
 
 deny contains res if {
 	some sg in input.nifcloud.computing.securitygroups
+	isManaged(sg)
 	without_description(sg)
-	res := result.new("Security group does not have a description.", sg.description)
+	res := result.new(
+		"Security group does not have a description.",
+		metadata.obj_by_path(sg, ["description"]),
+	)
 }
 
 deny contains res if {
 	some sg in input.nifcloud.computing.securitygroups
+	isManaged(sg)
 	sg.description.value == "Managed by Terraform"
 	res := result.new("Security group explicitly uses the default description.", sg.description)
 }

--- a/checks/cloud/nifcloud/computing/add_description_to_security_group_rule.rego
+++ b/checks/cloud/nifcloud/computing/add_description_to_security_group_rule.rego
@@ -37,13 +37,18 @@ import rego.v1
 import data.lib.cloud.metadata
 import data.lib.cloud.value
 
-deny contains res if {
+rules := [
+rule |
 	some sg in input.nifcloud.computing.securitygroups
 	some rule in array.concat(
 		object.get(sg, "ingressrules", []),
 		object.get(sg, "egressrules", []),
 	)
+]
 
+deny contains res if {
+	some rule in rules
+	isManaged(rule)
 	without_description(rule)
 	res := result.new(
 		"Security group rule does not have a description.",

--- a/checks/cloud/nifcloud/nas/add_description_to_nas_security_group.rego
+++ b/checks/cloud/nifcloud/nas/add_description_to_nas_security_group.rego
@@ -34,18 +34,27 @@ package builtin.nifcloud.nas.nifcloud0015
 
 import rego.v1
 
+import data.lib.cloud.metadata
 import data.lib.cloud.value
 
 deny contains res if {
 	some sg in input.nifcloud.nas.nassecuritygroups
+	isManaged(sg)
 	without_description(sg)
-	res := result.new("NAS security group does not have a description.", sg.description)
+	res := result.new(
+		"NAS security group does not have a description.",
+		metadata.obj_by_path(sg, ["description"]),
+	)
 }
 
 deny contains res if {
 	some sg in input.nifcloud.nas.nassecuritygroups
+	isManaged(sg)
 	sg.description.value == "Managed by Terraform"
-	res := result.new("NAS security group explicitly uses the default description.", sg.description)
+	res := result.new(
+		"NAS security group explicitly uses the default description.",
+		sg.description,
+	)
 }
 
 without_description(sg) if value.is_empty(sg.description)

--- a/checks/cloud/nifcloud/rdb/add_description_to_db_security_group.rego
+++ b/checks/cloud/nifcloud/rdb/add_description_to_db_security_group.rego
@@ -38,12 +38,14 @@ import data.lib.cloud.value
 
 deny contains res if {
 	some sg in input.nifcloud.rdb.dbsecuritygroups
+	isManaged(sg)
 	without_description(sg)
 	res := result.new("DB security group does not have a description.", sg.description)
 }
 
 deny contains res if {
 	some sg in input.nifcloud.rdb.dbsecuritygroups
+	isManaged(sg)
 	sg.description.value == "Managed by Terraform"
 	res := result.new("DB security group explicitly uses the default description.", sg.description)
 }

--- a/checks/cloud/openstack/networking/add_description_to_security_group.rego
+++ b/checks/cloud/openstack/networking/add_description_to_security_group.rego
@@ -26,12 +26,17 @@ package builtin.openstack.networking.openstack0005
 
 import rego.v1
 
+import data.lib.cloud.metadata
 import data.lib.cloud.value
 
 deny contains res if {
 	some sg in input.openstack.networking.securitygroups
+	isManaged(sg)
 	without_description(sg)
-	res := result.new("Network security group does not have a description.", sg.description)
+	res := result.new(
+		"Network security group does not have a description.",
+		metadata.obj_by_path(sg, ["description"]),
+	)
 }
 
 without_description(sg) if value.is_empty(sg.description)


### PR DESCRIPTION
This PR fixes the checks related to security groups so that they do not trigger on dummy resources. Trivy creates dummy resources to store orphan resources, i.e. without parent resources. For example, if no related `aws_security_group_rule` resources are found for `aws_security_group` resources, Trivy will create a dummy group to store the rules. 

Related issues:
- https://github.com/aquasecurity/trivy/issues/8054