### PR TITLE
ci: enable strict mode by default in opa check

### DIFF
--- a/.github/workflows/test-rego.yaml
+++ b/.github/workflows/test-rego.yaml
@@ -24,6 +24,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Rego Check
+        run: go run ./cmd/opa check lib checks --strict --v0-v1
+
       - name: Setup Regal 
         uses: StyraInc/setup-regal@33a142b1189004e0f14bf42b15972c67eecce776 # v1
         with:
@@ -31,13 +38,6 @@ jobs:
 
       - name: Lint Rego
         run: make lint-rego
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Rego Check
-        run: go run ./cmd/opa check lib checks --v0-v1
 
       - name: OPA Format
         run: |

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,12 @@ fmt-rego:
 test-rego:
 	go run ./cmd/opa test --explain=fails lib/ checks/ examples/ --ignore '*.yaml'
 
+.PHONY: check-rego
+check-rego:
+	go run ./cmd/opa check lib checks --v0-v1 --strict
+
 .PHONY: lint-rego
-lint-rego:
+lint-rego: check-rego
 	@regal test .regal/rules 
 	@regal lint lib checks \
 		--config-file .regal/config.yaml \

--- a/checks/cloud/aws/ec2/as_no_secrets_in_user_data_test.rego
+++ b/checks/cloud/aws/ec2/as_no_secrets_in_user_data_test.rego
@@ -3,7 +3,6 @@ package builtin.aws.ec2.aws0129_test
 import rego.v1
 
 import data.builtin.aws.ec2.aws0129 as check
