### PR TITLE
fix: align CIDR check rules with their title

### DIFF
--- a/avd_docs/azure/network/AVD-AZU-0047/docs.md
+++ b/avd_docs/azure/network/AVD-AZU-0047/docs.md
@@ -1,6 +1,5 @@
 
-Network security rules should not use very broad subnets.
-Where possible, segments should be broken into smaller subnets.
+Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 
 
 ### Impact

--- a/avd_docs/azure/network/AVD-AZU-0051/docs.md
+++ b/avd_docs/azure/network/AVD-AZU-0051/docs.md
@@ -1,6 +1,5 @@
 
-Network security rules should not use very broad subnets.
-Where possible, segments should be broken into smaller subnets.
+Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 
 
 ### Impact

--- a/avd_docs/digitalocean/compute/AVD-DIG-0001/docs.md
+++ b/avd_docs/digitalocean/compute/AVD-DIG-0001/docs.md
@@ -1,5 +1,5 @@
 
-Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
+Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 
 
 ### Impact

--- a/avd_docs/digitalocean/compute/AVD-DIG-0003/docs.md
+++ b/avd_docs/digitalocean/compute/AVD-DIG-0003/docs.md
@@ -1,5 +1,5 @@
 
-Opening up ports to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that explicitly require it where possible.
+Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 
 
 ### Impact

--- a/avd_docs/google/compute/AVD-GCP-0027/docs.md
+++ b/avd_docs/google/compute/AVD-GCP-0027/docs.md
@@ -1,6 +1,5 @@
 
-Network security rules should not use very broad subnets.
-Where possible, segments should be broken into smaller subnets and avoid using the <code>/0</code> subnet.
+Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 
 
 ### Impact

--- a/avd_docs/google/compute/AVD-GCP-0035/docs.md
+++ b/avd_docs/google/compute/AVD-GCP-0035/docs.md
@@ -1,6 +1,5 @@
 
-Network security rules should not use very broad subnets.
-Where possible, segments should be broken into smaller subnets and avoid using the <code>/0</code> subnet.
+Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 
 
 ### Impact

--- a/avd_docs/kubernetes/network/AVD-KUBE-0001/docs.md
+++ b/avd_docs/kubernetes/network/AVD-KUBE-0001/docs.md
@@ -1,5 +1,6 @@
 
-You should not expose infrastructure to the public internet except where explicitly required
+Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
+
 
 ### Impact
 <!-- Add Impact here -->

--- a/avd_docs/nifcloud/computing/AVD-NIF-0001/docs.md
+++ b/avd_docs/nifcloud/computing/AVD-NIF-0001/docs.md
@@ -1,5 +1,5 @@
 
-Opening up ports to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that explicitly require it where possible.
+Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 
 When publishing web applications, use a load balancer instead of publishing directly to instances.
 

--- a/avd_docs/nifcloud/nas/AVD-NIF-0014/docs.md
+++ b/avd_docs/nifcloud/nas/AVD-NIF-0014/docs.md
@@ -1,5 +1,5 @@
 
-Opening up ports to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that explicitly require it where possible.
+Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 
 
 ### Impact

--- a/avd_docs/nifcloud/rdb/AVD-NIF-0011/docs.md
+++ b/avd_docs/nifcloud/rdb/AVD-NIF-0011/docs.md
@@ -1,5 +1,5 @@
 
-Opening up ports to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that explicitly require it where possible.
+Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 
 
 ### Impact

--- a/checks/cloud/aws/ec2/no_public_egress_sgr.rego
+++ b/checks/cloud/aws/ec2/no_public_egress_sgr.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: A security group rule should not allow egress to any IP address.
+# title: A security group rule should not allow unrestricted egress to any IP address.
 # description: |
 #   Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 # scope: package
@@ -42,7 +42,7 @@ deny contains res if {
 	some block in rule.cidrs
 	net.cidr_allows_all_ips(block.value)
 	res := result.new(
-		"Security group rule allows egress to any IP address.",
+		"Security group rule allows unrestricted egress to any IP address.",
 		block,
 	)
 }

