### PR TITLE
chore: fix metadata for AVD-KSV-0123

### DIFF
--- a/avd_docs/kubernetes/general/AVD-KSV-0123/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KSV-0123/docs.md
@@ -1,5 +1,5 @@
 
-Binding to system:authenticate group to any clusterrole or role is a security risk.
+Binding to system:masters group to any clusterrole or role is a security risk.
 
 ### Impact
 <!-- Add Impact here -->
@@ -8,6 +8,6 @@ Binding to system:authenticate group to any clusterrole or role is a security ri
 {{ remediationActions }}
 
 ### Links
-- https://orca.security/resources/blog/sys-all-google-kubernetes-engine-risk/
+- https://www.aquasec.com/blog/kubernetes-authorization/
 
 

--- a/checks/kubernetes/general/masters_group_bind.rego
+++ b/checks/kubernetes/general/masters_group_bind.rego
@@ -1,17 +1,17 @@
 # METADATA
-# title: "system:authenticate group access binding"
-# description: "Binding to system:authenticate group to any clusterrole or role is a security risk."
+# title: "system:masters group access binding"
+# description: "Binding to system:masters group to any clusterrole or role is a security risk."
 # scope: package
 # schemas:
 # - input: schema["kubernetes"]
 # related_resources:
-# - https://orca.security/resources/blog/sys-all-google-kubernetes-engine-risk/
+# - https://www.aquasec.com/blog/kubernetes-authorization/
 # custom:
-#   id: KSV01011
+#   id: KSV0123
 #   avd_id: AVD-KSV-0123
 #   severity: CRITICAL
-#   short_code: no-system-authenticated-group-bind
-#   recommended_action: "Remove system:authenticated group binding from clusterrolebinding or rolebinding."
+#   short_code: no-system-masters-group-bind
+#   recommended_action: "Remove system:masters group binding from clusterrolebinding or rolebinding."
 #   input:
 #     selector:
 #     - type: kubernetes


### PR DESCRIPTION
Currently, the metadata for AVD-KSV-0123 is the same as that for [AVD-KSV-01011](https://github.com/aquasecurity/trivy-checks/blob/dbc1975e8fa81ac30489c43cead6dda722615c3a/checks/kubernetes/gke/authenticate_group_bind.rego). Since AVD-KSV-0123 is related to the rule for the `system:masters` group, we will update it to the appropriate info.