### PR TITLE
feat(checks): Add checks for `IngressNightmare`

### DIFF
--- a/avd_docs/kubernetes/general/AVD-KCV-0093/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0093/docs.md
@@ -1,0 +1,17 @@
+
+Check for insecure annotations in ingress-nginx configurations.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://github.com/kubernetes/kubernetes/issues/131008
+
+- https://github.com/kubernetes/kubernetes/issues/131007
+
+- https://github.com/kubernetes/kubernetes/issues/131006
+
+

--- a/checks/kubernetes/network/insecure_ingress_nginx.rego
+++ b/checks/kubernetes/network/insecure_ingress_nginx.rego
@@ -1,0 +1,54 @@
+# METADATA
+# title: "Ensure ingress-nginx annotations are secure"
+# description: "Check for insecure annotations in ingress-nginx configurations."
+# scope: package
+# schemas:
+# - input: schema["kubernetes"]
+# related_resources:
+# - https://github.com/kubernetes/kubernetes/issues/131008
+# - https://github.com/kubernetes/kubernetes/issues/131007
+# - https://github.com/kubernetes/kubernetes/issues/131006
+# custom:
+#   id: KCV0093
+#   avd_id: AVD-KCV-0093
+#   severity: CRITICAL
+#   short_code: insecure-ingress-nginx
+#   recommended_action: "Ensure that ingress-nginx annotations do not contain suspicious characters."
+#   input:
+#     selector:
+#     - type: kubernetes
+# examples: checks/kubernetes/network/insecure_ingress_nginx.yaml
+
+package builtin.kubernetes.kcv0093
+
+import data.lib.kubernetes
+import rego.v1
+
+annotation_keys := {
+	"auth_url": "nginx.ingress.kubernetes.io/auth-url",
+	"auth_tls_match_cn": "nginx.ingress.kubernetes.io/auth-tls-match-cn",
+	"mirror_target": "nginx.ingress.kubernetes.io/mirror-target",
+	"mirror_host": "nginx.ingress.kubernetes.io/mirror-host",
+}
+
+regex_patterns := {
+	"url": "https?://[^\\s<>\"{}|^`\\\\\\r\\n]*[\\r\\n<>\"{}|^`\\\\][^\\s]*",
+	"cn": "CN=.*[\\r\\n#{};|].*",
+}
+
+suspicious_annotation := {[key, value] |
+	lower(input.kind) == "ingress"
+	kubernetes.has_field(input.spec, "ingressClassName")
+	lower(input.spec.ingressClassName) == "nginx"
+	key := annotation_keys[_]
+	value := input.metadata.annotations[key]
+	regex.match(regex_patterns[_], value)
+}
+
+deny contains res if {
+	[key, value] := suspicious_annotation[_]
+	res := result.new(
+		sprintf("Pod has a %s annotation containing suspicious characters", [key]),
+		[value],
+	)
+}

