### PR TITLE
ci: use custom OPA to format Rego

### DIFF
--- a/.github/workflows/test-rego.yaml
+++ b/.github/workflows/test-rego.yaml
@@ -36,18 +36,14 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Setup OPA
-        uses: ./.github/actions/setup-opa
-
       - name: Rego Check
-        run: opa check lib checks --v0-v1
+        run: go run ./cmd/opa check lib checks --v0-v1
 
       - name: OPA Format
         run: |
-          files=$(opa fmt --list . | grep -v vendor || true)
-          if [ -n "$files" ]; then
-            echo "=== The following files are not formatted ==="
-            echo "$files"
+          make fmt-rego
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Run 'make fmt-rego' and push it"
             exit 1
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ rego: fmt-rego test-rego
 
 .PHONY: fmt-rego
 fmt-rego:
-	opa fmt -w lib/ checks/ examples/ .regal/rules
+	go run ./cmd/opa fmt -w lib/ checks/ examples/ .regal/rules
 
 .PHONY: test-rego
 test-rego:


### PR DESCRIPTION
I get the following warnings when running `fmt-rego` with OPA v1.0.0 on my machine:
```bash
❯ make fmt-rego
opa fmt -w lib/ checks/ examples/
failed to format Rego source file: 25 errors occurred:
lib/docker/docker.rego:9: rego_parse_error: `if` keyword is required before rule body
lib/docker/docker.rego:9: rego_parse_error: `contains` keyword is required for partial set rules
lib/docker/docker.rego:14: rego_parse_error: `if` keyword is required before rule body
lib/docker/docker.rego:14: rego_parse_error: `contains` keyword is required for partial set rules
lib/docker/docker.rego:19: rego_parse_error: `if` keyword is required before rule body
lib/docker/docker.rego:19: rego_parse_error: `contains` keyword is required for partial set rules
```

So we should use our custom OPA with the fixed version as in other actions