--- a/checks/cloud/aws/ec2/no_public_egress_sgr.rego
+++ b/checks/cloud/aws/ec2/no_public_egress_sgr.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: An egress security group rule allows traffic to /0.
+# title: A security group rule should not allow egress to any IP address.
 # description: |
 #   Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 # scope: package
@@ -35,13 +35,14 @@ package builtin.aws.ec2.aws0104
 
 import rego.v1
 
+import data.lib.net
+
 deny contains res if {
 	some rule in input.aws.ec2.securitygroups[_].egressrules
 	some block in rule.cidrs
-	cidr.is_public(block.value)
-	cidr.count_addresses(block.value) > 1
+	net.cidr_allows_all_ips(block.value)
 	res := result.new(
-		"Security group rule allows egress to multiple public internet addresses.",
+		"Security group rule allows egress to any IP address.",
 		block,
 	)
 }

--- a/checks/cloud/aws/ec2/no_public_egress_sgr_test.rego
+++ b/checks/cloud/aws/ec2/no_public_egress_sgr_test.rego
@@ -12,7 +12,11 @@ test_deny_sg_with_public_egress if {
 }
 
 test_allow_sg_without_private_egress if {
-	inp := {"aws": {"ec2": {"securitygroups": [{"egressrules": [{"cidrs": [{"value": "10.0.0.0/16"}]}]}]}}}
+	inp := {"aws": {"ec2": {"securitygroups": [{"egressrules": [{"cidrs": [
+		{"value": "10.0.0.0/8"},
+		{"value": "192.168.164.0/23"},
+		{"value": "22.0.0.0/8"},
+	]}]}]}}}
 
 	test.assert_empty(check.deny) with input as inp
 }

--- a/checks/cloud/aws/ec2/no_public_ingress_acl.rego
+++ b/checks/cloud/aws/ec2/no_public_ingress_acl.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: Network ACLs should not allow ingress to SSH or RDP from any IP address.
+# title: Network ACLs should not allow unrestricted ingress to SSH or RDP from any IP address.
 # description: |
 #   The Network Access Control List (NACL) function provide stateless filtering of ingress and
 #   egress network traffic to AWS resources. It is recommended that no NACL allows
@@ -56,7 +56,7 @@ deny contains res if {
 	some block in rule.cidrs
 	net.cidr_allows_all_ips(block.value)
 	res := result.new(
-		"Network ACL rule allows ingress from any IP address.",
+		"Network ACL rule allows unrestricted ingress from any IP address.",
 		block,
 	)
 }

--- a/checks/cloud/aws/ec2/no_public_ingress_acl.rego
+++ b/checks/cloud/aws/ec2/no_public_ingress_acl.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: Network ACLs should not allow ingress from 0.0.0.0/0 to port 22 or port 3389.
+# title: Network ACLs should not allow ingress to SSH or RDP from any IP address.
 # description: |
 #   The Network Access Control List (NACL) function provide stateless filtering of ingress and
 #   egress network traffic to AWS resources. It is recommended that no NACL allows
@@ -56,7 +56,7 @@ deny contains res if {
 	some block in rule.cidrs
 	net.cidr_allows_all_ips(block.value)
 	res := result.new(
-		"Network ACL rule allows ingress from public internet.",
+		"Network ACL rule allows ingress from any IP address.",
 		block,
 	)
 }

--- a/checks/cloud/aws/ec2/no_public_ingress_sgr.rego
+++ b/checks/cloud/aws/ec2/no_public_ingress_sgr.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: Security groups should not allow ingress from 0.0.0.0/0 or ::/0 to port 22 or port 3389.
+# title: Security groups should not allow ingress to SSH or RDP from any IP address.
 # description: |
 #   Security groups provide stateful filtering of ingress and egress network traffic to AWS
 #   resources. It is recommended that no security group allows unrestricted ingress access to
@@ -53,7 +53,7 @@ deny contains res if {
 	some block in rule.cidrs
 	net.cidr_allows_all_ips(block.value)
 	res := result.new(
-		"Security group rule allows ingress from public internet.",
+		"Security group rule allows ingress from any IP address.",
 		block,
 	)
 }