--- a/checks/kubernetes/network/insecure_ingress_nginx.yaml
+++ b/checks/kubernetes/network/insecure_ingress_nginx.yaml
@@ -1,0 +1,99 @@
+kubernetes:
+  good:
+    - |-
+      apiVersion: v1
+      kind: Ingress
+      metadata:
+        name: test-ingress-valid-url
+        namespace: default
+        annotations:
+          nginx.ingress.kubernetes.io/auth-url: "https://valid-url.com"
+    - |-
+      apiVersion: v1
+      kind: Ingress
+      metadata:
+        name: test-ingress-valid-cn
+        namespace: default
+        annotations:
+          nginx.ingress.kubernetes.io/auth-tls-match-cn: "CN=valid-cn"
+    - |-
+      apiVersion: v1
+      kind: Ingress
+      metadata:
+        name: test-ingress-valid-target
+        namespace: default
+        annotations:
+          nginx.ingress.kubernetes.io/mirror-target: "https://valid-url.com"
+    - |-
+      apiVersion: v1
+      kind: Ingress
+      metadata:
+        name: test-ingress-valid-host
+        namespace: default
+        annotations:
+          nginx.ingress.kubernetes.io/mirror-host: "https://valid-url.com"
+  bad:
+    - |-
+      apiVersion: v1
+      kind: Ingress
+      metadata:
+        name: test-ingress-invalid-url
+        namespace: default
+        annotations:
+          nginx.ingress.kubernetes.io/auth-url: "http://example.com/invalid|url"
+    - |-
+      apiVersion: v1
+      kind: Ingress
+      metadata:
+        name: test-ingress-suspicious-char
+        namespace: default
+        annotations:
+          nginx.ingress.kubernetes.io/auth-url: "http://example.com/#;\ninjection_point"
+    - |-
+      apiVersion: v1
+      kind: Ingress
+      metadata:
+        name: test-ingress-invalid-cn
+        namespace: default
+        annotations:
+          nginx.ingress.kubernetes.io/auth-tls-match-cn: "CN=invalid|cn"
+    - |-
+      apiVersion: v1
+      kind: Ingress
+      metadata:
+        name: test-ingress-suspicious-char-cn
+        namespace: default
+        annotations:
+          nginx.ingress.kubernetes.io/auth-tls-match-cn: "CN=valid#;\ninjection_point"
+    - |-
+      apiVersion: v1
+      kind: Ingress
+      metadata:
+        name: test-ingress-invalid-target
+        namespace: default
+        annotations:
+          nginx.ingress.kubernetes.io/mirror-target: "http://example.com/invalid|url"
+    - |-
+      apiVersion: v1
+      kind: Ingress
+      metadata:
+        name: test-ingress-suspicious-char-target
+        namespace: default
+        annotations:
+          nginx.ingress.kubernetes.io/mirror-target: "http://example.com/#;\ninjection_point"
+    - |-
+      apiVersion: v1
+      kind: Ingress
+      metadata:
+        name: test-ingress-invalid-host
+        namespace: default
+        annotations:
+          nginx.ingress.kubernetes.io/mirror-host: "http://example.com/invalid|url"
+    - |-
+      apiVersion: v1
+      kind: Ingress
+      metadata:
+        name: test-ingress-suspicious-char-host
+        namespace: default
+        annotations:
+          nginx.ingress.kubernetes.io/mirror-host: "http://example.com/#;\ninjection_point"

