### PR TITLE
fix(checks): dedupe KSV030 results

### DIFF
--- a/checks/kubernetes/pss/restricted/5_runtime_default_seccomp_profile_not_set_test.rego
+++ b/checks/kubernetes/pss/restricted/5_runtime_default_seccomp_profile_not_set_test.rego
@@ -23,7 +23,7 @@ test_pod_context_custom_profile_denied if {
 		},
 	}
 
-	count(r) == 2
+	count(r) == 1
 }
 
 test_both_undefined_type_denied if {
@@ -163,6 +163,29 @@ test_container_context_runtime_default_allowed if {
 			"name": "hello",
 			"securityContext": {"seccompProfile": {"type": "RuntimeDefault"}},
 		}]},
+	}
+
+	count(r) == 0
+}
+
+test_pod_context_runtime_default_is_overrided_allowed if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "hello-seccomp"},
+		"spec": {
+			"securityContext": {"seccompProfile": {"type": "Unconfined"}},
+			"containers": [{
+				"command": [
+					"sh",
+					"-c",
+					"echo 'Hello' && sleep 1h",
+				],
+				"image": "busybox",
+				"name": "hello",
+				"securityContext": {"seccompProfile": {"type": "RuntimeDefault"}},
+			}],
+		},
 	}
 
 	count(r) == 0


### PR DESCRIPTION
Related PRs:
- https://github.com/aquasecurity/trivy-checks/pull/315

The current implementation in KSV030 uses 4 rules to validate the Seccomp profile (1 for the annotation and 3 for the securityContext) because the SecurityContext of the container does not inherit values from the PodSecurityContext. This makes it difficult to support check. [This](https://github.com/aquasecurity/trivy-checks/pull/315) PR adds inheritance of certain fields from the PodSecurityContext, including `seccompProfile.type`. With this, we can reduce the number of rules to 2, covering all possible cases:

1. Checking the pod annotation - to support older versions of Kubernetes.
2. Checking the securityContext of the container - for newer versions of Kubernetes.