--- a/checks/cloud/aws/ec2/no_public_ingress_sgr.rego
+++ b/checks/cloud/aws/ec2/no_public_ingress_sgr.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: Security groups should not allow ingress to SSH or RDP from any IP address.
+# title: Security groups should not allow unrestricted ingress to SSH or RDP from any IP address.
 # description: |
 #   Security groups provide stateful filtering of ingress and egress network traffic to AWS
 #   resources. It is recommended that no security group allows unrestricted ingress access to
@@ -53,7 +53,7 @@ deny contains res if {
 	some block in rule.cidrs
 	net.cidr_allows_all_ips(block.value)
 	res := result.new(
-		"Security group rule allows ingress from any IP address.",
+		"Security group rule allows unrestricted ingress from any IP address.",
 		block,
 	)
 }

--- a/checks/cloud/azure/network/disable_rdp_from_internet.rego
+++ b/checks/cloud/azure/network/disable_rdp_from_internet.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: A security group should not allow ingress to the RDP port from any IP address.
+# title: A security group should not allow unrestricted ingress to the RDP port from any IP address.
 # description: |
 #   RDP access can be configured on either the network security group or in the network security group rule.
 #   RDP access should not be permitted from the internet (*, 0.0.0.0, /0, internet, any). Consider using the Azure Bastion Service.
@@ -45,7 +45,7 @@ deny contains res if {
 	some ip in rule.sourceaddresses
 	net.cidr_allows_all_ips(ip.value)
 	res := result.new(
-		"Security group rule allows ingress to RDP port from any IP address.",
+		"Security group rule allows unrestricted ingress to RDP port from any IP address.",
 		ip,
 	)
 }

--- a/checks/cloud/azure/network/disable_rdp_from_internet.rego
+++ b/checks/cloud/azure/network/disable_rdp_from_internet.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: RDP access should not be accessible from the Internet, should be blocked on port 3389
+# title: A security group should not allow ingress to the RDP port from any IP address.
 # description: |
 #   RDP access can be configured on either the network security group or in the network security group rule.
 #   RDP access should not be permitted from the internet (*, 0.0.0.0, /0, internet, any). Consider using the Azure Bastion Service.
@@ -32,6 +32,8 @@ package builtin.azure.network.azure0048
 
 import rego.v1
 
