### PR TITLE
feat: gatekeeper repo ambiguous prefix

### DIFF
--- a/avd_docs/generic/general/AVD-KSV-0124/docs.md
+++ b/avd_docs/generic/general/AVD-KSV-0124/docs.md
@@ -1,0 +1,10 @@
+
+A Gatekeeper policy that references image repositories for prefix-matching is using open-ended and ambiguous pattern, and can potentially match unintended repositories.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+

--- a/checks/kubernetes/gatekeeper/repo_ambiguous_prefix.rego
+++ b/checks/kubernetes/gatekeeper/repo_ambiguous_prefix.rego
@@ -23,7 +23,7 @@ deny contains res if {
 	not contains(repo, ":")
 	res := result.new(
 		"open-ended repository reference in prefix match",
-		repo,
+		input.spec.parameters,
 	)
 }
 
@@ -35,6 +35,6 @@ deny contains res if {
 	count(parts) <= 2
 	res := result.new(
 		"open-ended repository reference in prefix match",
-		repo,
+		input.spec.parameters,
 	)
 }

--- a/checks/kubernetes/gatekeeper/repo_ambiguous_prefix.rego
+++ b/checks/kubernetes/gatekeeper/repo_ambiguous_prefix.rego
@@ -5,19 +5,19 @@
 #   - input: schema["kubernetes"]
 # custom:
 #   id: KSV-0124
-#   avdid: AVD-KSV-0124
+#   avd_id: AVD-KSV-0124
 #   severity: HIGH
 package builtin.kubernetes.KSV0124
 
 import rego.v1
 