--- a/checks/kubernetes/network/insecure_ingress_nginx_test.rego
+++ b/checks/kubernetes/network/insecure_ingress_nginx_test.rego
@@ -1,0 +1,195 @@
+package builtin.kubernetes.kcv0093
+
+import rego.v1
+
+# Tests for auth-url annotation
+test_invalid_auth_url_annotation if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Ingress",
+		"metadata": {
+			"name": "test-ingress-invalid-url",
+			"namespace": "default",
+			"annotations": {"nginx.ingress.kubernetes.io/auth-url": "http://example.com/invalid|url"},
+		},
+		"spec": {"ingressClassName": "nginx"},
+	}
+
+	count(r) == 1
+	r[_].msg == "Pod has a nginx.ingress.kubernetes.io/auth-url annotation containing suspicious characters"
+}
+
+test_suspicious_char_auth_url_annotation if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Ingress",
+		"metadata": {
+			"name": "test-ingress-suspicious-char",
+			"namespace": "default",
+			"annotations": {"nginx.ingress.kubernetes.io/auth-url": "http://example.com/#;\ninjection_point"},
+		},
+		"spec": {"ingressClassName": "nginx"},
+	}
+
+	count(r) == 1
+	r[_].msg == "Pod has a nginx.ingress.kubernetes.io/auth-url annotation containing suspicious characters"
+}
+
+test_valid_auth_url_annotation if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Ingress",
+		"metadata": {
+			"name": "test-ingress-valid-url",
+			"namespace": "default",
+			"annotations": {"nginx.ingress.kubernetes.io/auth-url": "https://valid-url.com"},
+		},
+		"spec": {"ingressClassName": "nginx"},
+	}
+
+	count(r) == 0
+}
+
+# Tests for auth-tls-match-cn annotation
+test_invalid_auth_tls_match_cn_annotation if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Ingress",
+		"metadata": {
+			"name": "test-ingress-invalid-cn",
+			"namespace": "default",
+			"annotations": {"nginx.ingress.kubernetes.io/auth-tls-match-cn": "CN=invalid|cn"},
+		},
+		"spec": {"ingressClassName": "nginx"},
+	}
+
+	count(r) == 1
+	r[_].msg == "Pod has a nginx.ingress.kubernetes.io/auth-tls-match-cn annotation containing suspicious characters"
+}
+
+test_suspicious_char_auth_tls_match_cn_annotation if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Ingress",
+		"metadata": {
+			"name": "test-ingress-suspicious-char-cn",
+			"namespace": "default",
+			"annotations": {"nginx.ingress.kubernetes.io/auth-tls-match-cn": "CN=valid#;\ninjection_point"},
+		},
+		"spec": {"ingressClassName": "nginx"},
+	}
+
+	count(r) == 1
+	r[_].msg == "Pod has a nginx.ingress.kubernetes.io/auth-tls-match-cn annotation containing suspicious characters"
+}
+
+test_valid_auth_tls_match_cn_annotation if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Ingress",
+		"metadata": {
+			"name": "test-ingress-valid-cn",
+			"namespace": "default",
+			"annotations": {"nginx.ingress.kubernetes.io/auth-tls-match-cn": "CN=valid-cn"},
+		},
+		"spec": {"ingressClassName": "nginx"},
+	}
+
+	count(r) == 0
+}
+
+# Tests for mirror-target annotation
+test_invalid_mirror_target_annotation if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Ingress",
+		"metadata": {
+			"name": "test-ingress-invalid-target",
+			"namespace": "default",
+			"annotations": {"nginx.ingress.kubernetes.io/mirror-target": "http://example.com/invalid|url"},
+		},
+		"spec": {"ingressClassName": "nginx"},
+	}
+
+	count(r) == 1
+	r[_].msg == "Pod has a nginx.ingress.kubernetes.io/mirror-target annotation containing suspicious characters"
+}
+
+test_suspicious_char_mirror_target_annotation if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Ingress",
+		"metadata": {
+			"name": "test-ingress-suspicious-char-target",
+			"namespace": "default",
+			"annotations": {"nginx.ingress.kubernetes.io/mirror-target": "http://example.com/#;\ninjection_point"},
+		},
+		"spec": {"ingressClassName": "nginx"},
+	}
+
+	count(r) == 1
+	r[_].msg == "Pod has a nginx.ingress.kubernetes.io/mirror-target annotation containing suspicious characters"
+}
+
+test_valid_mirror_target_annotation if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Ingress",
+		"metadata": {
+			"name": "test-ingress-valid-target",
+			"namespace": "default",
+			"annotations": {"nginx.ingress.kubernetes.io/mirror-target": "https://valid-url.com"},
+		},
+		"spec": {"ingressClassName": "nginx"},
+	}
+
+	count(r) == 0
+}
+
+# Tests for mirror-host annotation
+test_invalid_mirror_host_annotation if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Ingress",
+		"metadata": {
+			"name": "test-ingress-invalid-host",
+			"namespace": "default",
+			"annotations": {"nginx.ingress.kubernetes.io/mirror-host": "http://example.com/invalid|url"},
+		},
+		"spec": {"ingressClassName": "nginx"},
+	}
+
+	count(r) == 1
+	r[_].msg == "Pod has a nginx.ingress.kubernetes.io/mirror-host annotation containing suspicious characters"
+}
+
+test_suspicious_char_mirror_host_annotation if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Ingress",
+		"metadata": {
+			"name": "test-ingress-suspicious-char-host",
+			"namespace": "default",
+			"annotations": {"nginx.ingress.kubernetes.io/mirror-host": "http://example.com/#;\ninjection_point"},
+		},
+		"spec": {"ingressClassName": "nginx"},
+	}
+
+	count(r) == 1
+	r[_].msg == "Pod has a nginx.ingress.kubernetes.io/mirror-host annotation containing suspicious characters"
+}
+
+test_valid_mirror_host_annotation if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Ingress",
+		"metadata": {
+			"name": "test-ingress-valid-host",
+			"namespace": "default",
+			"annotations": {"nginx.ingress.kubernetes.io/mirror-host": "https://valid-url.com"},
+		},
+		"spec": {"ingressClassName": "nginx"},
+	}
+
+	count(r) == 0
+}


