### PR TITLE
fix(checks): respect PodSecurityContext for containers

### DIFF
--- a/checks/kubernetes/general/runs_with_GID_le_10000_test.rego
+++ b/checks/kubernetes/general/runs_with_GID_le_10000_test.rego
@@ -62,3 +62,26 @@ test_low_gid_denied if {
 	count(r) == 1
 	r[_].msg == "Container 'hello' of Pod 'hello-gid' should set 'securityContext.runAsGroup' > 10000"
 }
+
+test_pod_sec_ctx_low_gid_denied if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "hello-gid"},
+		"spec": {
+			"securityContext": {"runAsGroup": 100},
+			"containers": [{
+				"command": [
+					"sh",
+					"-c",
+					"echo 'Hello' && sleep 1h",
+				],
+				"image": "busybox",
+				"name": "hello",
+			}],
+		},
+	}
+
+	count(r) == 1
+	r[_].msg == "Container 'hello' of Pod 'hello-gid' should set 'securityContext.runAsGroup' > 10000"
+}

--- a/checks/kubernetes/general/runs_with_UID_le_10000_test.rego
+++ b/checks/kubernetes/general/runs_with_UID_le_10000_test.rego
@@ -83,3 +83,26 @@ test_zero_uid_denied if {
 	count(r) == 1
 	r[_].msg == "Container 'hello' of Pod 'hello-uid' should set 'securityContext.runAsUser' > 10000"
 }
+
+test_pod_sec_ctx_low_uid_denied if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "hello-uid"},
+		"spec": {
+			"securityContext": {"runAsUser": 100},
+			"containers": [{
+				"command": [
+					"sh",
+					"-c",
+					"echo 'Hello' && sleep 1h",
+				],
+				"image": "busybox",
+				"name": "hello",
+			}],
+		},
+	}
+
+	count(r) == 1
+	r[_].msg == "Container 'hello' of Pod 'hello-uid' should set 'securityContext.runAsUser' > 10000"
+}

--- a/checks/kubernetes/pss/restricted/5_runtime_default_seccomp_profile_not_set_test.rego
+++ b/checks/kubernetes/pss/restricted/5_runtime_default_seccomp_profile_not_set_test.rego
@@ -23,7 +23,7 @@ test_pod_context_custom_profile_denied if {
 		},
 	}
 
-	count(r) == 1
+	count(r) == 2
 }
 
 test_both_undefined_type_denied if {

--- a/lib/kubernetes/kubernetes_test.rego
+++ b/lib/kubernetes/kubernetes_test.rego
@@ -229,18 +229,35 @@ test_containers if {
 	test_containers := containers with input as {
 		"apiVersion": "v1",
 		"kind": "Pod",
-		"spec": {"containers": [{
-			"command": [
-				"sh",
-				"-c",
-				"echo 'Hello !' && sleep 1h",
-			],
-			"image": "busybox",
-			"name": "hello-containers",
-		}]},
+		"spec": {
+			"securityContext": {
+				"runAsUser": 1000,
+				"runAsGroup": 1001,
+				"fsGroup": 2000,
+				"supplementalGroups": [4000],
+			},
+			"containers": [{
+				"command": [
+					"sh",
+					"-c",
+					"echo 'Hello !' && sleep 1h",
+				],
+				"image": "busybox",
+				"name": "hello-containers",
+				"securityContext": {
+					"runAsGroup": 3000,
+					"allowPrivilegeEscalation": false,
+				},
+			}],
+		},
 	}
 
 	test_containers[_].name == "hello-containers"
+	test_containers[_].securityContext == {
+		"runAsUser": 1000,
+		"runAsGroup": 3000,
+		"allowPrivilegeEscalation": false,
+	}
 }
 
 test_isapiserver_has_valid_container if {

--- a/lib/kubernetes/security_context.rego
+++ b/lib/kubernetes/security_context.rego
@@ -1,0 +1,33 @@
+# METADATA
+# custom:
+#   library: true
+#   input:
+#     selector:
+#     - type: kubernetes
+#     - type: rbac
+package lib.k8s_sec_context
+
+import rego.v1
+
+# Some fields are present in both SecurityContext and PodSecurityContext.
+# When both are set, the values in SecurityContext take precedence.
+# See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#securitycontext-v1-core
+resolve_container_sec_context(pod, container) := object.union(
+	_inherited_sec_ctx(pod),
+	object.get(container, "securityContext", {}),
+)
+
+_inherited_sec_ctx(pod) := {k: v |
+	ctx := object.get(pod, ["spec", "securityContext"], {})
+	some k, v in ctx
+	k in _inherited_sec_ctx_fields
+}
+
+_inherited_sec_ctx_fields := {
+	"runAsGroup",
+	"runAsNonRoot",
+	"runAsUser",
+	"seLinuxOptions",
+	"seccompProfile",
+	"windowsOptions",
+}


### PR DESCRIPTION
Fixes: https://github.com/aquasecurity/trivy/issues/8210

`SecurityContext` may inherit some fields from `PodSecurityContext`. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#securitycontext-v1-core

Before:
```bash
❯ trivy conf test.yaml
2025-01-14T16:15:39+06:00       INFO    [misconfig] Misconfiguration scanning is enabled
2025-01-14T16:15:43+06:00       INFO    Detected config files   num=1

test.yaml (kubernetes)

Tests: 93 (SUCCESSES: 91, FAILURES: 2)
Failures: 2 (UNKNOWN: 0, LOW: 2, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

AVD-KSV-0020 (LOW): Container 'sec-ctx-demo' of Pod 'security-context-demo' should set 'securityContext.runAsUser' > 10000
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Force the container to run with user ID > 10000 to avoid conflicts with the host’s user table.

See https://avd.aquasec.com/misconfig/ksv020
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 test.yaml:15-35
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  15 ┌   - name: sec-ctx-demo
  16 │     image: busybox:42
  17 │     command: [ "sh", "-c", "sleep 1h" ]
  18 │     volumeMounts:
  19 │     - name: sec-ctx-vol
  20 │       mountPath: /data/demo
  21 │     resources:
  22 │       requests:
  23 └         cpu: 100m
  ..   
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────


AVD-KSV-0021 (LOW): Container 'sec-ctx-demo' of Pod 'security-context-demo' should set 'securityContext.runAsGroup' > 10000
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Force the container to run with group ID > 10000 to avoid conflicts with the host’s user table.

See https://avd.aquasec.com/misconfig/ksv021
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 test.yaml:15-35
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  15 ┌   - name: sec-ctx-demo
  16 │     image: busybox:42
  17 │     command: [ "sh", "-c", "sleep 1h" ]
  18 │     volumeMounts:
  19 │     - name: sec-ctx-vol
  20 │       mountPath: /data/demo
  21 │     resources:
  22 │       requests:
  23 └         cpu: 100m
  ..   
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

After:
```bash
❯ trivy conf --cache-dir cache --checks-bundle-repository localhost:5111/trivy-checks:latest test.yaml
2025-01-14T16:15:55+06:00       INFO    [misconfig] Misconfiguration scanning is enabled
2025-01-14T16:15:55+06:00       INFO    [misconfig] Need to update the built-in checks
2025-01-14T16:15:55+06:00       INFO    [misconfig] Downloading the built-in checks...
163.59 KiB / 163.59 KiB [---------------------------------------------------------------------------------------------------] 100.00% ? p/s 100ms
2025-01-14T16:15:57+06:00       INFO    Detected config files   num=1
```