### PR TITLE
fix(checks): AVD-AWS-0034 enhanced container insights

### DIFF
--- a/checks/cloud/aws/ecs/enable_container_insight.rego
+++ b/checks/cloud/aws/ecs/enable_container_insight.rego
@@ -37,9 +37,9 @@ import data.lib.cloud.metadata
 
 deny contains res if {
 	some cluster in input.aws.ecs.clusters
-	not cluster.settings.containerinsightsenabled.value
+	value.is(cluster.settings.containerinsightsmode, "disabled")
 	res := result.new(
 		"Cluster does not have container insights enabled.",
-		metadata.obj_by_path(cluster, ["settings", "containerinsightsenabled"]),
+		metadata.obj_by_path(cluster, ["settings", "containerinsightsmode"]),
 	)
 }

--- a/checks/cloud/aws/ecs/enable_container_insight_test.rego
+++ b/checks/cloud/aws/ecs/enable_container_insight_test.rego
@@ -6,13 +6,19 @@ import data.builtin.aws.ecs.aws0034 as check
 import data.lib.test
 
 test_allow_cluster_with_container_insights if {
-	inp := {"aws": {"ecs": {"clusters": [{"settings": {"containerinsightsenabled": {"value": true}}}]}}}
+	inp := {"aws": {"ecs": {"clusters": [{"settings": {"containerinsightsmode": {"value": "enabled"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_cluster_with_enhanced_container_insights if {
+	inp := {"aws": {"ecs": {"clusters": [{"settings": {"containerinsightsmode": {"value": "enhanced"}}}]}}}
 
 	test.assert_empty(check.deny) with input as inp
 }
 
 test_deny_cluster_without_container_insights if {
-	inp := {"aws": {"ecs": {"clusters": [{"settings": {"containerinsightsenabled": {"value": false}}}]}}}
+	inp := {"aws": {"ecs": {"clusters": [{"settings": {"containerinsightsmode": {"value": "disabled"}}}]}}}
 
 	test.assert_equal_message("Cluster does not have container insights enabled.", check.deny) with input as inp
 }

--- a/test/rego/aws_ecs_test.go
+++ b/test/rego/aws_ecs_test.go
@@ -20,8 +20,8 @@ var awsEcsTestCases = testCases{
 					{
 						Metadata: trivyTypes.NewTestMetadata(),
 						Settings: ecs.ClusterSettings{
-							Metadata:                 trivyTypes.NewTestMetadata(),
-							ContainerInsightsEnabled: trivyTypes.Bool(false, trivyTypes.NewTestMetadata()),
+							Metadata:              trivyTypes.NewTestMetadata(),
+							ContainerInsightsMode: trivyTypes.String("disabled", trivyTypes.NewTestMetadata()),
 						},
 					},
 				},
@@ -35,8 +35,23 @@ var awsEcsTestCases = testCases{
 					{
 						Metadata: trivyTypes.NewTestMetadata(),
 						Settings: ecs.ClusterSettings{
-							Metadata:                 trivyTypes.NewTestMetadata(),
-							ContainerInsightsEnabled: trivyTypes.Bool(true, trivyTypes.NewTestMetadata()),
+							Metadata:              trivyTypes.NewTestMetadata(),
+							ContainerInsightsMode: trivyTypes.String("enabled", trivyTypes.NewTestMetadata()),
+						},
+					},
+				},
+			}}},
+			expected: false,
+		},
+		{
+			name: "Cluster with enhanced container insights",
+			input: state.State{AWS: aws.AWS{ECS: ecs.ECS{
+				Clusters: []ecs.Cluster{
+					{
+						Metadata: trivyTypes.NewTestMetadata(),
+						Settings: ecs.ClusterSettings{
+							Metadata:              trivyTypes.NewTestMetadata(),
+							ContainerInsightsMode: trivyTypes.String("enhanced", trivyTypes.NewTestMetadata()),
 						},
 					},
 				},


### PR DESCRIPTION
Replaces the current ContainerInsightsEnabled boolean attribute on the ECS cluster settings with ContainerInsightsMode. Container Insights now supports three possible values, enabled, disabled and enhanced (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ClusterSetting.html) 

The enhanced mode is what is recommended by AWS now to get further metrics and details but has been separted from enable/disable due to its cost. 
