### PR TITLE
chore: remove unnecessary regal lint arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ lint-rego: check-rego
 	@regal test .regal/rules
 	@regal lint lib checks \
 		--config-file .regal/config.yaml \
-		--enable deny-rule,naming-convention \
 		--timeout 5m
 
 .PHONY: fmt-examples


### PR DESCRIPTION
Enabling rules via a flag is not necessary, as this is already done via the config file. See https://docs.styra.com/regal#ignoring-all-rules-in-config