### PR TITLE
fix(bundle): Correctly add compliance checks into the bundle

### DIFF
--- a/cmd/bundle/bundle.sh
+++ b/cmd/bundle/bundle.sh
@@ -28,7 +28,7 @@ for dir in config; do
 done
 
 mkdir -p bundle/specs/compliance
-rsync -avr pkg/specs/compliance bundle/specs
+rsync -avr --exclude="*.go" --exclude="*.md" pkg/compliance bundle/specs
 
 cp checks/.manifest bundle/
 rm bundle/policies/.manifest


### PR DESCRIPTION
https://github.com/aquasecurity/trivy-checks/pull/308 missed adding the compliance specs to the bundle.

```shell
~/repos/trivy/trivy clean --checks-bundle
2025-03-27T23:30:06-06:00	INFO	Removing check bundle...

 ~/repos/trivy/trivy k8s --include-namespaces=default --checks-bundle-repository=localhost:5111/defsec:1  --scanners=misconfig --report=all  --severity=CRITICAL
2025-03-27T23:30:28-06:00	INFO	[misconfig] Need to update the checks bundle
2025-03-27T23:30:28-06:00	INFO	[misconfig] Downloading the checks bundle...
204.64 KiB / 204.64 KiB [-----------------------------------] 100.00% ? p/s 200ms
2025-03-27T23:30:30-06:00	INFO	Node scanning is enabled
2025-03-27T23:30:30-06:00	INFO	If you want to disable Node scanning via an in-cluster Job, please try '--disable-node-collector' to disable the Node-Collector job.
2025-03-27T23:30:30-06:00	INFO	Scanning K8s...	K8s="kind-default"



ls -lrth ~/Library/Caches/trivy/policy/content/specs/compliance
total 272
-rw-r--r--@ 1 ss  staff    32K Mar 10 23:48 rke2-cis-1.24.yaml
-rw-r--r--@ 1 ss  staff   4.1K Mar 10 23:48 k8s-pss-restricted-0.1.yaml
-rw-r--r--@ 1 ss  staff   2.9K Mar 10 23:48 k8s-pss-baseline-0.1.yaml
-rw-r--r--@ 1 ss  staff   6.1K Mar 10 23:48 k8s-nsa-1.0.yaml
-rw-r--r--@ 1 ss  staff    32K Mar 10 23:48 k8s-cis-1.23.yaml
-rw-r--r--@ 1 ss  staff    17K Mar 10 23:48 eks-cis-1.4.yaml
-rw-r--r--@ 1 ss  staff   3.4K Mar 10 23:48 docker-cis-1.6.0.yaml
-rw-r--r--@ 1 ss  staff   8.2K Mar 10 23:48 aws-cis-1.4.yaml
-rw-r--r--@ 1 ss  staff   7.0K Mar 10 23:48 aws-cis-1.2.yaml
```