### PR DESCRIPTION
## PoC

```bash
cat -n malicious-ingress.yaml
     1	apiVersion: networking.k8s.io/v1
     2	kind: Ingress
     3	metadata:
     4	  name: demo
     5	  annotations:
     6	    nginx.ingress.kubernetes.io/auth-url: "http://example.com/#;\ninjection_point"
     7	    nginx.ingress.kubernetes.io/auth-tls-match-cn: "CN=invalid|cn"
     8	    nginx.ingress.kubernetes.io/mirror-target: "http://example.com/#;\ninjection_point"
     9	    nginx.ingress.kubernetes.io/mirror-host: "http://example.com/#;\ninjection_point"
    10	spec:
    11	  ingressClassName: nginx
    12	  rules:
    13	  - host: test.example.com
    14	    http:
    15	      paths:
    16	      - path: /
    17	        pathType: Prefix
    18	        backend:
    19	          service:
    20	            name: test-service
    21	            port:
    22	              number: 80

```

### Scan output
```

$ trivy k8s --scanners=misconfig --report=all  --severity=CRITICAL

namespace: default, ingress: demo (kubernetes)

Tests: 8 (SUCCESSES: 4, FAILURES: 4)
Failures: 4 (CRITICAL: 4)

AVD-KCV-0093 (CRITICAL): Pod has a nginx.ingress.kubernetes.io/auth-tls-match-cn annotation containing suspicious characters
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Check for insecure annotations in ingress-nginx configurations.

See https://avd.aquasec.com/misconfig/kcv0093
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────


AVD-KCV-0093 (CRITICAL): Pod has a nginx.ingress.kubernetes.io/auth-url annotation containing suspicious characters
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Check for insecure annotations in ingress-nginx configurations.

See https://avd.aquasec.com/misconfig/kcv0093
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────


AVD-KCV-0093 (CRITICAL): Pod has a nginx.ingress.kubernetes.io/mirror-host annotation containing suspicious characters
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Check for insecure annotations in ingress-nginx configurations.

See https://avd.aquasec.com/misconfig/kcv0093
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────


AVD-KCV-0093 (CRITICAL): Pod has a nginx.ingress.kubernetes.io/mirror-target annotation containing suspicious characters
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Check for insecure annotations in ingress-nginx configurations.

See https://avd.aquasec.com/misconfig/kcv0093
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

```


## Details

  - CVE-2025-24514
      - IoC: `auth-url`
      - https://github.com/kubernetes/kubernetes/issues/131006
  - CVE-2025-1974
      - No known IoC 
      - https://github.com/kubernetes/kubernetes/issues/131009
  - CVE-2025-1097
      - IoC: `auth-tls-match-cn`
      - https://github.com/kubernetes/kubernetes/issues/131007
  - CVE-2025-1098
      - IoC: `mirror-target` or `mirror-host`
      - https://github.com/kubernetes/kubernetes/issues/131008
  - List of all annotations: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md
  - Updates to regex verification in ingress-nginx https://github.com/kubernetes/ingress-nginx/blob/1d7abc12ef727bca69a9e35b88d1167d6d502e9f/internal/ingress/annotations/parser/validators.go#L118 