### PR TITLE
ci: init Rego linting

### DIFF
--- a/.github/workflows/test-rego.yaml
+++ b/.github/workflows/test-rego.yaml
@@ -24,6 +24,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Regal 
+        uses: StyraInc/setup-regal@33a142b1189004e0f14bf42b15972c67eecce776 # v1
+        with:
+          version: 0.29
+
+      - name: Lint Rego
+        run: make lint-rego
+
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}

--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -1,0 +1,16 @@
+rules:
+  default:
+    level: ignore
+  custom:
+    naming-convention:
+      level: error
+      conventions:
+        - pattern: '^builtin|lib|defsec|appshield'
+          targets:
+            - package
+  naming:
+    deny-rule:
+      level: error
+      ignore:
+        files:
+          - "*_test.rego"

--- a/.regal/rules/custom/regal/rules/naming/deny-rule/deny_rule.rego
+++ b/.regal/rules/custom/regal/rules/naming/deny-rule/deny_rule.rego
@@ -1,0 +1,19 @@
+# METADATA
+# description: Ensures that no rules in the check are named with the prefix 'deny_'
+# related_resources:
+# - description: documentation
+#   ref: https://github.com/aquasecurity/trivy-checks/pull/283
+# schemas:
+# - input: schema.regal.ast
+package custom.regal.rules.naming["deny-rule"]
+
+import rego.v1
+
+import data.regal.ast
+import data.regal.result
+
+report contains violation if {
+	some rule in input.rules
+	startswith(ast.ref_to_string(rule.head.ref), "deny_")
+	violation := result.fail(rego.metadata.chain(), result.location(rule))
+}

--- a/.regal/rules/custom/regal/rules/naming/deny-rule/deny_rule_test.rego
+++ b/.regal/rules/custom/regal/rules/naming/deny-rule/deny_rule_test.rego
@@ -1,0 +1,35 @@
+package custom.regal.rules.naming["deny-rule_test"]
+
+import rego.v1
+
+import data.custom.regal.rules.naming["deny-rule"] as rule
+
+test_rule_named_startswith_not_allowed if {
+	module := regal.parse_module("example.rego", `
+	package policy
+
+	deny_foo := true`)
+
+	r := rule.report with input as module
+
+	r == {{
+		"category": "naming",
+		"description": "Ensures that no rules in the check are named with the prefix 'deny_'",
+		"related_resources": [{
+			"description": "documentation",
+			"ref": "https://github.com/aquasecurity/trivy-checks/pull/283",
+		}],
+		"level": "error",
+		"location": {
+			"file": "example.rego",
+			"row": 4,
+			"col": 2,
+			"end": {
+				"row": 4,
+				"col": 18,
+			},
+			"text": "\tdeny_foo := true",
+		},
+		"title": "deny-rule",
+	}}
+}

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,19 @@ rego: fmt-rego test-rego
 
 .PHONY: fmt-rego
 fmt-rego:
-	opa fmt -w lib/ checks/ examples/
+	opa fmt -w lib/ checks/ examples/ .regal/rules
 
 .PHONY: test-rego
 test-rego:
 	go run ./cmd/opa test --explain=fails lib/ checks/ examples/ --ignore '*.yaml'
+
+.PHONY: lint-rego
+lint-rego:
+	@regal test .regal/rules 
+	@regal lint lib checks \
+		--config-file .regal/config.yaml \
+		--enable deny-rule,naming-convention \
+		--timeout 5m
 
 .PHONY: bundle
 bundle: create-bundle verify-bundle


### PR DESCRIPTION
This PR adds linting for Rego with two rules:

1. Only allow the following package namespaces, otherwise the check will be ignored by Trivy: `builtin,lib,defsec,appshield`.
2. Disallowing rules whose names start with `deny_` to avoid the problems described in [this PR](https://github.com/aquasecurity/trivy-checks/pull/283).