### PR TITLE
lint: require input field of Rego metadata

### DIFF
--- a/.regal/rules/custom/regal/rules/custom/invalid-metadata/invalid_metadata.rego
+++ b/.regal/rules/custom/regal/rules/custom/invalid-metadata/invalid_metadata.rego
@@ -74,7 +74,7 @@ check_metadata_schema := {
 		"recommended_actions": {"type": "string"},
 		"recommended_action": {"type": "string"},
 	},
-	"required": ["id", "avd_id"],
+	"required": ["id", "avd_id", "input"],
 	"additionalProperties": false,
 	"anyOf": [
 		{"required": ["recommended_actions"]},

--- a/.regal/rules/custom/regal/rules/custom/invalid-metadata/invalid_metadata_test.rego
+++ b/.regal/rules/custom/regal/rules/custom/invalid-metadata/invalid_metadata_test.rego
@@ -23,7 +23,7 @@ foo := true`)
 
 	r == {{
 		"category": "custom",
-		"description": "(Root): avd_id is required\n(Root): Additional property avdid is not allowed",
+		"description": "(Root): avd_id is required\n(Root): input is required\n(Root): Additional property avdid is not allowed",
 		"level": "error",
 		"location": {
 			"col": 1,

--- a/avd_docs/kubernetes/general/AVD-KSV-0124/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KSV-0124/docs.md
@@ -1,0 +1,10 @@
+
+A Gatekeeper policy that references image repositories for prefix-matching is using open-ended and ambiguous pattern, and can potentially match unintended repositories.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+

--- a/checks/kubernetes/gatekeeper/repo_ambiguous_prefix.rego
+++ b/checks/kubernetes/gatekeeper/repo_ambiguous_prefix.rego
@@ -7,6 +7,9 @@
 #   id: KSV-0124
 #   avd_id: AVD-KSV-0124
 #   severity: HIGH
+#   input:
+#     selector:
+#     - type: kubernetes
 package builtin.kubernetes.KSV0124
 
 import rego.v1


### PR DESCRIPTION
Checks that do not use the input field are applied to all input data:
```bash
2025-01-30T02:59:21.0158634Z 2025-01-30T02:55:18Z	WARN	[rego] Module has no input selectors - it will be loaded for all inputs!	file_path="checks/kubernetes/gatekeeper/repo_ambiguous_prefix.rego" module="checks/kubernetes/gatekeeper/repo_ambiguous_prefix.rego"
```