### PR TITLE
fix: avoid reference to input.metadata.namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test-integration:
 	go test -v -timeout 5m -tags=integration ./integration/...
 
 .PHONY: rego
-rego: fmt-rego test-rego
+rego: fmt-rego check-rego lint-rego test-rego docs
 
 .PHONY: fmt-rego
 fmt-rego:

--- a/checks/kubernetes/advanced/default_namespace_should_not_be_used.rego
+++ b/checks/kubernetes/advanced/default_namespace_should_not_be_used.rego
@@ -29,6 +29,7 @@ package builtin.kubernetes.KSV110
 
 import rego.v1
 
+import data.lib.cloud.metadata
 import data.lib.kubernetes
 
 default defaultNamespaceInUse := false
@@ -43,5 +44,5 @@ defaultNamespaceInUse if {
 deny contains res if {
 	defaultNamespaceInUse
 	msg := kubernetes.format(sprintf("%s %s in %s namespace should set metadata.namespace to a non-default namespace", [lower(kubernetes.kind), kubernetes.name, kubernetes.namespace]))
-	res := result.new(msg, input.metadata.namespace)
+	res := result.new(msg, metadata.obj_by_path(input.metadata, ["namespace"]))
 }

--- a/checks/kubernetes/advanced/default_namespace_should_not_be_used_test.rego
+++ b/checks/kubernetes/advanced/default_namespace_should_not_be_used_test.rego
@@ -34,6 +34,23 @@ test_pod_with_default_namespace if {
 	count(r) == 1
 }
 
+test_pod_without_namespace if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "redis-master-85547b7b9-fxnrp",
+			"resourceVersion": "443282",
+		},
+		"spec": {"containers": [{
+			"image": "redis",
+			"name": "master",
+		}]},
+	}
+
+	count(r) == 1
+}
+
 test_pod_non_default_namespace if {
 	r := deny with input as {
 		"apiVersion": "v1",


### PR DESCRIPTION
The `input.metadata.namespace` field may be missing, which may cause the check to fail.