### PR TITLE
fix(ci): setup oras

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,10 @@ jobs:
       - name: Create bundle
         run: make bundle
 
+      - uses: oras-project/setup-oras@v1
+        with:
+          version: 1.2
+
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Fixes: https://github.com/aquasecurity/trivy-checks/actions/runs/12878785691/job/35905261053

`oras` is no longer included in the list of installed ubuntu 24 tools, so it must be installed manually.