### PR TITLE
fix: use container as cause in KSV104 check

### DIFF
--- a/checks/kubernetes/pss/baseline/11_seccomp_profile_unconfined.rego
+++ b/checks/kubernetes/pss/baseline/11_seccomp_profile_unconfined.rego
@@ -44,19 +44,17 @@ container_seccomp_from_annotations(container) := profile {
 
 # containers_with_unconfined_seccomp_profile_type returns all containers which have a seccomp
 # profile set and is profile set to "Unconfined"
-containers_with_unconfined_seccomp_profile_type[name] {
+containers_with_unconfined_seccomp_profile_type[seccomp.container] {
 	seccomp := container_seccomp[_]
 	lower(seccomp.type) == "unconfined"
-	name := seccomp.container.name
 }
 
 # containers_with_unconfined_seccomp_profile_type returns all containers that do not have
 # a seccomp profile type specified, since the default is unconfined
 # https://kubernetes.io/docs/tutorials/security/seccomp/#enable-the-use-of-runtimedefault-as-the-default-seccomp-profile-for-all-workloads
-containers_with_unconfined_seccomp_profile_type[name] {
+containers_with_unconfined_seccomp_profile_type[seccomp.container] {
 	seccomp := container_seccomp[_]
 	seccomp.type == ""
-	name := seccomp.container.name
 }
 
 container_seccomp[{"container": container, "type": type}] {
@@ -78,7 +76,7 @@ container_seccomp[{"container": container, "type": type}] {
 }
 
 deny[res] {
-	cause := containers_with_unconfined_seccomp_profile_type[_]
-	msg := kubernetes.format(sprintf("container %q of %s %q in %q namespace should specify a seccomp profile", [cause, lower(kubernetes.kind), kubernetes.name, kubernetes.namespace]))
-	res := result.new(msg, cause)
+	container := containers_with_unconfined_seccomp_profile_type[_]
+	msg := kubernetes.format(sprintf("container %q of %s %q in %q namespace should specify a seccomp profile", [container.name, lower(kubernetes.kind), kubernetes.name, kubernetes.namespace]))
+	res := result.new(msg, container)
 }


### PR DESCRIPTION
We should only use objects as causes in kubernetes checks , since only they contain the locations used to display the findings.

Config:
```yaml
---
apiVersion: v1
kind: Pod
metadata:
  name: hello-sysctls
spec:
  containers:
  - name: hello
    image: busybox
    command:
    - sh
    - "-c"
    - echo 'Hello' && sleep 1h
    securityContext:
      seccompProfile:
        type: Unconfined

```

### Before:
```bash
AVD-KSV-0104 (MEDIUM): container "hello" of pod "hello-sysctls" in "default" namespace should specify a seccomp profile
════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
A program inside the container can bypass Seccomp protection policies.

See https://avd.aquasec.com/misconfig/ksv104
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 test.yaml:1
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1 [ ---
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

### After:
```bash
AVD-KSV-0104 (MEDIUM): container "hello" of pod "hello-sysctls" in "default" namespace should specify a seccomp profile
════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
A program inside the container can bypass Seccomp protection policies.

See https://avd.aquasec.com/misconfig/ksv104
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 test.yaml:8-16
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   8 ┌   - name: hello
   9 │     image: busybox
  10 │     command:
  11 │     - sh
  12 │     - "-c"
  13 │     - echo 'Hello' && sleep 1h
  14 │     securityContext:
  15 │       seccompProfile:
  16 └         type: Unconfined
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```