### PR TITLE
fix(misconf): make protocol checks case-insensitive and convert numeric protocols to strings

### DIFF
--- a/checks/cloud/aws/ec2/no_public_ingress_sgr_test.rego
+++ b/checks/cloud/aws/ec2/no_public_ingress_sgr_test.rego
@@ -18,6 +18,28 @@ test_deny_ingress_sq_all_ips_for_ssh_port_and_tcp if {
 	test.assert_count(check.deny, 1) with input as inp
 }
 
+test_deny_ingress_sq_all_ips_for_ssh_port_and_uppercase_tcp if {
+	inp := build_input({
+		"protocol": {"value": "TCP"},
+		"cidrs": [{"value": "0.0.0.0/0"}],
+		"fromport": {"value": net.ssh_port},
+		"toport": {"value": net.ssh_port},
+	})
+
+	test.assert_count(check.deny, 1) with input as inp
+}
+
+test_deny_ingress_sq_all_ips_for_ssh_port_and_int_tcp if {
+	inp := build_input({
+		"protocol": {"value": 6},
+		"cidrs": [{"value": "0.0.0.0/0"}],
+		"fromport": {"value": net.ssh_port},
+		"toport": {"value": net.ssh_port},
+	})
+
+	test.assert_count(check.deny, 1) with input as inp
+}
+
 test_deny_ingress_sq_all_ips_for_rdp_port_and_udp if {
 	inp := build_input({
 		"protocol": {"value": "udp"},

--- a/lib/cloud/net.rego
+++ b/lib/cloud/net.rego
@@ -21,23 +21,23 @@ all_protocols := {"-1", "all"}
 
 # "6" is ID of TCP
 # https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
-is_tcp_protocol(protocol) if protocol in {"tcp", "6"}
+is_tcp_protocol(p) if protocol(p) in {"tcp", "6"}
 
-is_tcp_protocol(protocol) if protocol in all_protocols
+is_tcp_protocol(p) if protocol(p) in all_protocols
 
 # "17" is ID of UDP
 # https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
-is_udp_protocol(protocol) if protocol in {"udp", "17"}
+is_udp_protocol(p) if protocol(p) in {"udp", "17"}
 
-is_udp_protocol(protocol) if protocol in all_protocols
+is_udp_protocol(p) if protocol(p) in all_protocols
 
-is_tcp_or_udp_protocol(protocol) if is_tcp_protocol(protocol)
+is_tcp_or_udp_protocol(p) if is_tcp_protocol(p)
 
-is_tcp_or_udp_protocol(protocol) if is_udp_protocol(protocol)
+is_tcp_or_udp_protocol(p) if is_udp_protocol(p)
 
 # protocol "-1" allows traffic on all ports, regardless of any port range you specify.
 # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AuthorizeSecurityGroupIngress.html
-is_ssh_or_rdp_port(rule) if rule.protocol.value in {"-1"}
+is_ssh_or_rdp_port(rule) if protocol(rule.protocol.value) in {"-1", "all"}
 
 is_ssh_or_rdp_port(rule) if is_port_range_include(rule.fromport.value, rule.toport.value, ssh_port)
 
@@ -50,3 +50,7 @@ is_port_range_include(from, to, port) if {
 
 # check if CIDR defines an IP block containing all possible IP addresses
 cidr_allows_all_ips(cidr) if cidr in all_ips
+
+protocol(v) := lower(v) if is_string(v)
+
+protocol(v) := lower(format_int(v, 10)) if is_number(v)


### PR DESCRIPTION
Previously, protocol checks were case-sensitive, causing false positives. Now, all protocol values are normalized to lowercase before comparison. Additionally, numeric protocol values are converted to strings for consistency.

Related PRs:
- https://github.com/aquasecurity/trivy/issues/8460