### PR TITLE
fix: DS001 should not trigger for an empty image

### DIFF
--- a/checks/docker/latest_tag.rego
+++ b/checks/docker/latest_tag.rego
@@ -115,6 +115,7 @@ deny contains res if {
 	[img, tag] := parse_image_and_tag(instruction, vars)
 
 	img != "scratch"
+	img != ""
 	not is_alias(img)
 	tag == "latest"
 

--- a/checks/docker/latest_tag_test.rego
+++ b/checks/docker/latest_tag_test.rego
@@ -221,6 +221,21 @@ test_allow_tag_ref_to_global_arg_without_default_value if {
 	count(r) == 0
 }
 
+test_allow_from_with_only_arg_without_default_value if {
+	r := deny with input as {"Stages": [
+		{"Name": "", "Commands": [{
+			"Cmd": "arg",
+			"Value": ["BASE_IMAGE"],
+		}]},
+		{"Name": "$BASE_IMAGE", "Commands": [{
+			"Cmd": "from",
+			"Value": ["$BASE_IMAGE"],
+		}]},
+	]}
+
+	count(r) == 0
+}
+
 test_deny_image_ref_to_global_arg_without_default_value if {
 	r := deny with input as {"Stages": [
 		{"Name": "", "Commands": [{


### PR DESCRIPTION
Related issues:
- https://github.com/aquasecurity/trivy/issues/8438

### Before
```bash
Dockerfile (dockerfile)

Tests: 28 (SUCCESSES: 25, FAILURES: 3)
Failures: 3 (UNKNOWN: 0, LOW: 1, MEDIUM: 1, HIGH: 1, CRITICAL: 0)

AVD-DS-0001 (MEDIUM): Specify a tag in the 'FROM' statement for image ''
═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
When using a 'FROM' statement you should use a specific tag to avoid uncontrolled behavior when the image is updated.

See https://avd.aquasec.com/misconfig/ds001
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Dockerfile:2
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   2 [ FROM $BASE_IMAGE
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────


AVD-DS-0002 (HIGH): Specify at least 1 USER command in Dockerfile with non-root user as argument
═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Running containers with 'root' user can lead to a container escape situation. It is a best practice to run containers as non-root users, which can be done by adding a 'USER' statement to the Dockerfile.

See https://avd.aquasec.com/misconfig/ds002
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────


AVD-DS-0026 (LOW): Add HEALTHCHECK instruction in your Dockerfile
═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
You should add HEALTHCHECK instruction in your docker container images to perform the health check on running containers.

See https://avd.aquasec.com/misconfig/ds026
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

### After
```bash
Dockerfile (dockerfile)

Tests: 28 (SUCCESSES: 26, FAILURES: 2)
Failures: 2 (UNKNOWN: 0, LOW: 1, MEDIUM: 0, HIGH: 1, CRITICAL: 0)

AVD-DS-0002 (HIGH): Specify at least 1 USER command in Dockerfile with non-root user as argument
═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Running containers with 'root' user can lead to a container escape situation. It is a best practice to run containers as non-root users, which can be done by adding a 'USER' statement to the Dockerfile.

See https://avd.aquasec.com/misconfig/ds002
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────


AVD-DS-0026 (LOW): Add HEALTHCHECK instruction in your Dockerfile
═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
You should add HEALTHCHECK instruction in your docker container images to perform the health check on running containers.

See https://avd.aquasec.com/misconfig/ds026
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```