-relevan_resource if {
+relevant_resource if {
 	input.apiVersion == "constraints.gatekeeper.sh/v1beta1"
 	input.kind == "K8sAllowedRepos"
 }
 
 deny contains res if {
-	relevan_resource
+	relevant_resource
 	some repo in input.spec.parameters.repos
 	not contains(repo, "/")
 	not contains(repo, ":")
@@ -28,7 +28,7 @@ deny contains res if {
 }
 
 deny contains res if {
-	relevan_resource
+	relevant_resource
 	some repo in input.spec.parameters.repos
 	parts := split(repo, "/")
 	parts[0] == "docker.io"

--- a/checks/kubernetes/gatekeeper/repo_ambiguous_prefix.rego
+++ b/checks/kubernetes/gatekeeper/repo_ambiguous_prefix.rego
@@ -8,34 +8,33 @@
 #   avdid: AVD-KSV-0124
 #   severity: HIGH
 package builtin.kubernetes.KSV0124
+
 import rego.v1
 
 relevan_resource if {
-    input.apiVersion == "constraints.gatekeeper.sh/v1beta1"
-    input.kind == "K8sAllowedRepos"
+	input.apiVersion == "constraints.gatekeeper.sh/v1beta1"
+	input.kind == "K8sAllowedRepos"
 }
 
 deny contains res if {
-    relevan_resource
-    some repo in input.spec.parameters.repos
-    not contains(repo,"/")
-    not contains(repo,":")
-    res := result.new(
-        "open-ended repository reference in prefix match",
-        repo
-    )
+	relevan_resource
+	some repo in input.spec.parameters.repos
+	not contains(repo, "/")
+	not contains(repo, ":")
+	res := result.new(
+		"open-ended repository reference in prefix match",
+		repo,
+	)
 }
 
 deny contains res if {
-    relevan_resource
-    some repo in input.spec.parameters.repos
-    parts:=split(repo,"/")
-    parts[0] == "docker.io"
-    count(parts) <= 2
-    res := result.new(
-        "open-ended repository reference in prefix match",
-        repo
-    )
+	relevan_resource
+	some repo in input.spec.parameters.repos
+	parts := split(repo, "/")
+	parts[0] == "docker.io"
+	count(parts) <= 2
+	res := result.new(
+		"open-ended repository reference in prefix match",
+		repo,
+	)
 }
-
-

--- a/checks/kubernetes/gatekeeper/repo_ambiguous_prefix.rego
+++ b/checks/kubernetes/gatekeeper/repo_ambiguous_prefix.rego
@@ -1,0 +1,41 @@
+# METADATA
+# title: Gatekeeper repo reference is ambiguously open-ended
+# description: A Gatekeeper policy that references image repositories for prefix-matching is using open-ended and ambiguous pattern, and can potentially match unintended repositories.
+# schemas:
+#   - input: schema["kubernetes"]
+# custom:
+#   id: KSV-0124
+#   avdid: AVD-KSV-0124
+#   severity: HIGH
+package builtin.kubernetes.KSV0124
+import rego.v1
+
+relevan_resource if {
+    input.apiVersion == "constraints.gatekeeper.sh/v1beta1"
+    input.kind == "K8sAllowedRepos"
+}
+
+deny contains res if {
+    relevan_resource
+    some repo in input.spec.parameters.repos
+    not contains(repo,"/")
+    not contains(repo,":")
+    res := result.new(
+        "open-ended repository reference in prefix match",
+        repo
+    )
+}
+
+deny contains res if {
+    relevan_resource
+    some repo in input.spec.parameters.repos
+    parts:=split(repo,"/")
+    parts[0] == "docker.io"
+    count(parts) <= 2
+    res := result.new(
+        "open-ended repository reference in prefix match",
+        repo
+    )
+}
+
+

--- a/checks/kubernetes/gatekeeper/repo_ambiguous_prefix_test.rego
+++ b/checks/kubernetes/gatekeeper/repo_ambiguous_prefix_test.rego
@@ -1,0 +1,70 @@
+package builtin.kubernetes.KSV0124
+
+import rego.v1
+
+bad_repos := {
+	"myregistry.io", # circumvented by: myregistry.io.attacker.com
+	"myusername", # circumvented by: myusernameattacker
+	"ubuntu", # circumvented by: ubuntu.attacker.com/evil, ubuntuevil
+	"docker.io/ubuntu", # circumvented by: docker.io/ubuntuattacker/evil
+}
+
+good_repos := {
+	"myregistry.azurecr.io/",
+	"myusername/",
+	"myimage:",
+	"docker.io/library/ubuntu",
+}
+
+test_bad_repos if {
+	cases := [
+	{
+		"apiVersion": "constraints.gatekeeper.sh/v1beta1",
+		"kind": "K8sAllowedRepos",
+		"metadata": {"name": "allowedrepos"},
+		"spec": {
+			"match": {
+				"kinds": [{
+					"apiGroups": [""],
+					"kinds": ["Pod"],
+				}],
+				"namespaces": ["default"],
+			},
+			"parameters": {"repos": [repo]},
+		},
+	} |
+		some repo in bad_repos
+	]
+	every case in cases {
+		r := deny with input as case
+		count(r) > 0
+	}
+}
+
+test_good_repos if {
+	cases := [
+	{
+		"apiVersion": "constraints.gatekeeper.sh/v1beta1",
+		"kind": "K8sAllowedRepos",
+		"metadata": {"name": "allowedrepos"},
+		"spec": {
+			"match": {
+				"kinds": [{
+					"apiGroups": [""],
+					"kinds": ["Pod"],
+				}],
+				"namespaces": ["default"],
+			},
+			"parameters": {"repos": [repo]},
+		},
+	} |
+		some repo in good_repos
+	]
+
+	every case in cases {
+		r := deny with input as case
+		count(r) == 0
+	}
+}
+
+

--- a/checks/kubernetes/gatekeeper/repo_ambiguous_prefix_test.rego
+++ b/checks/kubernetes/gatekeeper/repo_ambiguous_prefix_test.rego
@@ -66,5 +66,3 @@ test_good_repos if {
 		count(r) == 0
 	}
 }
-
-


### PR DESCRIPTION
Gatekeeper does a prefix-match (startswith) to check if a repo is allowed. this can be leveraged by attackers who create repos with simlar prefix which can bypass the prefix matching (see tests for examples)

related: https://github.com/open-policy-agent/gatekeeper-library/pull/616