### PR TITLE
fix: make wildcard match in IAM policy checks case-insensitive

### DIFF
--- a/checks/cloud/aws/ecr/no_public_access.rego
+++ b/checks/cloud/aws/ecr/no_public_access.rego
@@ -38,7 +38,7 @@ deny contains res if {
 
 has_ecr_action(statement) if {
 	some action in statement.Action
-	startswith(action, "ecr:")
+	startswith(lower(action), "ecr:")
 }
 
 has_public_access(statement) if {

--- a/checks/cloud/aws/s3/enable_logging.rego
+++ b/checks/cloud/aws/s3/enable_logging.rego
@@ -79,6 +79,7 @@ bucket_has_server_logging_access(bucket) if {
 	doc := json.unmarshal(policy.document.value)
 	statement := doc.Statement[_]
 	statement.Effect == "Allow"
-	"s3:PutObject" in statement.Action
+	some action in statement.Action
+	lower(action) == "s3:putobject"
 	"logging.s3.amazonaws.com" in statement.Principal.Service
 }

--- a/checks/cloud/aws/sqs/no_wildcards_in_policy_documents.rego
+++ b/checks/cloud/aws/sqs/no_wildcards_in_policy_documents.rego
@@ -34,6 +34,6 @@ deny contains res if {
 	some statement in doc.Statement
 	statement.Effect == "Allow"
 	some action in statement.Action
-	action in ["*", "sqs:*"]
+	lower(action) in ["*", "sqs:*"]
 	res := result.new("Queue policy does not restrict actions to a known set.", policy_doc.document)
 }

--- a/checks/cloud/aws/sqs/no_wildcards_in_policy_documents_test.rego
+++ b/checks/cloud/aws/sqs/no_wildcards_in_policy_documents_test.rego
@@ -40,3 +40,15 @@ test_deny_with_wildcards if {
 
 	test.assert_equal_message("Queue policy does not restrict actions to a known set.", check.deny) with input as inp
 }
+
+test_deny_with_sqs_wildcards if {
+	inp := {"aws": {"sqs": {"queues": [{"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["SQS:*"],
+		}],
+	})}}]}]}}}
+
+	test.assert_equal_message("Queue policy does not restrict actions to a known set.", check.deny) with input as inp
+}


### PR DESCRIPTION
From [doc](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_action.html):
> The prefix and the action name are case insensitive

Related issues:
- https://github.com/aquasecurity/trivy/issues/8879