-import data.lib.test
 
 test_deny_launch_tmpl_with_sensitive_info if {
 	inp := {"aws": {"ec2": {"launchtemplates": [{"instance": {"userdata": {"value": `

--- a/checks/cloud/aws/ec2/no_secrets_in_user_data_test.rego
+++ b/checks/cloud/aws/ec2/no_secrets_in_user_data_test.rego
@@ -3,7 +3,6 @@ package builtin.aws.ec2.aws0029_test
 import rego.v1
 
 import data.builtin.aws.ec2.aws0029 as check
-import data.lib.test
 
 test_deny_instance_with_sensitive_info if {
 	inp := {"aws": {"ec2": {"instances": [{"userdata": {"value": `

--- a/checks/cloud/aws/ec2/no_sensitive_info_test.rego
+++ b/checks/cloud/aws/ec2/no_sensitive_info_test.rego
@@ -3,7 +3,6 @@ package builtin.aws.ec2.aws0122_test
 import rego.v1
 
 import data.builtin.aws.ec2.aws0122 as check
-import data.lib.test
 
 test_deny_launch_config_with_sensitive_info if {
 	inp := {"aws": {"ec2": {"launchconfigurations": [{"userdata": {"value": `

--- a/checks/cloud/aws/lambda/enable_tracing.rego
+++ b/checks/cloud/aws/lambda/enable_tracing.rego
@@ -34,7 +34,6 @@ package builtin.aws.lambda.aws0066
 import rego.v1
 
 import data.lib.cloud.metadata
-import data.lib.cloud.value
 
 deny contains res if {
 	some func in input.aws.lambda.functions

--- a/checks/cloud/aws/s3/block_public_acls_test.rego
+++ b/checks/cloud/aws/s3/block_public_acls_test.rego
@@ -3,7 +3,6 @@ package builtin.aws.s3.aws0086_test
 import rego.v1
 
 import data.builtin.aws.s3.aws0086 as check
-import data.lib.test
 
 test_deny_public_access_block_missing if {
 	inp := {"aws": {"s3": {"buckets": [{}]}}}

--- a/checks/cloud/aws/s3/block_public_policy_test.rego
+++ b/checks/cloud/aws/s3/block_public_policy_test.rego
@@ -3,7 +3,6 @@ package builtin.aws.s3.aws0087_test
 import rego.v1
 
 import data.builtin.aws.s3.aws0087 as check
-import data.lib.test
 
 test_deny_public_access_block_missing if {
 	inp := {"aws": {"s3": {"buckets": [{}]}}}

--- a/checks/cloud/aws/s3/enable_bucket_encryption_test.rego
+++ b/checks/cloud/aws/s3/enable_bucket_encryption_test.rego
@@ -3,7 +3,6 @@ package builtin.aws.s3.aws0088_test
 import rego.v1
 
 import data.builtin.aws.s3.aws0088 as check
-import data.lib.test
 
 test_deny_bucket_encryption_disabled if {
 	inp := {"aws": {"s3": {"buckets": [{"encryption": {"enabled": {"value": false}}}]}}}

--- a/checks/cloud/aws/s3/enable_object_read_logging_test.rego
+++ b/checks/cloud/aws/s3/enable_object_read_logging_test.rego
@@ -3,7 +3,6 @@ package builtin.aws.s3.aws0172_test
 import rego.v1
 
 import data.builtin.aws.s3.aws0172 as check
-import data.lib.test
 
 test_deny_bucket_without_cloudtrail_logging if {
 	inp := {"aws": {"s3": {"buckets": [{"name": {"value": "test-bucket"}}]}}}

--- a/checks/cloud/aws/s3/enable_object_write_logging_test.rego
+++ b/checks/cloud/aws/s3/enable_object_write_logging_test.rego
@@ -3,7 +3,6 @@ package builtin.aws.s3.aws0171_test
 import rego.v1
 
 import data.builtin.aws.s3.aws0171 as check
-import data.lib.test
 
 test_deny_bucket_without_cloudtrail_logging if {
 	inp := {"aws": {"s3": {"buckets": [{"name": {"value": "test-bucket"}}]}}}

--- a/checks/cloud/aws/s3/enable_versioning_test.rego
+++ b/checks/cloud/aws/s3/enable_versioning_test.rego
@@ -3,7 +3,6 @@ package builtin.aws.s3.aws0090_test
 import rego.v1
 
 import data.builtin.aws.s3.aws0090 as check
-import data.lib.test
 
 test_deny_versioning_disabled if {
 	inp := {"aws": {"s3": {"buckets": [{"versioning": {"enabled": {"value": false}}}]}}}

--- a/checks/cloud/aws/s3/encryption_customer_key_test.rego
+++ b/checks/cloud/aws/s3/encryption_customer_key_test.rego
@@ -23,4 +23,7 @@ test_allow_log_bucket_without_kms_key if {
 		"encryption": {},
 		"acl": {"value": "log-delivery-write"},
 	}]}}}
+
+	res := check.deny with input as inp
+	count(res) == 0
 }

--- a/checks/cloud/aws/s3/encryption_customer_key_test.rego
+++ b/checks/cloud/aws/s3/encryption_customer_key_test.rego
@@ -3,7 +3,6 @@ package builtin.aws.s3.aws0132_test
 import rego.v1
 
 import data.builtin.aws.s3.aws0132 as check
-import data.lib.test
 
 test_deny_bucket_without_kms_key if {
 	inp := {"aws": {"s3": {"buckets": [{"encryption": {}}]}}}

--- a/checks/cloud/aws/s3/ignore_public_acls_test.rego
+++ b/checks/cloud/aws/s3/ignore_public_acls_test.rego
@@ -3,7 +3,6 @@ package builtin.aws.s3.aws0091_test
 import rego.v1
 
 import data.builtin.aws.s3.aws0091 as check
-import data.lib.test
 
 test_deny_public_access_block_missing if {
 	inp := {"aws": {"s3": {"buckets": [{}]}}}

--- a/checks/cloud/aws/s3/no_public_access_with_acl_test.rego
+++ b/checks/cloud/aws/s3/no_public_access_with_acl_test.rego
@@ -3,7 +3,6 @@ package builtin.aws.s3.aws0092_test
 import rego.v1
 
 import data.builtin.aws.s3.aws0092 as check
-import data.lib.test
 
 test_deny_public_acl if {
 	inp := {"aws": {"s3": {"buckets": [{

--- a/checks/cloud/aws/s3/no_public_buckets_test.rego
+++ b/checks/cloud/aws/s3/no_public_buckets_test.rego
@@ -3,7 +3,6 @@ package builtin.aws.s3.aws0093_test
 import rego.v1
 
 import data.builtin.aws.s3.aws0093 as check
-import data.lib.test
 
 test_deny_public_access_block_missing if {
 	inp := {"aws": {"s3": {"buckets": [{}]}}}

--- a/checks/cloud/aws/s3/require_mfa_delete_test.rego
+++ b/checks/cloud/aws/s3/require_mfa_delete_test.rego
@@ -3,7 +3,6 @@ package builtin.aws.s3.aws0170_test
 import rego.v1
 
 import data.builtin.aws.s3.aws0170 as check
-import data.lib.test
 
 test_deny_bucket_without_mfa_delete if {
 	inp := {"aws": {"s3": {"buckets": [{"versioning": {"mfadelete": {"value": false}}}]}}}

--- a/checks/cloud/aws/s3/specify_public_access_block_test.rego
+++ b/checks/cloud/aws/s3/specify_public_access_block_test.rego
@@ -3,7 +3,6 @@ package builtin.aws.s3.aws0094_test
 import rego.v1
 
 import data.builtin.aws.s3.aws0094 as check
-import data.lib.test
 
 test_deny_public_access_block_missing if {
 	inp := {"aws": {"s3": {"buckets": [{}]}}}

--- a/checks/cloud/aws/sqs/enable_queue_encryption_test.rego
+++ b/checks/cloud/aws/sqs/enable_queue_encryption_test.rego
@@ -19,6 +19,8 @@ test_allow_without_key_but_managed if {
 		"kmskeyid": {"value": ""},
 		"managedencryption": {"value": true},
 	}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
 }
 
 test_deny_unencrypted if {

--- a/checks/cloud/azure/appservice/account_identity_registered_test.rego
+++ b/checks/cloud/azure/appservice/account_identity_registered_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.appservice.azure0002_test
 import rego.v1
 
 import data.builtin.azure.appservice.azure0002 as check
-import data.lib.test
 
 test_deny_identity_not_registerd if {
 	inp := {"azure": {"appservice": {"services": [{"identity": {"type": {"value": ""}}}]}}}

--- a/checks/cloud/azure/appservice/authentication_enabled_test.rego
+++ b/checks/cloud/azure/appservice/authentication_enabled_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.appservice.azure0003_test
 import rego.v1
 
 import data.builtin.azure.appservice.azure0003 as check
-import data.lib.test
 
 test_deny_authentication_disabled if {
 	inp := {"azure": {"appservice": {"services": [{"authentication": {"enabled": {"value": false}}}]}}}

--- a/checks/cloud/azure/appservice/enable_http2_test.rego
+++ b/checks/cloud/azure/appservice/enable_http2_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.appservice.azure0005_test
 import rego.v1
 
 import data.builtin.azure.appservice.azure0005 as check
-import data.lib.test
 
 test_deny_http2_disabled if {
 	inp := {"azure": {"appservice": {"services": [{"site": {"enablehttp2": {"value": false}}}]}}}

--- a/checks/cloud/azure/appservice/enforce_https_test.rego
+++ b/checks/cloud/azure/appservice/enforce_https_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.appservice.azure0004_test
 import rego.v1
 
 import data.builtin.azure.appservice.azure0004 as check
-import data.lib.test
 
 test_deny_app_does_not_enforce_https if {
 	inp := {"azure": {"appservice": {"functionapps": [{"httpsonly": {"value": false}}]}}}

--- a/checks/cloud/azure/appservice/require_client_cert_test.rego
+++ b/checks/cloud/azure/appservice/require_client_cert_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.appservice.azure0001_test
 import rego.v1
 
 import data.builtin.azure.appservice.azure0001 as check
-import data.lib.test
 
 test_deny_service_client_cert_disabled if {
 	inp := {"azure": {"appservice": {"services": [{"enableclientcert": {"value": false}}]}}}

--- a/checks/cloud/azure/appservice/use_secure_tls_policy_test.rego
+++ b/checks/cloud/azure/appservice/use_secure_tls_policy_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.appservice.azure0006_test
 import rego.v1
 
 import data.builtin.azure.appservice.azure0006 as check
-import data.lib.test
 
 test_deny_minimum_tls_version_is_tls1_0 if {
 	inp := {"azure": {"appservice": {"services": [{"site": {"minimumtlsversion": {"value": "1.0"}}}]}}}

--- a/checks/cloud/azure/authorization/limit_role_actions_test.rego
+++ b/checks/cloud/azure/authorization/limit_role_actions_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.authorization.azure0030_test
 import rego.v1
 
 import data.builtin.azure.authorization.azure0030 as check
-import data.lib.test
 
 test_deny_wildcard_action_with_all_scopes if {
 	inp := build_input({

--- a/checks/cloud/azure/compute/disable_password_authentication_test.rego
+++ b/checks/cloud/azure/compute/disable_password_authentication_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.compute.azure0039_test
 import rego.v1
 
 import data.builtin.azure.compute.azure0039 as check
-import data.lib.test
 
 test_deny_linux_vm_password_auth_enabled if {
 	res := check.deny with input as build_input(false)

--- a/checks/cloud/azure/compute/enable_disk_encryption_test.rego
+++ b/checks/cloud/azure/compute/enable_disk_encryption_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.compute.azure0038_test
 import rego.v1
 
 import data.builtin.azure.compute.azure0038 as check
-import data.lib.test
 
 test_deny_disk_encryption_disabled if {
 	res := check.deny with input as build_input(false)

--- a/checks/cloud/azure/compute/no_secrets_in_custom_data_test.rego
+++ b/checks/cloud/azure/compute/no_secrets_in_custom_data_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.compute.azure0037_test
 import rego.v1
 
 import data.builtin.azure.compute.azure0037 as check
-import data.lib.test
 
 test_deny_secrets_in_custom_data if {
 	inp := {"azure": {"compute": {"linuxvirtualmachines": [{"virtualmachine": {"customdata": {"value": `export DATABASE_PASSWORD=\"SomeSortOfPassword\"`}}}]}}}

--- a/checks/cloud/azure/container/configured_network_policy_test.rego
+++ b/checks/cloud/azure/container/configured_network_policy_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.container.azure0043_test
 import rego.v1
 
 import data.builtin.azure.container.azure0043 as check
-import data.lib.test
 
 test_deny_cluster_without_network_policy if {
 	inp := {"azure": {"container": {"kubernetesclusters": [{"networkprofile": {"networkpolicy": {"value": ""}}}]}}}

--- a/checks/cloud/azure/container/limit_authorized_ips_test.rego
+++ b/checks/cloud/azure/container/limit_authorized_ips_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.container.azure0041_test
 import rego.v1
 
 import data.builtin.azure.container.azure0041 as check
-import data.lib.test
 
 test_deny_authorized_ip_ranges_undefined if {
 	inp := {"azure": {"container": {"kubernetesclusters": [{}]}}}

--- a/checks/cloud/azure/container/logging_test.rego
+++ b/checks/cloud/azure/container/logging_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.container.azure0040_test
 import rego.v1
 
 import data.builtin.azure.container.azure0040 as check
-import data.lib.test
 
 test_deny_logging_via_oms_agent_disabled if {
 	inp := {"azure": {"container": {"kubernetesclusters": [{"addonprofile": {"omsagent": {"enabled": {"value": false}}}}]}}}

--- a/checks/cloud/azure/container/use_rbac_permissions_test.rego
+++ b/checks/cloud/azure/container/use_rbac_permissions_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.container.azure0042_test
 import rego.v1
 
 import data.builtin.azure.container.azure0042 as check
-import data.lib.test
 
 test_deny_rbac_disabled if {
 	inp := {"azure": {"container": {"kubernetesclusters": [{"rolebasedaccesscontrol": {"enabled": {"value": false}}}]}}}

--- a/checks/cloud/azure/database/all_threat_alerts_enabled_test.rego
+++ b/checks/cloud/azure/database/all_threat_alerts_enabled_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.database.azure0028_test
 import rego.v1
 
 import data.builtin.azure.database.azure0028 as check
-import data.lib.test
 
 test_deny_server_alerts_for_sql_injection_disabled if {
 	inp := {"azure": {"database": {"mssqlservers": [{"securityalertpolicies": [{"disabledalerts": [{"value": "Sql_Injection"}]}]}]}}}

--- a/checks/cloud/azure/database/enable_audit_test.rego
+++ b/checks/cloud/azure/database/enable_audit_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.database.azure0027_test
 import rego.v1
 
 import data.builtin.azure.database.azure0027 as check
-import data.lib.test
 
 test_deny_extended_audit_policy_not_configured if {
 	inp := {"azure": {"database": {"mssqlservers": [{"extendedauditingpolicies": []}]}}}

--- a/checks/cloud/azure/database/enable_ssl_enforcement_test.rego
+++ b/checks/cloud/azure/database/enable_ssl_enforcement_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.database.azure0020_test
 import rego.v1
 
 import data.builtin.azure.database.azure0020 as check
-import data.lib.test
 
 test_deny_maria_db_server_ssl_not_enforced if {
 	inp := {"azure": {"database": {"mariadbservers": [{"server": {"enablesslenforcement": {"value": false}}}]}}}

--- a/checks/cloud/azure/database/no_public_access.rego
+++ b/checks/cloud/azure/database/no_public_access.rego
@@ -31,7 +31,6 @@ package builtin.azure.database.azure0022
 import rego.v1
 
 import data.lib.azure.database
-import data.lib.cloud.metadata
 
 deny contains res if {
 	some server in database.all_servers

--- a/checks/cloud/azure/database/no_public_access_test.rego
+++ b/checks/cloud/azure/database/no_public_access_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.database.azure0022_test
 import rego.v1
 
 import data.builtin.azure.database.azure0022 as check
-import data.lib.test
 
 test_deny_mysql_server_public_access_enabled if {
 	res := check.deny with input as build_input("mysqlservers", true)

--- a/checks/cloud/azure/database/no_public_firewall_access_test.rego
+++ b/checks/cloud/azure/database/no_public_firewall_access_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.database.azure0029_test
 import rego.v1
 
 import data.builtin.azure.database.azure0029 as check
-import data.lib.test
 
 test_deny_mysql_server_allow_public_access if {
 	inp := {"azure": {"database": {"mysqlservers": [{"server": {"firewallrules": [{

--- a/checks/cloud/azure/database/postgres_configuration_connection_throttling_test.rego
+++ b/checks/cloud/azure/database/postgres_configuration_connection_throttling_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.database.azure0021_test
 import rego.v1
 
 import data.builtin.azure.database.azure0021 as check
-import data.lib.test
 
 test_deny_psql_server_connection_throttling_disabled if {
 	inp := {"azure": {"database": {"postgresqlservers": [{"config": {"connectionthrottling": {"value": false}}}]}}}

--- a/checks/cloud/azure/database/postgres_configuration_log_checkpoints_test.rego
+++ b/checks/cloud/azure/database/postgres_configuration_log_checkpoints_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.database.azure0024_test
 import rego.v1
 
 import data.builtin.azure.database.azure0024 as check
-import data.lib.test
 
 test_deny_psql_server_connection_logcheckpoints_disabled if {
 	inp := {"azure": {"database": {"postgresqlservers": [{"config": {"logcheckpoints": {"value": false}}}]}}}

--- a/checks/cloud/azure/database/postgres_configuration_log_connections_test.rego
+++ b/checks/cloud/azure/database/postgres_configuration_log_connections_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.database.azure0019_test
 import rego.v1
 
 import data.builtin.azure.database.azure0019 as check
-import data.lib.test
 
 test_deny_psql_server_connection_logconnections_disabled if {
 	inp := {"azure": {"database": {"postgresqlservers": [{"config": {"logconnections": {"value": false}}}]}}}

--- a/checks/cloud/azure/database/retention_period_set_test.rego
+++ b/checks/cloud/azure/database/retention_period_set_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.database.azure0025_test
 import rego.v1
 
 import data.builtin.azure.database.azure0025 as check
-import data.lib.test
 
 test_deny_retention_period_less_than_90_days if {
 	inp := {"azure": {"database": {"mssqlservers": [{"extendedauditingpolicies": [{"retentionindays": {"value": 30}}]}]}}}

--- a/checks/cloud/azure/database/secure_tls_policy_test.rego
+++ b/checks/cloud/azure/database/secure_tls_policy_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.database.azure0026_test
 import rego.v1
 
 import data.builtin.azure.database.azure0026 as check
-import data.lib.test
 
 test_deny_msql_server_minimum_tls_version_is_1_0 if {
 	inp := {"azure": {"database": {"mssqlservers": [build_server("1.0")]}}}

--- a/checks/cloud/azure/database/threat_alert_email_set_test.rego
+++ b/checks/cloud/azure/database/threat_alert_email_set_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.database.azure0018_test
 import rego.v1
 
 import data.builtin.azure.database.azure0018 as check
-import data.lib.test
 
 test_deny_policy_has_no_emails_for_threat_alerts if {
 	inp := {"azure": {"database": {"mssqlservers": [{"securityalertpolicies": [{}]}]}}}

--- a/checks/cloud/azure/database/threat_alert_email_to_owner_test.rego
+++ b/checks/cloud/azure/database/threat_alert_email_to_owner_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.database.azure0023_test
 import rego.v1
 
 import data.builtin.azure.database.azure0023 as check
-import data.lib.test
 
 test_deny_alert_account_admins_disabled if {
 	inp := {"azure": {"database": {"mssqlservers": [{"securityalertpolicies": [{"emailaccountadmins": {"value": false}}]}]}}}

--- a/checks/cloud/azure/datafactory/no_public_access_test.rego
+++ b/checks/cloud/azure/datafactory/no_public_access_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.datafactory.azure0035_test
 import rego.v1
 
 import data.builtin.azure.datafactory.azure0035 as check
-import data.lib.test
 
 test_deny_datafactory_public_access_enabled if {
 	res := check.deny with input as build_input(true)

--- a/checks/cloud/azure/datalake/enable_at_rest_encryption_test.rego
+++ b/checks/cloud/azure/datalake/enable_at_rest_encryption_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.datalake.azure0036_test
 import rego.v1
 
 import data.builtin.azure.datalake.azure0036 as check
-import data.lib.test
 
 test_deny_unencrypted_data_lake_store if {
 	res := check.deny with input as build_input(false)

--- a/checks/cloud/azure/keyvault/content_type_for_secret_test.rego
+++ b/checks/cloud/azure/keyvault/content_type_for_secret_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.keyvault.azure0015_test
 import rego.v1
 
 import data.builtin.azure.keyvault.azure0015 as check
-import data.lib.test
 
 test_deny_secret_wihout_content_type if {
 	res := check.deny with input as build_input("")

--- a/checks/cloud/azure/keyvault/ensure_key_expiry_test.rego
+++ b/checks/cloud/azure/keyvault/ensure_key_expiry_test.rego
@@ -4,7 +4,6 @@ import rego.v1
 
 import data.builtin.azure.keyvault.azure0014 as check
 import data.lib.datetime
-import data.lib.test
 
 test_deny_expiration_date_not_specified if {
 	inp := {"azure": {"keyvault": {"vaults": [{"keys": [{}]}]}}}

--- a/checks/cloud/azure/keyvault/ensure_secret_expiry_test.rego
+++ b/checks/cloud/azure/keyvault/ensure_secret_expiry_test.rego
@@ -4,7 +4,6 @@ import rego.v1
 
 import data.builtin.azure.keyvault.azure0017 as check
 import data.lib.datetime
-import data.lib.test
 
 test_deny_expiration_date_not_specified if {
 	inp := {"azure": {"keyvault": {"vaults": [{"secrets": [{}]}]}}}

--- a/checks/cloud/azure/keyvault/no_purge_test.rego
+++ b/checks/cloud/azure/keyvault/no_purge_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.keyvault.azure0016_test
 import rego.v1
 
 import data.builtin.azure.keyvault.azure0016 as check
-import data.lib.test
 
 test_deny_purge_protection_disabled if {
 	inp := {"azure": {"keyvault": {"vaults": [{}]}}}

--- a/checks/cloud/azure/keyvault/specify_network_acl_test.rego
+++ b/checks/cloud/azure/keyvault/specify_network_acl_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.keyvault.azure0013_test
 import rego.v1
 
 import data.builtin.azure.keyvault.azure0013 as check
-import data.lib.test
 
 test_deny_acl_default_action_is_allow if {
 	res := check.deny with input as build_input("Allow")

--- a/checks/cloud/azure/monitor/activity_log_retention_set_test.rego
+++ b/checks/cloud/azure/monitor/activity_log_retention_set_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.monitor.azure0031_test
 import rego.v1
 
 import data.builtin.azure.monitor.azure0031 as check
-import data.lib.test
 
 test_deny_retention_policy_disabled if {
 	inp := {"azure": {"monitor": {"logprofiles": [{"retentionpolicy": {"enabled": {"value": false}}}]}}}

--- a/checks/cloud/azure/monitor/capture_all_activities_test.rego
+++ b/checks/cloud/azure/monitor/capture_all_activities_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.monitor.azure0033_test
 import rego.v1
 
 import data.builtin.azure.monitor.azure0033 as check
-import data.lib.test
 
 test_deny_log_profile_captures_only_write_activities if {
 	inp := {"azure": {"monitor": {"logprofiles": [{"categories": [{"value": "Write"}]}]}}}

--- a/checks/cloud/azure/monitor/capture_all_regions_test.rego
+++ b/checks/cloud/azure/monitor/capture_all_regions_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.monitor.azure0032_test
 import rego.v1
 
 import data.builtin.azure.monitor.azure0032 as check
-import data.lib.test
 
 test_deny_profile_captures_only_one_region if {
 	inp := {"azure": {"monitor": {"logprofiles": [{"locations": [{"value": "eastus"}]}]}}}

--- a/checks/cloud/azure/network/disable_rdp_from_internet_test.rego
+++ b/checks/cloud/azure/network/disable_rdp_from_internet_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.network.azure0048_test
 import rego.v1
 
 import data.builtin.azure.network.azure0048 as check
-import data.lib.test
 
 test_deny_inbound_rule_allows_rdp_access_from_internet if {
 	inp := {"azure": {"network": {"securitygroups": [{"rules": [{

--- a/checks/cloud/azure/network/no_public_egress_test.rego
+++ b/checks/cloud/azure/network/no_public_egress_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.network.azure0051_test
 import rego.v1
 
 import data.builtin.azure.network.azure0051 as check
-import data.lib.test
 
 test_deny_outbound_rule_with_wildcard_destination_address if {
 	inp := {"azure": {"network": {"securitygroups": [{"rules": [{

--- a/checks/cloud/azure/network/no_public_ingress_test.rego
+++ b/checks/cloud/azure/network/no_public_ingress_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.network.azure0047_test
 import rego.v1
 
 import data.builtin.azure.network.azure0047 as check
-import data.lib.test
 
 test_deny_inbound_rule_with_wildcard_source_address if {
 	inp := {"azure": {"network": {"securitygroups": [{"rules": [{

--- a/checks/cloud/azure/network/retention_policy_set_test.rego
+++ b/checks/cloud/azure/network/retention_policy_set_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.network.azure0049_test
 import rego.v1
 
 import data.builtin.azure.network.azure0049 as check
-import data.lib.test
 
 test_deny_flow_log_retention_policy_disabled if {
 	inp := {"azure": {"network": {"networkwatcherflowlogs": [{"retentionpolicy": {"enabled": {"value": false}}}]}}}

--- a/checks/cloud/azure/network/ssh_blocked_from_internet_test.rego
+++ b/checks/cloud/azure/network/ssh_blocked_from_internet_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.network.azure0050_test
 import rego.v1
 
 import data.builtin.azure.network.azure0050 as check
-import data.lib.test
 
 test_deny_inbound_rule_allows_rdp_access_from_internet if {
 	inp := {"azure": {"network": {"securitygroups": [{"rules": [{

--- a/checks/cloud/azure/securitycenter/alert_on_severe_notifications_test.rego
+++ b/checks/cloud/azure/securitycenter/alert_on_severe_notifications_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.securitycenter.azure0044_test
 import rego.v1
 
 import data.builtin.azure.securitycenter.azure0044 as check
-import data.lib.test
 
 test_deny_security_center_alert_notifications_disabled if {
 	res := check.deny with input as build_input(false)

--- a/checks/cloud/azure/securitycenter/enable_standard_subscription_test.rego
+++ b/checks/cloud/azure/securitycenter/enable_standard_subscription_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.securitycenter.azure0045_test
 import rego.v1
 
 import data.builtin.azure.securitycenter.azure0045 as check
-import data.lib.test
 
 test_deny_subscription_use_free_tier if {
 	inp := {"azure": {"securitycenter": {"subscriptions": [{"tier": {"value": check.free_tier}}]}}}

--- a/checks/cloud/azure/securitycenter/set_required_contact_details_test.rego
+++ b/checks/cloud/azure/securitycenter/set_required_contact_details_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.securitycenter.azure0046_test
 import rego.v1
 
 import data.builtin.azure.securitycenter.azure0046 as check
-import data.lib.test
 
 test_deny_contact_without_phone if {
 	inp := {"azure": {"securitycenter": {"contacts": [{"phone": {"value": ""}}]}}}

--- a/checks/cloud/azure/synapse/virtual_network_enabled_test.rego
+++ b/checks/cloud/azure/synapse/virtual_network_enabled_test.rego
@@ -3,7 +3,6 @@ package builtin.azure.synapse.azure0034_test
 import rego.v1
 
 import data.builtin.azure.synapse.azure0034 as check
-import data.lib.test
 
 test_deny_managed_virtual_network_disabled if {
 	inp := {"azure": {"synapse": {"workspaces": [{"enablemanagedvirtualnetwork": {"value": false}}]}}}

--- a/checks/cloud/cloudstack/compute/no_sensitive_info_test.rego
+++ b/checks/cloud/cloudstack/compute/no_sensitive_info_test.rego
@@ -3,7 +3,6 @@ package builtin.cloudstack.compute.cloudstack0001_test
 import rego.v1
 
 import data.builtin.cloudstack.compute.cloudstack0001 as check
-import data.lib.test
 
 test_deny_compute_instance_with_sensitive_data if {
 	inp := {"cloudstack": {"compute": {"instances": [{"userdata": {"value": " export DATABASE_PASSWORD=\"SomeSortOfPassword\""}}]}}}

--- a/checks/cloud/digitalocean/spaces/acl_no_public_read_test.rego
+++ b/checks/cloud/digitalocean/spaces/acl_no_public_read_test.rego
@@ -3,7 +3,6 @@ package builtin.digitalocean.spaces.digitalocean0006_test
 import rego.v1
 
 import data.builtin.digitalocean.spaces.digitalocean0006 as check
-import data.lib.test
 
 test_allow_acl_private_for_bucket if {
 	inp := {"digitalocean": {"spaces": {"buckets": [{"acl": {"value": "private"}}]}}}

--- a/checks/cloud/digitalocean/spaces/disable_force_destroy_test.rego
+++ b/checks/cloud/digitalocean/spaces/disable_force_destroy_test.rego
@@ -3,7 +3,6 @@ package builtin.digitalocean.spaces.digitalocean0009_test
 import rego.v1
 
 import data.builtin.digitalocean.spaces.digitalocean0009 as check
-import data.lib.test
 
 test_allow_force_destroy_disabled if {
 	inp := {"digitalocean": {"spaces": {"buckets": [{"forcedestroy": {"value": false}}]}}}

--- a/checks/cloud/digitalocean/spaces/versioning_enabled_test.rego
+++ b/checks/cloud/digitalocean/spaces/versioning_enabled_test.rego
@@ -3,7 +3,6 @@ package builtin.digitalocean.spaces.digitalocean0007_test
 import rego.v1
 
 import data.builtin.digitalocean.spaces.digitalocean0007 as check
-import data.lib.test
 
 test_allow_versioning_enabled if {
 	inp := {"digitalocean": {"spaces": {"buckets": [{"versioning": {"enabled": {"value": true}}}]}}}

--- a/checks/cloud/github/actions/no_plain_text_action_secrets_test.rego
+++ b/checks/cloud/github/actions/no_plain_text_action_secrets_test.rego
@@ -3,7 +3,6 @@ package builtin.github.actions.github0002_test
 import rego.v1
 
 import data.builtin.github.actions.github0002 as check
-import data.lib.test
 
 test_allow_secret_without_plain_text if {
 	inp := {"github": {"environmentsecrets": [{"plaintextvalue": {"value": ""}}]}}

--- a/checks/cloud/github/branch_protections/require_signed_commits_test.rego
+++ b/checks/cloud/github/branch_protections/require_signed_commits_test.rego
@@ -3,7 +3,6 @@ package builtin.github.branch_protections.github0004_test
 import rego.v1
 
 import data.builtin.github.branch_protections.github0004 as check
-import data.lib.test
 
 test_allow_signed_commits_enabled if {
 	inp := {"github": {"branchprotections": [{"requiresignedcommits": {"value": true}}]}}

--- a/checks/cloud/github/repositories/enable_vulnerability_alerts_test.rego
+++ b/checks/cloud/github/repositories/enable_vulnerability_alerts_test.rego
@@ -3,7 +3,6 @@ package builtin.github.repositories.github0003_test
 import rego.v1
 
 import data.builtin.github.repositories.github0003 as check
-import data.lib.test
 
 test_allow_vulnerability_alerts_enabled if {
 	inp := {"github": {"repositories": [{

--- a/checks/cloud/github/repositories/private_repository_test.rego
+++ b/checks/cloud/github/repositories/private_repository_test.rego
@@ -3,7 +3,6 @@ package builtin.github.repositories.github0001_test
 import rego.v1
 
 import data.builtin.github.repositories.github0001 as check
-import data.lib.test
 
 test_allow_private_repo if {
 	inp := {"github": {"repositories": [{"public": {"value": false}}]}}

--- a/checks/cloud/google/bigquery/no_public_access_test.rego
+++ b/checks/cloud/google/bigquery/no_public_access_test.rego
@@ -3,7 +3,6 @@ package builtin.google.bigquery.google0046_test
 import rego.v1
 
 import data.builtin.google.bigquery.google0046 as check
-import data.lib.test
 
 test_deny_public_access if {
 	inp := {"google": {"bigquery": {"datasets": [{"accessgrants": [{"specialgroup": {"value": "allAuthenticatedUsers"}}]}]}}}

--- a/checks/cloud/google/compute/disk_encryption_customer_key_test.rego
+++ b/checks/cloud/google/compute/disk_encryption_customer_key_test.rego
@@ -3,7 +3,6 @@ package builtin.google.compute.google0034_test
 import rego.v1
 
 import data.builtin.google.compute.google0034 as check
-import data.lib.test
 
 test_deny_disk_is_not_encrypted if {
 	inp := {"google": {"compute": {"disks": [{"encryption": {"kmskeylink": {"value": ""}}}]}}}

--- a/checks/cloud/google/compute/disk_encryption_no_plaintext_key_test.rego
+++ b/checks/cloud/google/compute/disk_encryption_no_plaintext_key_test.rego
@@ -3,7 +3,6 @@ package builtin.google.compute.google0037_test
 import rego.v1
 
 import data.builtin.google.compute.google0037 as check
-import data.lib.test
 
 test_deny_disk_with_plaintext_encryption_key if {
 	inp := {"google": {"compute": {"disks": [{"encryption": {"rawkey": {"value": "b2ggbm8gdGhpcyBpcyBiYWQ"}}}]}}}

--- a/checks/cloud/google/compute/enable_shielded_vm_im_test.rego
+++ b/checks/cloud/google/compute/enable_shielded_vm_im_test.rego
@@ -3,7 +3,6 @@ package builtin.google.compute.google0045_test
 import rego.v1
 
 import data.builtin.google.compute.google0045 as check
-import data.lib.test
 
 test_deny_instance_shielded_vm_integrity_monitoring_disabled if {
 	inp := {"google": {"compute": {"instances": [{"shieldedvm": {"integritymonitoringenabled": {"value": false}}}]}}}

--- a/checks/cloud/google/compute/enable_shielded_vm_sb_test.rego
+++ b/checks/cloud/google/compute/enable_shielded_vm_sb_test.rego
@@ -3,7 +3,6 @@ package builtin.google.compute.google0067_test
 import rego.v1
 
 import data.builtin.google.compute.google0067 as check
-import data.lib.test
 
 test_deny_instance_shielded_vm_secure_boot_disabled if {
 	inp := {"google": {"compute": {"instances": [{"shieldedvm": {"securebootenabled": {"value": false}}}]}}}

--- a/checks/cloud/google/compute/enable_shielded_vm_vtpm_test.rego
+++ b/checks/cloud/google/compute/enable_shielded_vm_vtpm_test.rego
@@ -3,7 +3,6 @@ package builtin.google.compute.google0041_test
 import rego.v1
 
 import data.builtin.google.compute.google0041 as check
-import data.lib.test
 
 test_deny_instance_shielded_vm_vptm_disabled if {
 	inp := {"google": {"compute": {"instances": [{"shieldedvm": {"vtpmenabled": {"value": false}}}]}}}

--- a/checks/cloud/google/compute/enable_vpc_flow_logs_test.rego
+++ b/checks/cloud/google/compute/enable_vpc_flow_logs_test.rego
@@ -3,7 +3,6 @@ package builtin.google.compute.google0029_test
 import rego.v1
 
 import data.builtin.google.compute.google0029 as check
-import data.lib.test
 
 test_deny_vpc_flow_logs_disabled if {
 	inp := {"google": {"compute": {"networks": [{"subnetworks": [{"enableflowlogs": {"value": false}}]}]}}}

--- a/checks/cloud/google/compute/no_default_service_account_test.rego
+++ b/checks/cloud/google/compute/no_default_service_account_test.rego
@@ -3,7 +3,6 @@ package builtin.google.compute.google0044_test
 import rego.v1
 
 import data.builtin.google.compute.google0044 as check
-import data.lib.test
 
 test_deny_instance_use_default_service_account if {
 	inp := {"google": {"compute": {"instances": [{"serviceaccount": {"isdefault": {"value": true}}}]}}}

--- a/checks/cloud/google/compute/no_ip_forwarding_test.rego
+++ b/checks/cloud/google/compute/no_ip_forwarding_test.rego
@@ -3,7 +3,6 @@ package builtin.google.compute.google0043_test
 import rego.v1
 
 import data.builtin.google.compute.google0043 as check
-import data.lib.test
 
 test_deny_instance_ip_forwarding_enabled if {
 	inp := {"google": {"compute": {"instances": [{"canipforward": {"value": true}}]}}}

--- a/checks/cloud/google/compute/no_oslogin_override_test.rego
+++ b/checks/cloud/google/compute/no_oslogin_override_test.rego
@@ -3,7 +3,6 @@ package builtin.google.compute.google0036_test
 import rego.v1
 
 import data.builtin.google.compute.google0036 as check
-import data.lib.test
 
 test_deny_instance_os_login_disabled if {
 	inp := {"google": {"compute": {"instances": [{"osloginenabled": {"value": false}}]}}}

--- a/checks/cloud/google/compute/no_project_wide_ssh_keys_test.rego
+++ b/checks/cloud/google/compute/no_project_wide_ssh_keys_test.rego
@@ -3,7 +3,6 @@ package builtin.google.compute.google0030_test
 import rego.v1
 
 import data.builtin.google.compute.google0030 as check
-import data.lib.test
 
 test_deny_project_level_ssh_key_blocking_disabled if {
 	inp := {"google": {"compute": {"instances": [{"enableprojectsshkeyblocking": {"value": false}}]}}}

--- a/checks/cloud/google/compute/no_public_egress_test.rego
+++ b/checks/cloud/google/compute/no_public_egress_test.rego
@@ -3,7 +3,6 @@ package builtin.google.compute.google0035_test
 import rego.v1
 
 import data.builtin.google.compute.google0035 as check
-import data.lib.test
 
 test_deny_egress_rule_with_multiple_public_destinations if {
 	inp := {"google": {"compute": {"networks": [{"firewall": {"egressrules": [{

--- a/checks/cloud/google/compute/no_public_ingress_test.rego
+++ b/checks/cloud/google/compute/no_public_ingress_test.rego
@@ -3,7 +3,6 @@ package builtin.google.compute.google0027_test
 import rego.v1
 
 import data.builtin.google.compute.google0027 as check
-import data.lib.test
 
 test_deny_ingress_rule_with_multiple_public_sources if {
 	inp := {"google": {"compute": {"networks": [{"firewall": {"ingressrules": [{

--- a/checks/cloud/google/compute/no_public_ip_test.rego
+++ b/checks/cloud/google/compute/no_public_ip_test.rego
@@ -3,7 +3,6 @@ package builtin.google.compute.google0031_test
 import rego.v1
 
 import data.builtin.google.compute.google0031 as check
-import data.lib.test
 
 test_deny_instance_network_interface_has_public_ip if {
 	inp := {"google": {"compute": {"instances": [{"networkinterfaces": [{"haspublicip": {"value": true}}]}]}}}

--- a/checks/cloud/google/compute/no_serial_port_test.rego
+++ b/checks/cloud/google/compute/no_serial_port_test.rego
@@ -3,7 +3,6 @@ package builtin.google.compute.google0032_test
 import rego.v1
 
 import data.builtin.google.compute.google0032 as check
-import data.lib.test
 
 test_deny_instance_serial_port_enabled if {
 	inp := {"google": {"compute": {"instances": [{"enableserialport": {"value": true}}]}}}

--- a/checks/cloud/google/compute/project_level_oslogin_test.rego
+++ b/checks/cloud/google/compute/project_level_oslogin_test.rego
@@ -3,7 +3,6 @@ package builtin.google.compute.google0042_test
 import rego.v1
 
 import data.builtin.google.compute.google0042 as check
-import data.lib.test
 
 test_deny_compute_os_login_disabled if {
 	inp := {"google": {"compute": {"projectmetadata": {"enableoslogin": {"value": false}}}}}

--- a/checks/cloud/google/compute/use_secure_tls_policy_test.rego
+++ b/checks/cloud/google/compute/use_secure_tls_policy_test.rego
@@ -3,7 +3,6 @@ package builtin.google.compute.google0039_test
 import rego.v1
 
 import data.builtin.google.compute.google0039 as check
-import data.lib.test
 
 test_deny_ssl_policy_minimum_tls_version_is_1 if {
 	inp := {"google": {"compute": {"sslpolicies": [{"minimumtlsversion": {"value": "TLS_1_0"}}]}}}

--- a/checks/cloud/google/compute/vm_disk_encryption_customer_key_test.rego
+++ b/checks/cloud/google/compute/vm_disk_encryption_customer_key_test.rego
@@ -3,7 +3,6 @@ package builtin.google.compute.google0033_test
 import rego.v1
 
 import data.builtin.google.compute.google0033 as check
-import data.lib.test
 
 test_deny_instance_boot_disk_is_not_encrypted if {
 	inp := {"google": {"compute": {"instances": [{"bootdisks": [{"encryption": {"kmskeylink": {"value": ""}}}]}]}}}

--- a/checks/cloud/google/dns/enable_dnssec_test.rego
+++ b/checks/cloud/google/dns/enable_dnssec_test.rego
@@ -3,7 +3,6 @@ package builtin.google.dns.google0013_test
 import rego.v1
 
 import data.builtin.google.dns.google0013 as check
-import data.lib.test
 
 test_deny_dns_sec_disabled if {
 	inp := build_input({

--- a/checks/cloud/google/dns/no_rsa_sha1_test.rego
+++ b/checks/cloud/google/dns/no_rsa_sha1_test.rego
@@ -3,7 +3,6 @@ package builtin.google.dns.google0012_test
 import rego.v1
 
 import data.builtin.google.dns.google0012 as check
-import data.lib.test
 
 test_deny_rsa_sha1 if {
 	inp := build_input({"algorithm": {"value": "rsasha1"}})

--- a/checks/cloud/google/gke/enable_auto_repair_test.rego
+++ b/checks/cloud/google/gke/enable_auto_repair_test.rego
@@ -3,7 +3,6 @@ package builtin.google.gke.google0063_test
 import rego.v1
 
 import data.builtin.google.gke.google0063 as check
-import data.lib.test
 
 test_deny_auto_repair_disabled if {
 	inp := {"google": {"gke": {"clusters": [{"nodepools": [{"management": {"enableautorepair": {"value": false}}}]}]}}}

--- a/checks/cloud/google/gke/enable_auto_upgrade_test.rego
+++ b/checks/cloud/google/gke/enable_auto_upgrade_test.rego
@@ -3,7 +3,6 @@ package builtin.google.gke.google0058_test
 import rego.v1
 
 import data.builtin.google.gke.google0058 as check
-import data.lib.test
 
 test_deny_auto_upgrade_disabled if {
 	inp := {"google": {"gke": {"clusters": [{"nodepools": [{"management": {"enableautoupgrade": {"value": false}}}]}]}}}

--- a/checks/cloud/google/gke/enable_ip_aliasing_test.rego
+++ b/checks/cloud/google/gke/enable_ip_aliasing_test.rego
@@ -3,7 +3,6 @@ package builtin.google.gke.google0049_test
 import rego.v1
 
 import data.builtin.google.gke.google0049 as check
-import data.lib.test
 
 test_deny_ip_aliasing_disabled if {
 	inp := {"google": {"gke": {"clusters": [{"ipallocationpolicy": {"enabled": {"value": false}}}]}}}

--- a/checks/cloud/google/gke/enable_master_networks_test.rego
+++ b/checks/cloud/google/gke/enable_master_networks_test.rego
@@ -3,7 +3,6 @@ package builtin.google.gke.google0061_test
 import rego.v1
 
 import data.builtin.google.gke.google0061 as check
-import data.lib.test
 
 test_deny_master_networks_disabled if {
 	inp := {"google": {"gke": {"clusters": [{"masterauthorizednetworks": {"enabled": {"value": false}}}]}}}

--- a/checks/cloud/google/gke/enable_network_policy_test.rego
+++ b/checks/cloud/google/gke/enable_network_policy_test.rego
@@ -3,7 +3,6 @@ package builtin.google.gke.google0056_test
 import rego.v1
 
 import data.builtin.google.gke.google0056 as check
-import data.lib.test
 
 test_deny_network_policy_disabled if {
 	inp := {"google": {"gke": {"clusters": [{"networkpolicy": {"enabled": {"value": false}}}]}}}

--- a/checks/cloud/google/gke/enable_private_cluster_test.rego
+++ b/checks/cloud/google/gke/enable_private_cluster_test.rego
@@ -3,7 +3,6 @@ package builtin.google.gke.google0059_test
 import rego.v1
 
 import data.builtin.google.gke.google0059 as check
-import data.lib.test
 
 test_deny_private_cluster_disabled if {
 	inp := {"google": {"gke": {"clusters": [{"privatecluster": {"enableprivatenodes": {"value": false}}}]}}}

--- a/checks/cloud/google/gke/enable_stackdriver_logging_test.rego
+++ b/checks/cloud/google/gke/enable_stackdriver_logging_test.rego
@@ -3,7 +3,6 @@ package builtin.google.gke.google0060_test
 import rego.v1
 
 import data.builtin.google.gke.google0060 as check
-import data.lib.test
 
 test_deny_stackdriver_logging_disabled if {
 	inp := {"google": {"gke": {"clusters": [{"loggingservice": {"value": ""}}]}}}

--- a/checks/cloud/google/gke/enable_stackdriver_monitoring_test.rego
+++ b/checks/cloud/google/gke/enable_stackdriver_monitoring_test.rego
@@ -3,7 +3,6 @@ package builtin.google.gke.google0052_test
 import rego.v1
 
 import data.builtin.google.gke.google0052 as check
-import data.lib.test
 
 test_deny_stackdriver_monitoring_disabled if {
 	inp := {"google": {"gke": {"clusters": [{"monitoringservice": {"value": ""}}]}}}

--- a/checks/cloud/google/gke/metadata_endpoints_disabled_test.rego
+++ b/checks/cloud/google/gke/metadata_endpoints_disabled_test.rego
@@ -3,7 +3,6 @@ package builtin.google.gke.google0048_test
 import rego.v1
 
 import data.builtin.google.gke.google0048 as check
-import data.lib.test
 
 test_deny_cluster_legacy_metadata_endpoints_enabled if {
 	inp := {"google": {"gke": {"clusters": [{"nodeconfig": {"enablelegacyendpoints": {"value": true}}}]}}}

--- a/checks/cloud/google/gke/no_legacy_authentication_test.rego
+++ b/checks/cloud/google/gke/no_legacy_authentication_test.rego
@@ -3,7 +3,6 @@ package builtin.google.gke.google0064_test
 import rego.v1
 
 import data.builtin.google.gke.google0064 as check
-import data.lib.test
 
 test_deny_master_auth_by_certificate if {
 	inp := {"google": {"gke": {"clusters": [{"masterauth": {"clientcertificate": {"issuecertificate": {"value": true}}}}]}}}

--- a/checks/cloud/google/gke/no_public_control_plane_test.rego
+++ b/checks/cloud/google/gke/no_public_control_plane_test.rego
@@ -3,7 +3,6 @@ package builtin.google.gke.google0053_test
 import rego.v1
 
 import data.builtin.google.gke.google0053 as check
-import data.lib.test
 
 test_deny_master_auth_network_with_public_cidr if {
 	inp := {"google": {"gke": {"clusters": [{"masterauthorizednetworks": {"cidrs": [{"value": "0.0.0.0/0"}]}}]}}}

--- a/checks/cloud/google/gke/node_metadata_security_test.rego
+++ b/checks/cloud/google/gke/node_metadata_security_test.rego
@@ -3,7 +3,6 @@ package builtin.google.gke.google0057_test
 import rego.v1
 
 import data.builtin.google.gke.google0057 as check
-import data.lib.test
 
 test_deny_cluster_node_pools_metadata_exposed_by_default if {
 	inp := {"google": {"gke": {"clusters": [{"nodeconfig": {"workloadmetadataconfig": {"nodemetadata": {"value": "UNSPECIFIED"}}}}]}}}

--- a/checks/cloud/google/gke/node_pool_uses_cos_test.rego
+++ b/checks/cloud/google/gke/node_pool_uses_cos_test.rego
@@ -3,7 +3,6 @@ package builtin.google.gke.google0054_test
 import rego.v1
 
 import data.builtin.google.gke.google0054 as check
-import data.lib.test
 
 test_deny_cluster_node_config_image_type_is_ubuntu if {
 	inp := {"google": {"gke": {"clusters": [{"nodeconfig": {"imagetype": {"value": "UBUNTU"}}}]}}}

--- a/checks/cloud/google/gke/node_shielding_enabled_test.rego
+++ b/checks/cloud/google/gke/node_shielding_enabled_test.rego
@@ -3,7 +3,6 @@ package builtin.google.gke.google0055_test
 import rego.v1
 
 import data.builtin.google.gke.google0055 as check
-import data.lib.test
 
 test_deny_cluster_shielded_nodes_disabled if {
 	inp := {"google": {"gke": {"clusters": [{"enableshieldednodes": {"value": false}}]}}}

--- a/checks/cloud/google/gke/use_cluster_labels_test.rego
+++ b/checks/cloud/google/gke/use_cluster_labels_test.rego
@@ -3,7 +3,6 @@ package builtin.google.gke.google0051_test
 import rego.v1
 
 import data.builtin.google.gke.google0051 as check
-import data.lib.test
 
 test_deny_cluster_does_not_use_labels if {
 	inp := {"google": {"gke": {"clusters": [{"resourcelabels": {"value": {}}}]}}}

--- a/checks/cloud/google/gke/use_rbac_permissions_test.rego
+++ b/checks/cloud/google/gke/use_rbac_permissions_test.rego
@@ -3,7 +3,6 @@ package builtin.google.gke.google0062_test
 import rego.v1
 
 import data.builtin.google.gke.google0062 as check
-import data.lib.test
 
 test_deny_legacy_abac_enabled if {
 	inp := {"google": {"gke": {"clusters": [{"enablelegacyabac": {"value": true}}]}}}

--- a/checks/cloud/google/gke/use_service_account_test.rego
+++ b/checks/cloud/google/gke/use_service_account_test.rego
@@ -3,7 +3,6 @@ package builtin.google.gke.google0050_test
 import rego.v1
 
 import data.builtin.google.gke.google0050 as check
-import data.lib.test
 
 test_node_config_with_default_service_account if {
 	inp := {"google": {"gke": {"clusters": [{

--- a/checks/cloud/google/iam/no_conditions_on_workload_identity_pool_provider_test.rego
+++ b/checks/cloud/google/iam/no_conditions_on_workload_identity_pool_provider_test.rego
@@ -3,7 +3,6 @@ package builtin.google.iam.google0068_test
 import rego.v1
 
 import data.builtin.google.iam.google0068 as check
-import data.lib.test
 
 test_deny_empty_attribute_condition if {
 	inp := build_input({"attributecondition": {"value": ""}})

--- a/checks/cloud/google/iam/no_default_network_test.rego
+++ b/checks/cloud/google/iam/no_default_network_test.rego
@@ -3,7 +3,6 @@ package builtin.google.iam.google0010_test
 import rego.v1
 
 import data.builtin.google.iam.google0010 as check
-import data.lib.test
 
 test_allow_auto_create_network_disabled if {
 	inp := {"google": {"iam": {"projects": [{"autocreatenetwork": {"value": false}}]}}}

--- a/checks/cloud/google/iam/no_folder_level_default_service_account_assignment_test.rego
+++ b/checks/cloud/google/iam/no_folder_level_default_service_account_assignment_test.rego
@@ -3,7 +3,6 @@ package builtin.google.iam.google0004_test
 import rego.v1
 
 import data.builtin.google.iam.google0004 as check
-import data.lib.test
 
 service_email := "123-compute@developer.gserviceaccount.com"
 

--- a/checks/cloud/google/iam/no_folder_level_service_account_impersonation_test.rego
+++ b/checks/cloud/google/iam/no_folder_level_service_account_impersonation_test.rego
@@ -4,7 +4,6 @@ import rego.v1
 
 import data.builtin.google.IAM.google0005 as check
 import data.lib.google.iam
-import data.lib.test
 
 test_deny_role_is_service_account_user_for_folder_member if {
 	inp := build_input({"members": [{"role": {"value": iam.service_account_user_role}}]})

--- a/checks/cloud/google/iam/no_org_level_default_service_account_assignment_test.rego
+++ b/checks/cloud/google/iam/no_org_level_default_service_account_assignment_test.rego
@@ -3,7 +3,6 @@ package builtin.google.iam.google0008_test
 import rego.v1
 
 import data.builtin.google.iam.google0008 as check
-import data.lib.test
 
 test_deny_default_member_for_org_binding if {
 	inp := build_input({"bindings": [{

--- a/checks/cloud/google/iam/no_org_level_service_account_impersonation_test.rego
+++ b/checks/cloud/google/iam/no_org_level_service_account_impersonation_test.rego
@@ -4,7 +4,6 @@ import rego.v1
 
 import data.builtin.google.iam.google0009 as check
 import data.lib.google.iam
-import data.lib.test
 
 test_deny_service_account_for_org_member if {
 	inp := build_input({"members": [{"role": {"value": iam.service_account_user_role}}]})

--- a/checks/cloud/google/iam/no_privileged_service_accounts_test.rego
+++ b/checks/cloud/google/iam/no_privileged_service_accounts_test.rego
@@ -4,7 +4,6 @@ import rego.v1
 
 import data.builtin.google.iam.google0007 as check
 import data.lib.google.iam
-import data.lib.test
 
 service_account := "serviceAccount:${google_service_account.test.email}"
 

--- a/checks/cloud/google/iam/no_project_level_default_service_account_assignment_test.rego
+++ b/checks/cloud/google/iam/no_project_level_default_service_account_assignment_test.rego
@@ -3,7 +3,6 @@ package builtin.google.iam.google0006_test
 import rego.v1
 
 import data.builtin.google.iam.google0006 as check
-import data.lib.test
 
 test_deny_default_service_account_enabled_for_folder_member if {
 	inp := build_input({"members": [{

--- a/checks/cloud/google/iam/no_project_level_service_account_impersonation_test.rego
+++ b/checks/cloud/google/iam/no_project_level_service_account_impersonation_test.rego
@@ -4,7 +4,6 @@ import rego.v1
 
 import data.builtin.google.iam.google0011 as check
 import data.lib.google.iam
-import data.lib.test
 
 test_deny_role_is_service_account_user_for_project_member if {
 	inp := build_input({"members": [{"role": {"value": iam.service_account_user_role}}]})

--- a/checks/cloud/google/iam/no_user_granted_permissions_test.rego
+++ b/checks/cloud/google/iam/no_user_granted_permissions_test.rego
@@ -3,7 +3,6 @@ package builtin.google.iam.google0003_test
 import rego.v1
 
 import data.builtin.google.iam.google0003 as check
-import data.lib.test
 
 user_member := {"value": "user:test@example.com"}
 

--- a/checks/cloud/google/kms/rotate_kms_keys_test.rego
+++ b/checks/cloud/google/kms/rotate_kms_keys_test.rego
@@ -3,7 +3,6 @@ package builtin.google.kms.google0065_test
 import rego.v1
 
 import data.builtin.google.kms.google0065 as check
-import data.lib.test
 
 test_deny_key_rotation_period_greather_than_90_days if {
 	inp := {"google": {"kms": {"keyrings": [{"keys": [{"rotationperiodseconds": {"value": 7862400}}]}]}}} # 91 days

--- a/checks/cloud/google/sql/enable_backup_test.rego
+++ b/checks/cloud/google/sql/enable_backup_test.rego
@@ -3,7 +3,6 @@ package builtin.google.sql.google0024_test
 import rego.v1
 
 import data.builtin.google.sql.google0024 as check
-import data.lib.test
 
 test_allow_backups_enabled if {
 	inp := build_input({

--- a/checks/cloud/google/sql/enable_pg_temp_file_logging_test.rego
+++ b/checks/cloud/google/sql/enable_pg_temp_file_logging_test.rego
@@ -3,7 +3,6 @@ package builtin.google.sql.google0014_test
 import rego.v1
 
 import data.builtin.google.sql.google0014 as check
-import data.lib.test
 
 test_deny_temp_files_logging_disabled_for_all_files if {
 	inp := build_input({

--- a/checks/cloud/google/sql/encrypt_in_transit_data_test.rego
+++ b/checks/cloud/google/sql/encrypt_in_transit_data_test.rego
@@ -3,7 +3,6 @@ package builtin.google.sql.google0015_test
 import rego.v1
 
 import data.builtin.google.sql.google0015 as check
-import data.lib.test
 
 test_allow_tls_required if {
 	inp := build_input({"requiretls": {"value": true}})

--- a/checks/cloud/google/sql/mysql_no_local_infile_test.rego
+++ b/checks/cloud/google/sql/mysql_no_local_infile_test.rego
@@ -3,7 +3,6 @@ package builtin.google.sql.google0026_test
 import rego.v1
 
 import data.builtin.google.sql.google0026 as check
-import data.lib.test
 
 test_deny_local_file_read_access_enabled if {
 	inp := build_input({

--- a/checks/cloud/google/sql/no_contained_db_auth_test.rego
+++ b/checks/cloud/google/sql/no_contained_db_auth_test.rego
@@ -3,7 +3,6 @@ package builtin.google.sql.google0023_test
 import rego.v1
 
 import data.builtin.google.sql.google0023 as check
-import data.lib.test
 
 test_allow_db_auth_disabled if {
 	inp := build_input({

--- a/checks/cloud/google/sql/no_cross_db_ownership_chaining_test.rego
+++ b/checks/cloud/google/sql/no_cross_db_ownership_chaining_test.rego
@@ -3,7 +3,6 @@ package builtin.google.sql.google0019_test
 import rego.v1
 
 import data.builtin.google.sql.google0019 as check
-import data.lib.test
 
 test_deny_cross_database_ownership_chaining_enabled if {
 	inp := build_input({

--- a/checks/cloud/google/sql/no_public_access_test.rego
+++ b/checks/cloud/google/sql/no_public_access_test.rego
@@ -3,7 +3,6 @@ package builtin.google.sql.google0017_test
 import rego.v1
 
 import data.builtin.google.sql.google0017 as check
-import data.lib.test
 
 test_deny_ipv4_enabled if {
 	inp := build_input({"settings": {"ipconfiguration": {"enableipv4": {"value": true}}}})

--- a/checks/cloud/google/sql/pg_log_checkpoints_test.rego
+++ b/checks/cloud/google/sql/pg_log_checkpoints_test.rego
@@ -3,7 +3,6 @@ package builtin.google.sql.google0025_test
 import rego.v1
 
 import data.builtin.google.sql.google0025 as check
-import data.lib.test
 
 test_deny_log_checkpoints_disabled if {
 	inp := build_input({

--- a/checks/cloud/google/sql/pg_log_connections_test.rego
+++ b/checks/cloud/google/sql/pg_log_connections_test.rego
@@ -3,7 +3,6 @@ package builtin.google.sql.google0016_test
 import rego.v1
 
 import data.builtin.google.sql.google0016 as check
-import data.lib.test
 
 test_deny_connections_logging_disabled if {
 	inp := build_input({

--- a/checks/cloud/google/sql/pg_log_disconnections_test.rego
+++ b/checks/cloud/google/sql/pg_log_disconnections_test.rego
@@ -3,7 +3,6 @@ package builtin.google.sql.google0022_test
 import rego.v1
 
 import data.builtin.google.sql.google0022 as check
-import data.lib.test
 
 test_deny_disconnections_logging_disabled if {
 	inp := build_input({

--- a/checks/cloud/google/sql/pg_log_errors_test.rego
+++ b/checks/cloud/google/sql/pg_log_errors_test.rego
@@ -3,7 +3,6 @@ package builtin.google.sql.google0018_test
 import rego.v1
 
 import data.builtin.google.sql.google0018 as check
-import data.lib.test
 
 test_deny_minimum_log_level_is_not_error if {
 	inp := build_input({

--- a/checks/cloud/google/sql/pg_log_lock_waits_test.rego
+++ b/checks/cloud/google/sql/pg_log_lock_waits_test.rego
@@ -3,7 +3,6 @@ package builtin.google.sql.google0020_test
 import rego.v1
 
 import data.builtin.google.sql.google0020 as check
-import data.lib.test
 
 test_deny_lock_waits_loggging_disabled if {
 	inp := build_input({

--- a/checks/cloud/google/sql/pg_no_min_statement_logging_test.rego
+++ b/checks/cloud/google/sql/pg_no_min_statement_logging_test.rego
@@ -3,7 +3,6 @@ package builtin.google.sql.google0021_test
 import rego.v1
 
 import data.builtin.google.sql.google0021 as check
-import data.lib.test
 
 test_deny_logging_enabled_for_all_statements if {
 	inp := build_input({

--- a/checks/cloud/google/storage/bucket_encryption_customer_key_test.rego
+++ b/checks/cloud/google/storage/bucket_encryption_customer_key_test.rego
@@ -3,7 +3,6 @@ package builtin.google.storage.google0066_test
 import rego.v1
 
 import data.builtin.google.storage.google0066 as check
-import data.lib.test
 
 test_allow_bucket_with_customer_key if {
 	inp := {"google": {"storage": {"buckets": [{"encryption": {"defaultkmskeyname": {"value": "key"}}}]}}}

--- a/checks/cloud/google/storage/enable_ubla_test.rego
+++ b/checks/cloud/google/storage/enable_ubla_test.rego
@@ -3,7 +3,6 @@ package builtin.google.storage.google0002_test
 import rego.v1
 
 import data.builtin.google.storage.google0002 as check
-import data.lib.test
 
 test_allow_uniform_bucket_level_access_enabled if {
 	inp := {"google": {"storage": {"buckets": [{"enableuniformbucketlevelaccess": {"value": true}}]}}}

--- a/checks/cloud/google/storage/no_public_access_test.rego
+++ b/checks/cloud/google/storage/no_public_access_test.rego
@@ -3,7 +3,6 @@ package builtin.google.storage.google0001_test
 import rego.v1
 
 import data.builtin.google.storage.google0001 as check
-import data.lib.test
 
 test_allow_bucket_does_not_allow_public_access if {
 	inp := build_input({"bindings": [{"members": [{"value": "user:zKqzW@example.com"}]}]})

--- a/checks/cloud/nifcloud/computing/add_description_to_security_group_rule_test.rego
+++ b/checks/cloud/nifcloud/computing/add_description_to_security_group_rule_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.computing.nifcloud0003_test
 import rego.v1
 
 import data.builtin.nifcloud.computing.nifcloud0003 as check
-import data.lib.test
 
 test_allow_rules_with_description if {
 	inp := build_input({"ingressrules": [{"description": {"value": "test"}}]})

--- a/checks/cloud/nifcloud/computing/add_description_to_security_group_test.rego
+++ b/checks/cloud/nifcloud/computing/add_description_to_security_group_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.computing.nifcloud0002_test
 import rego.v1
 
 import data.builtin.nifcloud.computing.nifcloud0002 as check
-import data.lib.test
 
 test_allow_sg_with_description if {
 	inp := {"nifcloud": {"computing": {"securitygroups": [{"description": {"value": "Test"}}]}}}

--- a/checks/cloud/nifcloud/computing/add_security_group_to_instance_test.rego
+++ b/checks/cloud/nifcloud/computing/add_security_group_to_instance_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.computing.nifcloud0004_test
 import rego.v1
 
 import data.builtin.nifcloud.computing.nifcloud0004 as check
-import data.lib.test
 
 test_allow_instance_with_sg if {
 	inp := {"nifcloud": {"computing": {"instances": [{"securitygroup": {"value": "some-sg"}}]}}}

--- a/checks/cloud/nifcloud/computing/no_common_private_instance_test.rego
+++ b/checks/cloud/nifcloud/computing/no_common_private_instance_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.computing.nifcloud0005_test
 import rego.v1
 
 import data.builtin.nifcloud.computing.nifcloud0005 as check
-import data.lib.test
 
 test_allow_instance_with_private_lan if {
 	inp := {"nifcloud": {"computing": {"instances": [{"networkinterfaces": [{"networkid": {"value": "net-some-private-lan"}}]}]}}}

--- a/checks/cloud/nifcloud/computing/no_public_ingress_sgr_test.rego
+++ b/checks/cloud/nifcloud/computing/no_public_ingress_sgr_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.computing.nifcloud0001_test
 import rego.v1
 
 import data.builtin.nifcloud.computing.nifcloud0001 as check
-import data.lib.test
 
 test_deny_ingress_sg_rule_with_wildcard_address if {
 	inp := {"nifcloud": {"computing": {"securitygroups": [{"ingressrules": [{"cidr": {"value": "0.0.0.0/0"}}]}]}}}

--- a/checks/cloud/nifcloud/dns/remove_verified_record_test.rego
+++ b/checks/cloud/nifcloud/dns/remove_verified_record_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.dns.nifcloud0007_test
 import rego.v1
 
 import data.builtin.nifcloud.dns.nifcloud0007 as check
-import data.lib.test
 
 test_allow_txt_record if {
 	inp := build_input({

--- a/checks/cloud/nifcloud/nas/add_description_to_nas_security_group_test.rego
+++ b/checks/cloud/nifcloud/nas/add_description_to_nas_security_group_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.nas.nifcloud0015_test
 import rego.v1
 
 import data.builtin.nifcloud.nas.nifcloud0015 as check
-import data.lib.test
 
 test_allow_sg_with_description if {
 	res := check.deny with input as build_input("Test")

--- a/checks/cloud/nifcloud/nas/no_common_private_nas_instance_test.rego
+++ b/checks/cloud/nifcloud/nas/no_common_private_nas_instance_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.nas.nifcloud0013_test
 import rego.v1
 
 import data.builtin.nifcloud.nas.nifcloud0013 as check
-import data.lib.test
 
 test_allow_private_lan if {
 	inp := {"nifcloud": {"nas": {"nasinstances": [{"networkid": {"value": "net-some-private-lan"}}]}}}

--- a/checks/cloud/nifcloud/nas/no_public_ingress_nas_sgr_test.rego
+++ b/checks/cloud/nifcloud/nas/no_public_ingress_nas_sgr_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.nas.nifcloud0014_test
 import rego.v1
 
 import data.builtin.nifcloud.nas.nifcloud0014 as check
-import data.lib.test
 
 test_deny_ingress_sg_rule_with_wildcard_address if {
 	inp := {"nifcloud": {"nas": {"nassecuritygroups": [{"cidrs": [{"value": "0.0.0.0/0"}]}]}}}

--- a/checks/cloud/nifcloud/network/add_security_group_to_router_test.rego
+++ b/checks/cloud/nifcloud/network/add_security_group_to_router_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.network.nifcloud0016_test
 import rego.v1
 
 import data.builtin.nifcloud.network.nifcloud0016 as check
-import data.lib.test
 
 test_allow_router_with_sg if {
 	inp := {"nifcloud": {"network": {"routers": [{"securitygroup": {"value": "some-group"}}]}}}

--- a/checks/cloud/nifcloud/network/add_security_group_to_vpn_gateway_test.rego
+++ b/checks/cloud/nifcloud/network/add_security_group_to_vpn_gateway_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.network.nifcloud0018_test
 import rego.v1
 
 import data.builtin.nifcloud.network.nifcloud0018 as check
-import data.lib.test
 
 test_allow_gateway_with_sg if {
 	inp := {"nifcloud": {"network": {"vpngateways": [{"securitygroup": {"value": "some-group"}}]}}}

--- a/checks/cloud/nifcloud/network/http_not_used_test.rego
+++ b/checks/cloud/nifcloud/network/http_not_used_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.network.nifcloud0021_test
 import rego.v1
 
 import data.builtin.nifcloud.network.nifcloud0021 as check
-import data.lib.test
 
 test_deny_elastic_lb_with_http_protocol_on_global if {
 	inp := build_elb_input({

--- a/checks/cloud/nifcloud/network/no_common_private_elb_test.rego
+++ b/checks/cloud/nifcloud/network/no_common_private_elb_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.network.nifcloud0019_test
 import rego.v1
 
 import data.builtin.nifcloud.network.nifcloud0019 as check
-import data.lib.test
 
 test_allow_elb_with_private_lan if {
 	inp := {"nifcloud": {"network": {"elasticloadbalancers": [{"networkinterfaces": [{"networkid": {"value": "net-some-private-lan"}}]}]}}}

--- a/checks/cloud/nifcloud/network/no_common_private_router_test.rego
+++ b/checks/cloud/nifcloud/network/no_common_private_router_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.network.nifcloud0017_test
 import rego.v1
 
 import data.builtin.nifcloud.network.nifcloud0017 as check
-import data.lib.test
 
 test_allow_with_private_lan if {
 	inp := {"nifcloud": {"network": {"routers": [{"networkinterfaces": [{"networkid": {"value": "net-some-private-lan"}}]}]}}}

--- a/checks/cloud/nifcloud/network/use_secure_tls_policy_test.rego
+++ b/checks/cloud/nifcloud/network/use_secure_tls_policy_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.network.nifcloud0020_test
 import rego.v1
 
 import data.builtin.nifcloud.network.nifcloud0020 as check
-import data.lib.test
 
 test_allow_lb_using_tls_v12 if {
 	inp := {"nifcloud": {"network": {"loadbalancers": [{"listeners": [{

--- a/checks/cloud/nifcloud/rdb/add_description_to_db_security_group_test.rego
+++ b/checks/cloud/nifcloud/rdb/add_description_to_db_security_group_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.rdb.nifcloud0012_test
 import rego.v1
 
 import data.builtin.nifcloud.rdb.nifcloud0012 as check
-import data.lib.test
 
 test_allow_sg_with_description if {
 	inp := {"nifcloud": {"rdb": {"dbsecuritygroups": [{"description": {"value": "Test"}}]}}}

--- a/checks/cloud/nifcloud/rdb/no_common_private_db_instance_test.rego
+++ b/checks/cloud/nifcloud/rdb/no_common_private_db_instance_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.rdb.nifcloud0010_test
 import rego.v1
 
 import data.builtin.nifcloud.rdb.nifcloud0010 as check
-import data.lib.test
 
 test_allow_db_with_private_lan if {
 	inp := {"nifcloud": {"rdb": {"dbinstances": [{"networkid": {"value": "net-some-private-lan"}}]}}}

--- a/checks/cloud/nifcloud/rdb/no_public_db_access_test.rego
+++ b/checks/cloud/nifcloud/rdb/no_public_db_access_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.rdb.nifcloud0008_test
 import rego.v1
 
 import data.builtin.nifcloud.rdb.nifcloud0008 as check
-import data.lib.test
 
 test_allow_db_without_public_access if {
 	inp := {"nifcloud": {"rdb": {"dbinstances": [{"publicaccess": {"value": false}}]}}}

--- a/checks/cloud/nifcloud/rdb/no_public_ingress_db_sgr_test.rego
+++ b/checks/cloud/nifcloud/rdb/no_public_ingress_db_sgr_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.rdb.nifcloud0011_test
 import rego.v1
 
 import data.builtin.nifcloud.rdb.nifcloud0011 as check
-import data.lib.test
 
 test_deny_ingress_sg_rule_with_wildcard_address if {
 	inp := {"nifcloud": {"rdb": {"dbsecuritygroups": [{"cidrs": [{"value": "0.0.0.0/0"}]}]}}}

--- a/checks/cloud/nifcloud/rdb/specify_backup_retention_test.rego
+++ b/checks/cloud/nifcloud/rdb/specify_backup_retention_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.rdb.nifcloud0009_test
 import rego.v1
 
 import data.builtin.nifcloud.rdb.nifcloud0009 as check
-import data.lib.test
 
 test_allow_frequent_retention_perid if {
 	inp := {"nifcloud": {"rdb": {"dbinstances": {{"backupretentionperioddays": {"value": 5}}}}}}

--- a/checks/cloud/nifcloud/sslcertificate/remove_expired_certificates_test.rego
+++ b/checks/cloud/nifcloud/sslcertificate/remove_expired_certificates_test.rego
@@ -3,7 +3,6 @@ package builtin.nifcloud.sslcertificate.nifcloud0006_test
 import rego.v1
 
 import data.builtin.nifcloud.sslcertificate.nifcloud0006 as check
-import data.lib.test
 
 test_allow_not_expired_certificate if {
 	inp := {"nifcloud": {"sslcertificate": {"servercertificates": [{"expiration": {"value": time.format(time.now_ns() + 3600000000000)}}]}}}

--- a/checks/cloud/openstack/compute/no_plaintext_password_test.rego
+++ b/checks/cloud/openstack/compute/no_plaintext_password_test.rego
@@ -3,7 +3,6 @@ package builtin.openstack.compute.openstack0001_test
 import rego.v1
 
 import data.builtin.openstack.compute.openstack0001 as check
-import data.lib.test
 
 test_allow_no_plaintext_password if {
 	inp := {"openstack": {"compute": {"instances": [{"adminpassword": {"value": ""}}]}}}

--- a/checks/cloud/openstack/compute/no_public_access_test.rego
+++ b/checks/cloud/openstack/compute/no_public_access_test.rego
@@ -3,7 +3,6 @@ package builtin.openstack.compute.openstack0002_test
 import rego.v1
 
 import data.builtin.openstack.compute.openstack0002 as check
-import data.lib.test
 
 test_deny_rule_missing_destination_address if {
 	inp := build_input({

--- a/checks/cloud/openstack/networking/add_description_to_security_group_test.rego
+++ b/checks/cloud/openstack/networking/add_description_to_security_group_test.rego
@@ -3,7 +3,6 @@ package builtin.openstack.networking.openstack0005_test
 import rego.v1
 
 import data.builtin.openstack.networking.openstack0005 as check
-import data.lib.test
 
 test_allow_sg_with_description if {
 	inp := {"openstack": {"networking": {"securitygroups": [{"description": {"value": "test"}}]}}}

--- a/checks/cloud/openstack/networking/no_public_egress_test.rego
+++ b/checks/cloud/openstack/networking/no_public_egress_test.rego
@@ -3,7 +3,6 @@ package builtin.openstack.networking.openstack0004_test
 import rego.v1
 
 import data.builtin.openstack.networking.openstack0004 as check
-import data.lib.test
 
 test_deny_public_egress if {
 	inp := {"openstack": {"networking": {"securitygroups": [{"rules": [{

--- a/checks/cloud/openstack/networking/no_public_ingress_test.rego
+++ b/checks/cloud/openstack/networking/no_public_ingress_test.rego
@@ -3,7 +3,6 @@ package builtin.openstack.networking.openstack0003_test
 import rego.v1
 
 import data.builtin.openstack.networking.openstack0003 as check
-import data.lib.test
 
 test_deny_public_ingress if {
 	inp := {"openstack": {"networking": {"securitygroups": [{"rules": [{

--- a/checks/cloud/oracle/compute/no_public_ip_test.rego
+++ b/checks/cloud/oracle/compute/no_public_ip_test.rego
@@ -3,7 +3,6 @@ package builtin.oracle.compute.oracle0001_test
 import rego.v1
 
 import data.builtin.oracle.compute.oracle0001 as check
-import data.lib.test
 
 test_deny_pool_is_public if {
 	inp := {"oracle": {"compute": {"addressreservations": [{"pool": {"value": "public-ippool"}}]}}}

--- a/checks/docker/copy_from_references_current_from_alias.rego
+++ b/checks/docker/copy_from_references_current_from_alias.rego
@@ -44,7 +44,7 @@ is_alias_current_from_alias(current_name, current_alias) := allow if {
 	#expecting stage name as "myimage:tag as dep"
 	[_, alias] := regex.split(`\s+as\s+`, current_name_lower)
 
-	alias == current_alias
+	alias == current_alias_lower
 
 	allow = true
 }

--- a/checks/docker/copy_from_references_current_from_alias_test.rego
+++ b/checks/docker/copy_from_references_current_from_alias_test.rego
@@ -44,6 +44,29 @@ test_basic_denied if {
 	r[_].msg == "'COPY --from' should not mention current alias 'dep' since it is impossible to copy from itself"
 }
 
+test_deny_stage_name_non_lowercase if {
+	r := deny with input as {"Stages": [{
+		"Name": "golang:1.18 as Builder",
+		"Commands": [
+			{
+				"Cmd": "from",
+				"Value": ["golang:1.18", "as", "Builder"],
+			},
+			{
+				"Cmd": "copy",
+				"Flags": ["--from=builder"],
+				"Value": [
+					"/binary",
+					"/",
+				],
+			},
+		],
+	}]}
+
+	count(r) == 1
+	r[_].msg == "'COPY --from' should not mention current alias 'builder' since it is impossible to copy from itself"
+}
+
 test_extra_spaces_denied if {
 	r := deny with input as {"Stages": [
 		{

--- a/checks/docker/leaked_secrets.rego
+++ b/checks/docker/leaked_secrets.rego
@@ -19,7 +19,6 @@ package builtin.dockerfile.DS031
 import rego.v1
 
 import data.ds031
-import data.lib.docker
 import data.lib.path
 
 final_stage := last(input.Stages)

--- a/checks/docker/maintainer_is_deprecated.rego
+++ b/checks/docker/maintainer_is_deprecated.rego
@@ -19,8 +19,6 @@ package builtin.dockerfile.DS022
 
 import rego.v1
 
-import data.lib.docker
-
 get_maintainer contains mntnr if {
 	mntnr := input.Stages[_].Commands[_]
 	mntnr.Cmd == "maintainer"

--- a/checks/docker/root_user_test.rego
+++ b/checks/docker/root_user_test.rego
@@ -2,8 +2,6 @@ package builtin.dockerfile.DS002
 
 import rego.v1
 
-import data.lib.docker
-
 test_not_root_allowed if {
 	r := deny with input as {"Stages": [{
 		"Name": "alpine:3.13",

--- a/checks/docker/same_alias_in_different_froms.rego
+++ b/checks/docker/same_alias_in_different_froms.rego
@@ -19,8 +19,6 @@ package builtin.dockerfile.DS012
 
 import rego.v1
 
-import data.lib.docker
-
 get_duplicate_alias contains output if {
 	output1 := get_aliased_name[_]
 	output2 := get_aliased_name[_]

--- a/checks/docker/yum_clean_all_missing.rego
+++ b/checks/docker/yum_clean_all_missing.rego
@@ -37,8 +37,9 @@ has_install(cmds, package_manager) := indexes if {
 	indexes := docker.command_indexes(cmds, ["install"], package_manager)
 }
 
-install_followed_by_clean(cmds, package_manager, install_indexes) if {
-	clean_indexes := docker.command_indexes(cmds, ["clean"], package_manager)
+install_followed_by_clean(cmds, _, install_indexes) if {
+	# TODO: fix
+	# clean_indexes := docker.command_indexes(cmds, ["clean"], package_manager)
 	clean_all_indexes = [idx | cmd := cmds[idx]; "all" in cmd]
 	count(clean_all_indexes) > 0
 	install_indexes[count(install_indexes) - 1] < clean_all_indexes[count(clean_all_indexes) - 1]

--- a/checks/kubernetes/advanced/optional/use_limit_range.rego
+++ b/checks/kubernetes/advanced/optional/use_limit_range.rego
@@ -20,7 +20,6 @@ package builtin.kubernetes.KSV039
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 limitRangeConfigure if {
 	lower(input.kind) == "limitrange"

--- a/checks/kubernetes/advanced/optional/use_resource_quota.rego
+++ b/checks/kubernetes/advanced/optional/use_resource_quota.rego
@@ -20,7 +20,6 @@ package builtin.kubernetes.KSV040
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 resourceQuotaConfigure if {
 	lower(input.kind) == "resourcequota"

--- a/checks/kubernetes/advanced/optional/uses_untrusted_azure_registry.rego
+++ b/checks/kubernetes/advanced/optional/uses_untrusted_azure_registry.rego
@@ -28,7 +28,6 @@ package builtin.kubernetes.KSV032
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 default failTrustedAzureRegistry := false
 

--- a/checks/kubernetes/advanced/optional/uses_untrusted_ecr_registry.rego
+++ b/checks/kubernetes/advanced/optional/uses_untrusted_ecr_registry.rego
@@ -28,7 +28,6 @@ package builtin.kubernetes.KSV035
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 default failTrustedECRRegistry := false
 

--- a/checks/kubernetes/advanced/optional/uses_untrusted_gcr_registry.rego
+++ b/checks/kubernetes/advanced/optional/uses_untrusted_gcr_registry.rego
@@ -28,7 +28,6 @@ package builtin.kubernetes.KSV033
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 default failTrustedGCRRegistry := false
 

--- a/checks/kubernetes/advanced/optional/uses_untrusted_public_registries.rego
+++ b/checks/kubernetes/advanced/optional/uses_untrusted_public_registries.rego
@@ -28,7 +28,6 @@ package builtin.kubernetes.KSV034
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 default failPublicRegistry := false
 

--- a/checks/kubernetes/advanced/protect_core_components_namespace.rego
+++ b/checks/kubernetes/advanced/protect_core_components_namespace.rego
@@ -20,7 +20,6 @@ package builtin.kubernetes.KSV037
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 systemNamespaceInUse(metadata, spec) if {
 	kubernetes.namespace == "kube-system"

--- a/checks/kubernetes/advanced/selector_usage_in_network_policies.rego
+++ b/checks/kubernetes/advanced/selector_usage_in_network_policies.rego
@@ -60,12 +60,12 @@ hasSelector(spec) if {
 
 hasSelector(spec) if {
 	kubernetes.spec.podSelector == {}
-	"Egress" in input.spec.policyType
+	"Egress" in spec.policyType
 }
 
 hasSelector(spec) if {
 	kubernetes.spec.podSelector == {}
-	"Ingress" in input.spec.policyType
+	"Ingress" in spec.policyType
 }
 
 deny contains res if {

--- a/checks/kubernetes/advanced/selector_usage_in_network_policies.rego
+++ b/checks/kubernetes/advanced/selector_usage_in_network_policies.rego
@@ -20,7 +20,6 @@ package builtin.kubernetes.KSV038
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 hasSelector(spec) if {
 	kubernetes.has_field(spec, "podSelector")

--- a/checks/kubernetes/cisbenchmarks/apiserver/admin_conf_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/admin_conf_ownership.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0061
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_conf_ownership(sp) := {"adminConfFileOwnership": violation} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/apiserver/admin_conf_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/admin_conf_permission.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0060
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_conf_permission(sp) := {"adminConfFilePermissions": violation} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/apiserver/always_admit_plugin.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/always_admit_plugin.rego
@@ -22,13 +22,13 @@ import rego.v1
 import data.lib.kubernetes
 
 check_flag(container) if {
-	cmd := kubernetes.containers[_].command[_]
+	some cmd in container.command
 	output := regex.find_all_string_submatch_n(`--enable-admission-plugins=([^\s]+)`, cmd, -1)
 	regex.match("AlwaysAdmit", output[0][1])
 }
 
 check_flag(container) if {
-	arg := kubernetes.containers[_].args[_]
+	some arg in container.args
 	output := regex.find_all_string_submatch_n(`--enable-admission-plugins=([^\s]+)`, arg, -1)
 	regex.match("AlwaysAdmit", output[0][1])
 }

--- a/checks/kubernetes/cisbenchmarks/apiserver/anonymous_auth.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/anonymous_auth.rego
@@ -22,12 +22,12 @@ import rego.v1
 import data.lib.kubernetes
 
 check_flag(container) if {
-	arg := kubernetes.containers[_].args[_]
+	some arg in container.args
 	contains(arg, "--anonymous-auth=false")
 }
 
 check_flag(container) if {
-	cmd := kubernetes.containers[_].command[_]
+	some cmd in container.command
 	contains(cmd, "--anonymous-auth=false")
 }
 

--- a/checks/kubernetes/cisbenchmarks/apiserver/kubernetes_pki_cert_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/kubernetes_pki_cert_permission.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0068
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_pki_cert_permission(sp) := {"kubernetesPKICertificateFilePermissions": violation} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/apiserver/kubernetes_pki_directory_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/kubernetes_pki_directory_ownership.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0066
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_pki_directory_ownership(sp) := {"kubePKIDirectoryFileOwnership": violation} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/apiserver/kubernetes_pki_key_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/kubernetes_pki_key_permission.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0067
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_pki_key_permission(sp) := {"kubePKIKeyFilePermissions": violation} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/apiserver/pod_spec_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/pod_spec_ownership.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0049
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_spec_ownership(sp) := {"kubeAPIServerSpecFileOwnership": violation} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/apiserver/pod_spec_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/apiserver/pod_spec_permission.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0048
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_spec_permission(sp) := {"kubeAPIServerSpecFilePermission": violation} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/cni/pod_spec_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/cni/pod_spec_ownership.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0057
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_spec_ownership(sp) := {"containerNetworkInterfaceFileOwnership": violation} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/cni/pod_spec_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/cni/pod_spec_permission.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0056
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_cni_permission(sp) := {"containerNetworkInterfaceFilePermissions": violation} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/controllermamager/controller_manager_conf_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/controller_manager_conf_ownership.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0065
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_conf_ownership(sp) := {"controllerManagerConfFileOwnership": violation} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/controllermamager/controller_manager_conf_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/controller_manager_conf_permission.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0064
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_conf_permission(sp) := {"controllerManagerConfFilePermissions": violation} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/controllermamager/pod_spec_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/pod_spec_ownership.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0051
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_spec_ownership(sp) := {"kubeControllerManagerSpecFileOwnership": violation} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/controllermamager/pod_spec_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/controllermamager/pod_spec_permission.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0050
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_spec_permission(sp) := {"kubeControllerManagerSpecFilePermission": violation} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/etcd/data_directory_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/data_directory_ownership.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0059
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_data_dir_ownership(sp) := {"etcdDataDirectoryOwnership": ownership} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/etcd/data_directory_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/data_directory_permission.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0058
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_spec_permission(sp) := {"etcdDataDirectoryPermissions": permission} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/etcd/pod_spec_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/pod_spec_ownership.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0055
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_spec_ownership(sp) := {"kubeEtcdSpecFileOwnership": violation} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/etcd/pod_spec_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/etcd/pod_spec_permission.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0054
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_spec_permission(sp) := {"kubeEtcdSpecFilePermission": violation} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/kubelet/certificate_authorities_file_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/certificate_authorities_file_ownership.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0076
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_certificate_authorities_ownership(sp) := {"certificateAuthoritiesFileOwnership": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/certificate_authorities_file_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/certificate_authorities_file_permission.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0075
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_certificate_authorities_file_permission(sp) := {"certificateAuthoritiesFilePermissions": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_anonymous_auth_argument.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_anonymous_auth_argument.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0079
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_kubelet_anonymous_auth_set(sp) := {"kubeletAnonymousAuthArgumentSet": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_authorization_mode_argument.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_authorization_mode_argument.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0080
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_kubelet_authorization_mode(sp) := {"kubeletAuthorizationModeArgumentSet": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_client_ca_file_argument.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_client_ca_file_argument.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0081
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_client_ca_set(sp) := {"kubeletClientCaFileArgumentSet": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_config_file_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_config_file_ownership.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0074
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_kubelet_file_ownership(sp) := {"kubeletConfFileOwnership": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_config_file_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_config_file_permission.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0073
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_kubelet_file_permission(sp) := {"kubeletConfFilePermissions": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_config_yaml_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_config_yaml_ownership.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0078
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_kubelet_config_yaml_ownership(sp) := {"kubeletConfigYamlConfigurationFileOwnership": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_config_yaml_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_config_yaml_permission.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0077
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_kubelet_config_yaml_permission(sp) := {"kubeletConfigYamlConfigurationFilePermission": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_event_qps.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_event_qps.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0087
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_kubelet_event_qps_set(sp) := {"kubeletEventQpsArgumentSet": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_hostname_override.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_hostname_override.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0086
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_kubelet_hostname_override_set(sp) := {"kubeletHostnameOverrideArgumentSet": hostname_override} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_make_iptables_util_chains.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_make_iptables_util_chains.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0084
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_kubelet_iptables_util_chains_set(sp) := {"kubeletMakeIptablesUtilChainsArgumentSet": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_only_use_strong_cryptographic.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_only_use_strong_cryptographic.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0092
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 strong_cryptographic := [

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_protect_kernel_defaults.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_protect_kernel_defaults.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0083
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_kubelet_anonymous_auth_set(sp) := {"kubeletProtectKernelDefaultsArgumentSet": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_read_only_port_argument.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_read_only_port_argument.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0082
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_kubelet_read_only_set(sp) := {"kubeletReadOnlyPortArgumentSet": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_rotate_certificates.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_rotate_certificates.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0090
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_kubelet_rotate_certificates(sp) := {"kubeletRotateCertificatesArgumentSet": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_rotate_kubelet_server_certificate.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_rotate_kubelet_server_certificate.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0091
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_kubelet_rotate_kubelet_server_certificate(sp) := {"kubeletRotateKubeletServerCertificateArgumentSet": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_streaming_connection_argument.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_streaming_connection_argument.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0085
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_kubelet_streaming_connection_idle_timeout_set(sp) := {"kubeletStreamingConnectionIdleTimeoutArgumentSet": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_tls_cert_file.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_tls_cert_file.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0088
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_kubelet_tls_cert_file(sp) := {"kubeletTlsCertFileTlsArgumentSet": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/kubelet_tls_key_file.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kubelet_tls_key_file.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0089
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_kubelet_tls_key_file(sp) := {"kubeletTlsPrivateKeyFileArgumentSet": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/kublet_service_file_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kublet_service_file_ownership.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0070
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_service_file_ownership(sp) := {"kubeletServiceFileOwnership": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/kublet_service_file_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/kublet_service_file_permission.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0069
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_service_file_permission(sp) := {"kubeletServiceFilePermissions": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/proxy_kube_config_file_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/proxy_kube_config_file_ownership.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0072
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_kube_config_file_ownership(sp) := {"kubeconfigFileExistsOwnership": violation} if {

--- a/checks/kubernetes/cisbenchmarks/kubelet/proxy_kube_config_file_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/kubelet/proxy_kube_config_file_permission.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0071
 
 import rego.v1
 
-import data.lib.kubernetes
-
 types := ["master", "worker"]
 
 validate_kube_config_file_permission(sp) := {"kubeconfigFileExistsPermissions": violation} if {

--- a/checks/kubernetes/cisbenchmarks/scheduler/pod_spec_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/scheduler/pod_spec_ownership.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0053
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_spec_ownership(sp) := {"kubeSchedulerSpecFileOwnership": violation} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/scheduler/pod_spec_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/scheduler/pod_spec_permission.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0052
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_spec_permission(sp) := {"kubeSchedulerSpecFilePermission": violation} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/scheduler/scheduler_conf_ownership.rego
+++ b/checks/kubernetes/cisbenchmarks/scheduler/scheduler_conf_ownership.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0063
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_conf_ownership(sp) := {"schedulerConfFileOwnership": violation} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/cisbenchmarks/scheduler/scheduler_conf_permission.rego
+++ b/checks/kubernetes/cisbenchmarks/scheduler/scheduler_conf_permission.rego
@@ -21,8 +21,6 @@ package builtin.kubernetes.KCV0062
 
 import rego.v1
 
-import data.lib.kubernetes
-
 validate_conf_permission(sp) := {"schedulerConfFilePermissions": violation} if {
 	sp.kind == "NodeInfo"
 	sp.type == "master"

--- a/checks/kubernetes/dynamic/outdated_api.rego
+++ b/checks/kubernetes/dynamic/outdated_api.rego
@@ -37,7 +37,7 @@ exists(obj, k) if {
 	_ = obj[k]
 }
 
-pick(k, obj1, obj2) := v if {
+pick(k, obj1, _) := v if {
 	v := obj1[k]
 }
 
@@ -84,7 +84,7 @@ compareVersion(obj) if {
 	valid(resultDep, resultRem)
 }
 
-compareVersion(obj) if {
+compareVersion(_) if {
 	not k8s
 }
 

--- a/checks/kubernetes/dynamic/outdated_api.rego
+++ b/checks/kubernetes/dynamic/outdated_api.rego
@@ -3,8 +3,6 @@ package defsec.kubernetes.KSV107
 import rego.v1
 
 import data.k8s
-import data.lib.kubernetes
-import data.lib.utils
 
 __rego_metadata__ := {
 	"id": "KSV107",

--- a/checks/kubernetes/general/allowing_create_role_binding_and_associate_privileged_clusterrole.rego
+++ b/checks/kubernetes/general/allowing_create_role_binding_and_associate_privileged_clusterrole.rego
@@ -19,9 +19,6 @@ package builtin.kubernetes.KSV051
 
 import rego.v1
 
-import data.lib.kubernetes
-import data.lib.utils
-
 readKinds := ["Role", "ClusterRole"]
 
 readroles := ["clusterroles", "roles"]

--- a/checks/kubernetes/general/allowing_create_role_clusterrolebinding_and_associate_privileged_clusterrole.rego
+++ b/checks/kubernetes/general/allowing_create_role_clusterrolebinding_and_associate_privileged_clusterrole.rego
@@ -19,9 +19,6 @@ package builtin.kubernetes.KSV052
 
 import rego.v1
 
-import data.lib.kubernetes
-import data.lib.utils
-
 readKinds := ["Role", "ClusterRole"]
 
 allowing_create_clusterrolebindings_binding_and_associate_cluster_role contains ruleA if {

--- a/checks/kubernetes/general/allowing_to_update_a_malicious_pod.rego
+++ b/checks/kubernetes/general/allowing_to_update_a_malicious_pod.rego
@@ -23,7 +23,6 @@ package builtin.kubernetes.KSV048
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 workloads := ["pods", "deployments", "jobs", "cronjobs", "statefulsets", "daemonsets", "replicasets", "replicationcontrollers"]
 

--- a/checks/kubernetes/general/allowing_users_rolebinding_add_other_users_rolebindings.rego
+++ b/checks/kubernetes/general/allowing_users_rolebinding_add_other_users_rolebindings.rego
@@ -19,9 +19,6 @@ package builtin.kubernetes.KSV055
 
 import rego.v1
 
-import data.lib.kubernetes
-import data.lib.utils
-
 readKinds := ["Role", "ClusterRole"]
 
 allowing_users_rolebinding_add_other_users_their_rolebindings contains input.rules[ru] if {

--- a/checks/kubernetes/general/anonymous_user_bind.rego
+++ b/checks/kubernetes/general/anonymous_user_bind.rego
@@ -25,17 +25,15 @@ import rego.v1
 
 import data.lib.kubernetes
 
-readRoleRefs := ["system:unauthenticated", "system:anonymous"]
+readRoleRefs := {"system:unauthenticated", "system:anonymous"}
 
-readKinds := ["RoleBinding", "ClusterRolebinding"]
-
-anonymousUserBind(roleBinding) if {
-	kubernetes.kind == readKinds[_]
-	kubernetes.object.subjects[_].name == readRoleRefs[_]
+anonymousUserBind if {
+	kubernetes.is_role_binding_kind
+	kubernetes.object.subjects[_].name in readRoleRefs
 }
 
 deny contains res if {
-	anonymousUserBind(input)
+	anonymousUserBind
 	msg := kubernetes.format(sprintf("%s '%s' should not bind to roles %s", [kubernetes.kind, kubernetes.name, readRoleRefs]))
 	res := result.new(msg, input.metadata)
 }

--- a/checks/kubernetes/general/any_any.rego
+++ b/checks/kubernetes/general/any_any.rego
@@ -19,9 +19,6 @@ package builtin.kubernetes.KSV044
 
 import rego.v1
 
-import data.lib.kubernetes
-import data.lib.utils
-
 readKinds := ["Role", "ClusterRole"]
 
 anyAnyResource contains input.rules[ru] if {

--- a/checks/kubernetes/general/any_verb.rego
+++ b/checks/kubernetes/general/any_verb.rego
@@ -19,9 +19,6 @@ package builtin.kubernetes.KSV045
 
 import rego.v1
 
-import data.lib.kubernetes
-import data.lib.utils
-
 resourceRead := ["secrets", "pods", "deployments", "daemonsets", "statefulsets", "replicationcontrollers", "replicasets", "cronjobs", "jobs", "roles", "clusterroles", "rolebindings", "clusterrolebindings", "users", "groups"]
 
 readKinds := ["Role", "ClusterRole"]

--- a/checks/kubernetes/general/attaching_pod_view_logs_realtime.rego
+++ b/checks/kubernetes/general/attaching_pod_view_logs_realtime.rego
@@ -19,9 +19,6 @@ package builtin.kubernetes.KSV054
 
 import rego.v1
 
-import data.lib.kubernetes
-import data.lib.utils
-
 readKinds := ["Role", "ClusterRole"]
 
 attach_shell_on_pod contains ruleA if {

--- a/checks/kubernetes/general/delete_pod_logs.rego
+++ b/checks/kubernetes/general/delete_pod_logs.rego
@@ -23,7 +23,6 @@ package builtin.kubernetes.KSV042
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 readVerbs := ["delete", "deletecollection", "*"]
 

--- a/checks/kubernetes/general/get_shell_on_pod.rego
+++ b/checks/kubernetes/general/get_shell_on_pod.rego
@@ -23,7 +23,6 @@ package builtin.kubernetes.KSV053
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 workloads := ["pods/exec"]
 

--- a/checks/kubernetes/general/impersonate_privileged_groups.rego
+++ b/checks/kubernetes/general/impersonate_privileged_groups.rego
@@ -19,9 +19,6 @@ package builtin.kubernetes.KSV043
 
 import rego.v1
 
-import data.lib.kubernetes
-import data.lib.utils
-
 readKinds := ["Role", "ClusterRole"]
 
 impersonatePrivilegedGroups contains input.rules[ru] if {

--- a/checks/kubernetes/general/manage_all_resources.rego
+++ b/checks/kubernetes/general/manage_all_resources.rego
@@ -22,7 +22,6 @@ package builtin.kubernetes.KSV046
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 readVerbs := ["create", "update", "delete", "deletecollection", "impersonate", "*", "list", "get"]
 

--- a/checks/kubernetes/general/manage_all_resources_at_namespace.rego
+++ b/checks/kubernetes/general/manage_all_resources_at_namespace.rego
@@ -22,7 +22,6 @@ package builtin.kubernetes.KSV112
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 readVerbs := ["create", "update", "delete", "deletecollection", "impersonate", "*", "list", "get"]
 

--- a/checks/kubernetes/general/manage_configmaps.rego
+++ b/checks/kubernetes/general/manage_configmaps.rego
@@ -23,7 +23,6 @@ package builtin.kubernetes.KSV049
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 readVerbs := ["create", "update", "patch", "delete", "deletecollection", "impersonate", "*"]
 

--- a/checks/kubernetes/general/manage_eks_iam_auth_configmap.rego
+++ b/checks/kubernetes/general/manage_eks_iam_auth_configmap.rego
@@ -23,7 +23,6 @@ package builtin.kubernetes.KSV115
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 readVerbs := ["create", "update", "patch", "delete", "deletecollection", "impersonate", "*"]
 

--- a/checks/kubernetes/general/manage_kubernetes_networking.rego
+++ b/checks/kubernetes/general/manage_kubernetes_networking.rego
@@ -23,7 +23,6 @@ package builtin.kubernetes.KSV056
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 readKinds := ["Role", "ClusterRole"]
 

--- a/checks/kubernetes/general/manage_kubernetes_rbac_resources.rego
+++ b/checks/kubernetes/general/manage_kubernetes_rbac_resources.rego
@@ -23,7 +23,6 @@ package builtin.kubernetes.KSV050
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 readVerbs := ["create", "update", "delete", "deletecollection", "impersonate", "*"]
 

--- a/checks/kubernetes/general/manage_namespace_secrets.rego
+++ b/checks/kubernetes/general/manage_namespace_secrets.rego
@@ -22,7 +22,6 @@ package builtin.kubernetes.KSV113
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 readVerbs := ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection", "impersonate", "*"]
 

--- a/checks/kubernetes/general/manage_secrets.rego
+++ b/checks/kubernetes/general/manage_secrets.rego
@@ -22,7 +22,6 @@ package builtin.kubernetes.KSV041
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 readVerbs := ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection", "impersonate", "*"]
 

--- a/checks/kubernetes/general/manage_webhook_configurations.rego
+++ b/checks/kubernetes/general/manage_webhook_configurations.rego
@@ -23,7 +23,6 @@ package builtin.kubernetes.KSV114
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 readVerbs := ["create", "update", "patch", "delete", "deletecollection", "impersonate", "*"]
 

--- a/checks/kubernetes/general/masters_group_bind.rego
+++ b/checks/kubernetes/general/masters_group_bind.rego
@@ -25,17 +25,15 @@ import rego.v1
 
 import data.lib.kubernetes
 
-readRoleRefs := ["system:masters"]
+readRoleRefs := {"system:masters"}
 
-readKinds := ["RoleBinding", "ClusterRolebinding"]
-
-mastersGroupBind(roleBinding) if {
-	kubernetes.kind == readKinds[_]
-	kubernetes.object.subjects[_].name == readRoleRefs[_]
+mastersGroupBind if {
+	kubernetes.is_role_binding_kind
+	kubernetes.object.subjects[_].name in readRoleRefs
 }
 
 deny contains res if {
-	mastersGroupBind(input)
+	mastersGroupBind
 	msg := kubernetes.format(sprintf("%s '%s' should not bind to roles %s", [kubernetes.kind, kubernetes.name, readRoleRefs]))
 	res := result.new(msg, input.metadata)
 }

--- a/checks/kubernetes/general/masters_group_bind.rego
+++ b/checks/kubernetes/general/masters_group_bind.rego
@@ -23,7 +23,6 @@ package appshield.kubernetes.KSV0123
 
 import rego.v1
 
-import data.k8s
 import data.lib.kubernetes
 
 readRoleRefs := ["system:masters"]

--- a/checks/kubernetes/general/privilege_escalation_from_node_proxy.rego
+++ b/checks/kubernetes/general/privilege_escalation_from_node_proxy.rego
@@ -19,9 +19,6 @@ package builtin.kubernetes.KSV047
 
 import rego.v1
 
-import data.lib.kubernetes
-import data.lib.utils
-
 readVerbs := ["get", "create"]
 
 readKinds := ["Role", "ClusterRole"]

--- a/checks/kubernetes/general/runs_with_a_root_primary_or_supplementary_GID.rego
+++ b/checks/kubernetes/general/runs_with_a_root_primary_or_supplementary_GID.rego
@@ -30,7 +30,6 @@ package builtin.kubernetes.KSV116
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 default failRootGroupId := false
 

--- a/checks/kubernetes/gke/authenticate_group_bind.rego
+++ b/checks/kubernetes/gke/authenticate_group_bind.rego
@@ -26,18 +26,16 @@ import rego.v1
 import data.k8s
 import data.lib.kubernetes
 
-readRoleRefs := ["system:authenticated"]
+readRoleRefs := {"system:authenticated"}
 
-readKinds := ["RoleBinding", "ClusterRolebinding"]
-
-authenticatedGroupBind(roleBinding) if {
-	kubernetes.kind == readKinds[_]
-	kubernetes.object.subjects[_].name == readRoleRefs[_]
+authenticatedGroupBind if {
+	kubernetes.is_role_binding_kind
+	kubernetes.object.subjects[_].name in readRoleRefs
 }
 
 deny contains res if {
 	contains(k8s.version, "-gke")
-	authenticatedGroupBind(input)
+	authenticatedGroupBind
 	msg := kubernetes.format(sprintf("%s '%s' should not bind to roles %s", [kubernetes.kind, kubernetes.name, readRoleRefs]))
 	res := result.new(msg, input.metadata)
 }

--- a/checks/kubernetes/pss/baseline/10_windows_host_process.rego
+++ b/checks/kubernetes/pss/baseline/10_windows_host_process.rego
@@ -30,7 +30,6 @@ package builtin.kubernetes.KSV103
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 failHostProcess contains spec if {
 	spec := input.spec

--- a/checks/kubernetes/pss/baseline/6_apparmor_policy_disabled_test.rego
+++ b/checks/kubernetes/pss/baseline/6_apparmor_policy_disabled_test.rego
@@ -2,8 +2,6 @@ package builtin.kubernetes.KSV002
 
 import rego.v1
 
-import data.lib.kubernetes
-
 test_custom_deny if {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/pss/baseline/9_unsafe_sysctl_options_set.rego
+++ b/checks/kubernetes/pss/baseline/9_unsafe_sysctl_options_set.rego
@@ -30,7 +30,6 @@ package builtin.kubernetes.KSV026
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 default failSysctls := false
 

--- a/checks/kubernetes/pss/restricted/2_can_elevate_its_own_privileges.rego
+++ b/checks/kubernetes/pss/restricted/2_can_elevate_its_own_privileges.rego
@@ -30,7 +30,6 @@ package builtin.kubernetes.KSV001
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 default checkAllowPrivilegeEscalation := false
 

--- a/checks/kubernetes/pss/restricted/3_runs_as_root.rego
+++ b/checks/kubernetes/pss/restricted/3_runs_as_root.rego
@@ -30,7 +30,6 @@ package builtin.kubernetes.KSV012
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 default checkRunAsNonRoot := false
 

--- a/checks/kubernetes/pss/restricted/4_runs_with_a_root_uid.rego
+++ b/checks/kubernetes/pss/restricted/4_runs_with_a_root_uid.rego
@@ -20,7 +20,6 @@ package builtin.kubernetes.KSV105
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 failRootUserId contains securityContext if {
 	container := kubernetes.containers[_]

--- a/checks/kubernetes/pss/restricted/5_runtime_default_seccomp_profile_not_set.rego
+++ b/checks/kubernetes/pss/restricted/5_runtime_default_seccomp_profile_not_set.rego
@@ -30,7 +30,6 @@ package builtin.kubernetes.KSV030
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 seccomp_pod_annotation_key := "seccomp.security.alpha.kubernetes.io/pod"
 

--- a/checks/kubernetes/pss/restricted/5_runtime_default_seccomp_profile_not_set_test.rego
+++ b/checks/kubernetes/pss/restricted/5_runtime_default_seccomp_profile_not_set_test.rego
@@ -2,8 +2,6 @@ package builtin.kubernetes.KSV030
 
 import rego.v1
 
-import data.lib.kubernetes
-
 test_pod_context_custom_profile_denied if {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/pss/restricted/6_drop_all_capabilities_only_add_net_bind_service.rego
+++ b/checks/kubernetes/pss/restricted/6_drop_all_capabilities_only_add_net_bind_service.rego
@@ -20,7 +20,6 @@ package builtin.kubernetes.KSV106
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 hasDropAll(container) if {
 	upper(container.securityContext.capabilities.drop[_]) == "ALL"

--- a/checks/kubernetes/pss/restricted/6_drop_all_capabilities_only_add_net_bind_service_test.rego
+++ b/checks/kubernetes/pss/restricted/6_drop_all_capabilities_only_add_net_bind_service_test.rego
@@ -2,8 +2,6 @@ package builtin.kubernetes.KSV106
 
 import rego.v1
 
-import data.lib.kubernetes
-
 test_drop_all_allowed if {
 	r := deny with input as {
 		"apiVersion": "v1",

--- a/checks/kubernetes/pss/restricted/7_Kubernetes_resource_with_disallowed_volumes_mounted.rego
+++ b/checks/kubernetes/pss/restricted/7_Kubernetes_resource_with_disallowed_volumes_mounted.rego
@@ -30,7 +30,6 @@ package builtin.kubernetes.KSV121
 import rego.v1
 
 import data.lib.kubernetes
-import data.lib.utils
 
 # Add disallowed volume type
 disallowedVolumes := [

--- a/lib/cidr_test.rego
+++ b/lib/cidr_test.rego
@@ -2,8 +2,6 @@ package lib.cidr_test
 
 import rego.v1
 
-import data.lib.test
-
 uint64max := 18446744073709551615
 
 test_count_addresses if {

--- a/lib/kubernetes/kubernetes.rego
+++ b/lib/kubernetes/kubernetes.rego
@@ -43,6 +43,10 @@ namespace := object.metadata.namespace
 
 kind := object.kind
 
+roleBindingKinds := {"RoleBinding", "ClusterRolebinding"}
+
+is_role_binding_kind if kind in roleBindingKinds
+
 is_pod if {
 	kind = "Pod"
 }

--- a/lib/squealer_test.rego
+++ b/lib/squealer_test.rego
@@ -2,8 +2,6 @@ package lib.squealer_test
 
 import rego.v1
 
-import data.lib.test
-
 test_squealer_secret_not_found if {
 	res := squealer.scan_string(`export GREETING="Hello there"`)
 	res.transgressionFound == false


### PR DESCRIPTION
In OPA 1.0, some strict mode checks will be enabled by default. See https://www.openpolicyagent.org/docs/latest/v0-upgrade/ and https://github.com/open-policy-agent/opa/issues/6271 . This PR includes a strict mode now.