### PR TITLE
Fix unreachable URL of AVD-AWS-0320 metadata

### DIFF
--- a/avd_docs/aws/s3/AVD-AWS-0320/docs.md
+++ b/avd_docs/aws/s3/AVD-AWS-0320/docs.md
@@ -8,6 +8,6 @@ Ensures that S3 buckets have DNS complaint bucket names.
 {{ remediationActions }}
 
 ### Links
-- https://docs.aws.amazon.com/AmazonS3/latest./dev/transfer-acceleration.html
+- https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html
 
 

--- a/checks/cloud/aws/s3/dns_compliant_name.rego
+++ b/checks/cloud/aws/s3/dns_compliant_name.rego
@@ -5,7 +5,7 @@
 # schemas:
 # - input: schema["cloud"]
 # related_resources:
-# - https://docs.aws.amazon.com/AmazonS3/latest./dev/transfer-acceleration.html
+# - https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html
 # custom:
 #   id: AVD-AWS-0320
 #   avd_id: AVD-AWS-0320


### PR DESCRIPTION
<https://docs.aws.amazon.com/AmazonS3/latest./dev/transfer-acceleration.html> is not found, whereas <https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html> is redirected to <https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration.html>.