### PR TITLE
fix: check only managed load balancers

### DIFF
--- a/checks/cloud/aws/elb/http_not_used.rego
+++ b/checks/cloud/aws/elb/http_not_used.rego
@@ -29,6 +29,7 @@ import rego.v1
 
 deny contains res if {
 	some lb in input.aws.elb.loadbalancers
+	isManaged(lb)
 	lb.type.value == "application"
 
 	some listener in lb.listeners

--- a/checks/cloud/aws/elb/use_secure_tls_policy.rego
+++ b/checks/cloud/aws/elb/use_secure_tls_policy.rego
@@ -39,6 +39,7 @@ outdated_ssl_policies := {
 
 deny contains res if {
 	some lb in input.aws.elb.loadbalancers
+	isManaged(lb)
 	some listener in lb.listeners
 	has_outdated_policy(listener)
 	res := result.new("Listener uses an outdated TLS policy.", listener.tlspolicy)


### PR DESCRIPTION
Trivy assigns orphaned load balancer listeners (those that do not have an associated load balancer) to a dummy load balancer. Such a dummy load balancer should not be checked.