### PR TITLE
ci: grant permission to release workflow

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -11,3 +11,6 @@ jobs:
     with:
       nightly: true
     secrets: inherit
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,3 +9,6 @@ jobs:
     name: Release
     uses: ./.github/workflows/reusable-release.yaml
     secrets: inherit
+    permissions:
+      contents: read
+      packages: write


### PR DESCRIPTION
Permissions must be granted to the called workflow.

Fix: https://github.com/aquasecurity/trivy-checks/actions/runs/13583124854