+import data.lib.net
+
 deny contains res if {
 	some group in input.azure.network.securitygroups
 	some rule in group.rules
@@ -41,10 +43,9 @@ deny contains res if {
 	some ports in rule.destinationports
 	port_range_includes(ports.start, ports.end, 3389)
 	some ip in rule.sourceaddresses
-	cidr.is_public(ip.value)
-	cidr.count_addresses(ip.value) > 1
+	net.cidr_allows_all_ips(ip.value)
 	res := result.new(
-		"Security group rule allows ingress to RDP port from multiple public internet addresses.",
+		"Security group rule allows ingress to RDP port from any IP address.",
 		ip,
 	)
 }

--- a/checks/cloud/azure/network/no_public_egress.rego
+++ b/checks/cloud/azure/network/no_public_egress.rego
@@ -1,8 +1,7 @@
 # METADATA
-# title: An outbound network security rule allows traffic to /0.
+# title: A security rule should not allow egress to any IP address.
 # description: |
-#   Network security rules should not use very broad subnets.
-#   Where possible, segments should be broken into smaller subnets.
+#   Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 # scope: package
 # schemas:
 #   - input: schema["cloud"]
@@ -31,12 +30,14 @@ package builtin.azure.network.azure0051
 
 import rego.v1
 
+import data.lib.net
+
 deny contains res if {
 	some group in input.azure.network.securitygroups
 	some rule in group.rules
 	rule.outbound.value
 	rule.allow.value
 	some addr in rule.destinationaddresses
-	cidr.is_public(addr.value)
-	res := result.new("Security group rule allows egress to public internet.", addr)
+	net.cidr_allows_all_ips(addr.value)
+	res := result.new("Security group rule allows egress to any IP address.", addr)
 }

--- a/checks/cloud/azure/network/no_public_egress.rego
+++ b/checks/cloud/azure/network/no_public_egress.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: A security rule should not allow egress to any IP address.
+# title: A security rule should not allow unrestricted egress to any IP address.
 # description: |
 #   Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 # scope: package
@@ -39,5 +39,5 @@ deny contains res if {
 	rule.allow.value
 	some addr in rule.destinationaddresses
 	net.cidr_allows_all_ips(addr.value)
-	res := result.new("Security group rule allows egress to any IP address.", addr)
+	res := result.new("Security group rule allows unrestricted egress to any IP address.", addr)
 }

--- a/checks/cloud/azure/network/no_public_egress_test.rego
+++ b/checks/cloud/azure/network/no_public_egress_test.rego
@@ -16,6 +16,17 @@ test_deny_outbound_rule_with_wildcard_destination_address if {
 	count(res) == 1
 }
 
+test_deny_outbound_rule_with_public_destination_address if {
+	inp := {"azure": {"network": {"securitygroups": [{"rules": [{
+		"allow": {"value": true},
+		"outbound": {"value": true},
+		"destinationaddresses": [{"value": "0.0.0.0/0"}],
+	}]}]}}}
+
+	res := check.deny with input as inp
+	count(res) == 1
+}
+
 test_allow_outbound_rule_with_private_destination_address if {
 	inp := {"azure": {"network": {"securitygroups": [{"rules": [{
 		"allow": {"value": true},

--- a/checks/cloud/azure/network/no_public_ingress.rego
+++ b/checks/cloud/azure/network/no_public_ingress.rego
@@ -1,8 +1,7 @@
 # METADATA
-# title: An inbound network security rule allows traffic from /0.
+# title: A security group rule should not allow ingress from any IP address.
 # description: |
-#   Network security rules should not use very broad subnets.
-#   Where possible, segments should be broken into smaller subnets.
+#   Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 # scope: package
 # schemas:
 #   - input: schema["cloud"]
@@ -31,13 +30,14 @@ package builtin.azure.network.azure0047
 
 import rego.v1
 
+import data.lib.net
+
 deny contains res if {
 	some group in input.azure.network.securitygroups
 	some rule in group.rules
 	not rule.outbound.value
 	rule.allow.value
 	some addr in rule.sourceaddresses
-	cidr.is_public(addr.value)
-	cidr.count_addresses(addr.value) > 1
-	res := result.new("Security group rule allows ingress from public internet.", addr)
+	net.cidr_allows_all_ips(addr.value)
+	res := result.new("Security group rule allows ingress from any IP address.", addr)
 }

--- a/checks/cloud/azure/network/no_public_ingress.rego
+++ b/checks/cloud/azure/network/no_public_ingress.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: A security group rule should not allow ingress from any IP address.
+# title: A security group rule should not allow unrestricted ingress from any IP address.
 # description: |
 #   Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 # scope: package
@@ -39,5 +39,5 @@ deny contains res if {
 	rule.allow.value
 	some addr in rule.sourceaddresses
 	net.cidr_allows_all_ips(addr.value)
-	res := result.new("Security group rule allows ingress from any IP address.", addr)
+	res := result.new("Security group rule allows unrestricted ingress from any IP address.", addr)
 }

--- a/checks/cloud/azure/network/ssh_blocked_from_internet.rego
+++ b/checks/cloud/azure/network/ssh_blocked_from_internet.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: Security group should not allow ingress to SSH port from any IP address.
+# title: Security group should not allow unrestricted ingress to SSH port from any IP address.
 # description: |
 #   SSH access can be configured on either the network security group or in the network security group rule.
 #   SSH access should not be permitted from the internet (*, 0.0.0.0, /0, internet, any)
@@ -43,7 +43,7 @@ deny contains res if {
 	some ip in rule.sourceaddresses
 	net.cidr_allows_all_ips(ip.value)
 	res := result.new(
-		"Security group rule allows ingress to SSH port from any IP address.",
+		"Security group rule allows unrestricted ingress to SSH port from any IP address.",
 		ip,
 	)
 }

--- a/checks/cloud/azure/network/ssh_blocked_from_internet.rego
+++ b/checks/cloud/azure/network/ssh_blocked_from_internet.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: SSH access should not be accessible from the Internet, should be blocked on port 22
+# title: Security group should not allow ingress to SSH port from any IP address.
 # description: |
 #   SSH access can be configured on either the network security group or in the network security group rule.
 #   SSH access should not be permitted from the internet (*, 0.0.0.0, /0, internet, any)
@@ -30,6 +30,8 @@ package builtin.azure.network.azure0050
 
 import rego.v1
 
+import data.lib.net
+
 deny contains res if {
 	some group in input.azure.network.securitygroups
 	some rule in group.rules
@@ -39,10 +41,9 @@ deny contains res if {
 	some ports in rule.destinationports
 	port_range_includes(ports.start, ports.end, 22)
 	some ip in rule.sourceaddresses
-	cidr.is_public(ip.value)
-	cidr.count_addresses(ip.value) > 1
+	net.cidr_allows_all_ips(ip.value)
 	res := result.new(
-		"Security group rule allows ingress to SSH port from multiple public internet addresses.",
+		"Security group rule allows ingress to SSH port from any IP address.",
 		ip,
 	)
 }

--- a/checks/cloud/digitalocean/compute/no_public_egress.rego
+++ b/checks/cloud/digitalocean/compute/no_public_egress.rego
@@ -1,7 +1,7 @@
 # METADATA
-# title: The firewall has an outbound rule with open access
+# title: A firewall rule should not allow egress to any IP address.
 # description: |
-#   Opening up ports to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that explicitly require it where possible.
+#   Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 # scope: package
 # schemas:
 #   - input: schema["cloud"]
@@ -30,12 +30,13 @@ package builtin.digitalocean.compute.digitalocean0003
 
 import rego.v1
 
+import data.lib.net
+
 deny contains res if {
 	some address in input.digitalocean.compute.firewalls[_].outboundrules[_].destinationaddresses
-	cidr.is_public(address.value)
-	cidr.count_addresses(address.value) > 1
+	net.cidr_allows_all_ips(address.value)
 	res := result.new(
-		"Egress rule allows access to multiple public addresses.",
+		"Firewall rule allows egress traffic to any IP address.",
 		address,
 	)
 }

--- a/checks/cloud/digitalocean/compute/no_public_egress.rego
+++ b/checks/cloud/digitalocean/compute/no_public_egress.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: A firewall rule should not allow egress to any IP address.
+# title: A firewall rule should not allow unrestricted egress to any IP address.
 # description: |
 #   Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 # scope: package

--- a/checks/cloud/digitalocean/compute/no_public_ingress.rego
+++ b/checks/cloud/digitalocean/compute/no_public_ingress.rego
@@ -1,7 +1,7 @@
 # METADATA
-# title: The firewall has an inbound rule with open access
+# title: A firewall rule should not allow ingress from any IP address.
 # description: |
-#   Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
+#   Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 # scope: package
 # schemas:
 #   - input: schema["cloud"]
@@ -30,12 +30,13 @@ package builtin.digitalocean.compute.digitalocean0001
 
 import rego.v1
 
+import data.lib.net
+
 deny contains res if {
 	some address in input.digitalocean.compute.firewalls[_].inboundrules[_].sourceaddresses
-	cidr.is_public(address.value)
-	cidr.count_addresses(address.value) > 1
+	net.cidr_allows_all_ips(address.value)
 	res := result.new(
-		"Ingress rule allows access from multiple public addresses.",
+		"Firewall rule allows ingress from any IP address.",
 		address,
 	)
 }

--- a/checks/cloud/digitalocean/compute/no_public_ingress.rego
+++ b/checks/cloud/digitalocean/compute/no_public_ingress.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: A firewall rule should not allow ingress from any IP address.
+# title: A firewall rule should not allow unrestricted ingress from any IP address.
 # description: |
 #   Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 # scope: package
@@ -36,7 +36,7 @@ deny contains res if {
 	some address in input.digitalocean.compute.firewalls[_].inboundrules[_].sourceaddresses
 	net.cidr_allows_all_ips(address.value)
 	res := result.new(
-		"Firewall rule allows ingress from any IP address.",
+		"Firewall rule allows unrestricted ingress from any IP address.",
 		address,
 	)
 }

--- a/checks/cloud/google/compute/no_public_egress.rego
+++ b/checks/cloud/google/compute/no_public_egress.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: A firewall rule should not allow egress to any IP address.
+# title: A firewall rule should not allow unrestricted egress to any IP address.
 # description: |
 #   Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 # scope: package
@@ -40,7 +40,7 @@ deny contains res if {
 	some destination in rule.destinationranges
 	net.cidr_allows_all_ips(destination.value)
 	res := result.new(
-		"Firewall rule allows egress traffic to any IP address.",
+		"Firewall rule allows unrestricted egress to any IP address.",
 		destination,
 	)
 }

--- a/checks/cloud/google/compute/no_public_egress.rego
+++ b/checks/cloud/google/compute/no_public_egress.rego
@@ -1,8 +1,7 @@
 # METADATA
-# title: An outbound firewall rule allows traffic to /0.
+# title: A firewall rule should not allow egress to any IP address.
 # description: |
-#   Network security rules should not use very broad subnets.
-#   Where possible, segments should be broken into smaller subnets and avoid using the <code>/0</code> subnet.
+#   Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 # scope: package
 # schemas:
 #   - input: schema["cloud"]
@@ -31,16 +30,17 @@ package builtin.google.compute.google0035
 
 import rego.v1
 
+import data.lib.net
+
 deny contains res if {
 	some network in input.google.compute.networks
 	some rule in network.firewall.egressrules
 	rule.firewallrule.isallow.value
 	rule.firewallrule.enforced.value
 	some destination in rule.destinationranges
-	cidr.is_public(destination.value)
-	cidr.count_addresses(destination.value) > 1
+	net.cidr_allows_all_ips(destination.value)
 	res := result.new(
-		"Firewall rule allows egress traffic to multiple addresses on the public internet.",
+		"Firewall rule allows egress traffic to any IP address.",
 		destination,
 	)
 }

--- a/checks/cloud/google/compute/no_public_egress_test.rego
+++ b/checks/cloud/google/compute/no_public_egress_test.rego
@@ -21,7 +21,7 @@ test_deny_egress_rule_with_multiple_public_destinations if {
 	count(res) == 1
 }
 
-test_allow_egress_rule_with_public_destination if {
+test_allow_egress_rule_with_private_destination if {
 	inp := {"google": {"compute": {"networks": [{"firewall": {"egressrules": [{
 		"firewallrule": {
 			"isallow": {"value": true},

--- a/checks/cloud/google/compute/no_public_ingress.rego
+++ b/checks/cloud/google/compute/no_public_ingress.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: A firewall rule should not allow ingress from any IP address.
+# title: A firewall rule should not allow unrestricted ingress from any IP address.
 # description: |
 #   Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 # scope: package
@@ -45,7 +45,7 @@ deny contains res if {
 	some source in rule.sourceranges
 	net.cidr_allows_all_ips(source.value)
 	res := result.new(
-		"Firewall rule allows ingress from any IP address.",
+		"Firewall rule allows unrestricted ingress from any IP address.",
 		source,
 	)
 }

--- a/checks/cloud/nifcloud/computing/no_public_ingress_sgr.rego
+++ b/checks/cloud/nifcloud/computing/no_public_ingress_sgr.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: A security group rule should not allow ingress from any IP address.
+# title: A security group rule should not allow unrestricted ingress from any IP address.
 # description: |
 #   Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 #
@@ -41,7 +41,7 @@ deny contains res if {
 	some rule in sg.ingressrules
 	net.cidr_allows_all_ips(rule.cidr.value)
 	res := result.new(
-		"Security group rule allows ingress from any IP address.",
+		"Security group rule allows unrestricted ingress from any IP address.",
 		rule.cidr,
 	)
 }

--- a/checks/cloud/nifcloud/computing/no_public_ingress_sgr.rego
+++ b/checks/cloud/nifcloud/computing/no_public_ingress_sgr.rego
@@ -1,7 +1,7 @@
 # METADATA
-# title: An ingress security group rule allows traffic from /0.
+# title: A security group rule should not allow ingress from any IP address.
 # description: |
-#   Opening up ports to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that explicitly require it where possible.
+#   Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 #
 #   When publishing web applications, use a load balancer instead of publishing directly to instances.
 # scope: package
@@ -34,10 +34,14 @@ package builtin.nifcloud.computing.nifcloud0001
 
 import rego.v1
 
+import data.lib.net
+
 deny contains res if {
 	some sg in input.nifcloud.computing.securitygroups
 	some rule in sg.ingressrules
-	cidr.is_public(rule.cidr.value)
-	cidr.count_addresses(rule.cidr.value) > 1
-	res := result.new("Security group rule allows ingress from public internet.", rule.cidr)
+	net.cidr_allows_all_ips(rule.cidr.value)
+	res := result.new(
+		"Security group rule allows ingress from any IP address.",
+		rule.cidr,
+	)
 }

--- a/checks/cloud/nifcloud/nas/no_public_ingress_nas_sgr.rego
+++ b/checks/cloud/nifcloud/nas/no_public_ingress_nas_sgr.rego
@@ -1,7 +1,7 @@
 # METADATA
-# title: An ingress nas security group rule allows traffic from /0.
+# title: A security group rule should not allow ingress from any IP address.
 # description: |
-#   Opening up ports to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that explicitly require it where possible.
+#   Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 # scope: package
 # schemas:
 #   - input: schema["cloud"]
@@ -32,10 +32,11 @@ package builtin.nifcloud.nas.nifcloud0014
 
 import rego.v1
 
+import data.lib.net
+
 deny contains res if {
 	some sg in input.nifcloud.nas.nassecuritygroups
 	some c in sg.cidrs
-	cidr.is_public(c.value)
-	cidr.count_addresses(c.value) > 1
-	res := result.new("Security group rule allows ingress from public internet.", c)
+	net.cidr_allows_all_ips(c.value)
+	res := result.new("Security group rule allows ingress from any IP address.", c)
 }

--- a/checks/cloud/nifcloud/nas/no_public_ingress_nas_sgr.rego
+++ b/checks/cloud/nifcloud/nas/no_public_ingress_nas_sgr.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: A security group rule should not allow ingress from any IP address.
+# title: A security group rule should not allow unrestricted ingress from any IP address.
 # description: |
 #   Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 # scope: package
@@ -38,5 +38,5 @@ deny contains res if {
 	some sg in input.nifcloud.nas.nassecuritygroups
 	some c in sg.cidrs
 	net.cidr_allows_all_ips(c.value)
-	res := result.new("Security group rule allows ingress from any IP address.", c)
+	res := result.new("Security group rule allows unrestricted ingress from any IP address.", c)
 }

--- a/checks/cloud/nifcloud/rdb/no_public_ingress_db_sgr.rego
+++ b/checks/cloud/nifcloud/rdb/no_public_ingress_db_sgr.rego
@@ -1,7 +1,7 @@
 # METADATA
-# title: An ingress db security group rule allows traffic from /0.
+# title: A security group rule should not allow ingress traffic from any IP address.
 # description: |
-#   Opening up ports to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that explicitly require it where possible.
+#   Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 # scope: package
 # schemas:
 #   - input: schema["cloud"]
@@ -32,10 +32,11 @@ package builtin.nifcloud.rdb.nifcloud0011
 
 import rego.v1
 
+import data.lib.net
+
 deny contains res if {
 	some sg in input.nifcloud.rdb.dbsecuritygroups
 	some c in sg.cidrs
-	cidr.is_public(c.value)
-	cidr.count_addresses(c.value) > 1
-	res := result.new("DB Security group rule allows ingress from public internet.", c)
+	net.cidr_allows_all_ips(c.value)
+	res := result.new("Security group rule allows ingress traffic from any IP address.", c)
 }

--- a/checks/cloud/nifcloud/rdb/no_public_ingress_db_sgr.rego
+++ b/checks/cloud/nifcloud/rdb/no_public_ingress_db_sgr.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: A security group rule should not allow ingress traffic from any IP address.
+# title: A security group rule should not allow unrestricted ingress traffic from any IP address.
 # description: |
 #   Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 # scope: package
@@ -38,5 +38,5 @@ deny contains res if {
 	some sg in input.nifcloud.rdb.dbsecuritygroups
 	some c in sg.cidrs
 	net.cidr_allows_all_ips(c.value)
-	res := result.new("Security group rule allows ingress traffic from any IP address.", c)
+	res := result.new("Security group rule allows unrestricted ingress from any IP address.", c)
 }

--- a/checks/kubernetes/network/no_public_egress.rego
+++ b/checks/kubernetes/network/no_public_egress.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: A network policy should not allow egress to any IP address.
+# title: A network policy should not allow unrestricted egress to any IP address.
 # description: You should not expose infrastructure to the public internet except where explicitly required
 # scope: package
 # schemas:
@@ -34,7 +34,7 @@ deny contains res if {
 	some dest in policy.spec.egress.destinationcidrs
 	net.cidr_allows_all_ips(dest.value)
 	res := result.new(
-		"Network policy allows egress to any IP address.",
+		"Network policy allows unrestricted egress to any IP address.",
 		dest,
 	)
 }

--- a/checks/kubernetes/network/no_public_egress.rego
+++ b/checks/kubernetes/network/no_public_egress.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: Public egress should not be allowed via network policies
+# title: A network policy should not allow egress to any IP address.
 # description: You should not expose infrastructure to the public internet except where explicitly required
 # scope: package
 # schemas:
@@ -26,13 +26,15 @@ package builtin.kube.network.kube0002
 
 import rego.v1
 
+import data.lib.net
+
 deny contains res if {
 	some policy in input.kubernetes.networkpolicies
 	isManaged(policy)
 	some dest in policy.spec.egress.destinationcidrs
-	cidr.is_public(dest.value)
+	net.cidr_allows_all_ips(dest.value)
 	res := result.new(
-		"Network policy allows egress to the public internet.",
+		"Network policy allows egress to any IP address.",
 		dest,
 	)
 }

--- a/checks/kubernetes/network/no_public_ingress.rego
+++ b/checks/kubernetes/network/no_public_ingress.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: A network policy should not allow ingress from any IP address.
+# title: A network policy should not allow unrestricted ingress from any IP address.
 # description: |
 #   Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 # scope: package
@@ -35,7 +35,7 @@ deny contains res if {
 	some source in policy.spec.ingress.sourcecidrs
 	net.cidr_allows_all_ips(source.value)
 	res := result.new(
-		"Network policy allows ingress from any IP address.",
+		"Network policy allows unrestricted ingress from any IP address.",
 		source,
 	)
 }

--- a/checks/kubernetes/network/no_public_ingress.rego
+++ b/checks/kubernetes/network/no_public_ingress.rego
@@ -1,6 +1,7 @@
 # METADATA
-# title: Public ingress should not be allowed via network policies
-# description: You should not expose infrastructure to the public internet except where explicitly required
+# title: A network policy should not allow ingress from any IP address.
+# description: |
+#   Opening up ports to allow connections from the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.
 # scope: package
 # schemas:
 # - input: schema["cloud"]
@@ -26,13 +27,15 @@ package builtin.kube.network.kube0001
 
 import rego.v1
 
+import data.lib.net
+
 deny contains res if {
 	some policy in input.kubernetes.networkpolicies
 	isManaged(policy)
 	some source in policy.spec.ingress.sourcecidrs
-	cidr.is_public(source.value)
+	net.cidr_allows_all_ips(source.value)
 	res := result.new(
-		"Network policy allows ingress from the public internet.",
+		"Network policy allows ingress from any IP address.",
 		source,
 	)
 }

--- a/lib/cloud/net.rego
+++ b/lib/cloud/net.rego
@@ -12,7 +12,7 @@ ssh_port := 22
 
 rdp_port := 3389
 
-all_ips := {"0.0.0.0/0", "0000:0000:0000:0000:0000:0000:0000:0000/0", "::/0"}
+all_ips := {"0.0.0.0/0", "0000:0000:0000:0000:0000:0000:0000:0000/0", "::/0", "*"}
 
 # "-1" or "all" equivalent to all protocols
 # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AuthorizeSecurityGroupIngress.html


### PR DESCRIPTION
Related issues:
- https://github.com/aquasecurity/trivy/issues/8184

Checks that require restricting access to or from any IP address now check only this condition. In addition, the titles, descriptions, and messages for all such checks have been unified.