### PR TITLE
lint: enable some rules from bugs category

### DIFF
--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -17,27 +17,27 @@ rules:
         files:
           - "*_test.rego"
   bugs:
+    constant-condition:
+      level: error
     duplicate-rule:
       level: error
-    sprintf-arguments-mismatch:
+    if-empty-object:
       level: error
-    rule-assigns-default:
-      level: error
-    redundant-loop-count:
-      level: error
-    not-equals-in-loop:
-      level: error
-    redundant-existence-check:
-      level: error
-    invalid-metadata-attribute:
+    if-object-literal:
       level: error
     impossible-not:
       level: error
     import-shadows-rule:
       level: error
-    if-object-literal:
+    invalid-metadata-attribute:
       level: error
-    if-empty-object:
+    not-equals-in-loop:
       level: error
-    constant-condition:
+    redundant-existence-check:
+      level: error
+    redundant-loop-count:
+      level: error
+    rule-assigns-default:
+      level: error
+    sprintf-arguments-mismatch:
       level: error

--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -19,3 +19,25 @@ rules:
   bugs:
     duplicate-rule:
       level: error
+    sprintf-arguments-mismatch:
+      level: error
+    rule-assigns-default:
+      level: error
+    redundant-loop-count:
+      level: error
+    not-equals-in-loop:
+      level: error
+    redundant-existence-check:
+      level: error
+    invalid-metadata-attribute:
+      level: error
+    impossible-not:
+      level: error
+    import-shadows-rule:
+      level: error
+    if-object-literal:
+      level: error
+    if-empty-object:
+      level: error
+    constant-condition:
+      level: error

--- a/checks/kubernetes/insecure_ingress_nginx.rego
+++ b/checks/kubernetes/insecure_ingress_nginx.rego
@@ -17,7 +17,7 @@
 #   input:
 #     selector:
 #     - type: kubernetes
-# examples: checks/kubernetes/network/insecure_ingress_nginx.yaml
+#   examples: checks/kubernetes/insecure_ingress_nginx.yaml
 
 package builtin.kubernetes.kcv0093
 

--- a/checks/kubernetes/insecure_ingress_nginx.yaml
+++ b/checks/kubernetes/insecure_ingress_nginx.yaml
@@ -8,6 +8,8 @@ kubernetes:
               nginx.ingress.kubernetes.io/auth-url: https://valid-url.com
           name: test-ingress-valid-url
           namespace: default
+      spec:
+          ingressClassName: nginx
     - |-
       apiVersion: v1
       kind: Ingress
@@ -16,6 +18,8 @@ kubernetes:
               nginx.ingress.kubernetes.io/auth-tls-match-cn: CN=valid-cn
           name: test-ingress-valid-cn
           namespace: default
+      spec:
+          ingressClassName: nginx
     - |-
       apiVersion: v1
       kind: Ingress
@@ -24,6 +28,8 @@ kubernetes:
               nginx.ingress.kubernetes.io/mirror-target: https://valid-url.com
           name: test-ingress-valid-target
           namespace: default
+      spec:
+          ingressClassName: nginx
     - |-
       apiVersion: v1
       kind: Ingress
@@ -32,6 +38,8 @@ kubernetes:
               nginx.ingress.kubernetes.io/mirror-host: https://valid-url.com
           name: test-ingress-valid-host
           namespace: default
+      spec:
+          ingressClassName: nginx
   bad:
     - |-
       apiVersion: v1
@@ -41,6 +49,8 @@ kubernetes:
               nginx.ingress.kubernetes.io/auth-url: http://example.com/invalid|url
           name: test-ingress-invalid-url
           namespace: default
+      spec:
+          ingressClassName: nginx
     - |-
       apiVersion: v1
       kind: Ingress
@@ -51,6 +61,8 @@ kubernetes:
                   injection_point
           name: test-ingress-suspicious-char
           namespace: default
+      spec:
+          ingressClassName: nginx
     - |-
       apiVersion: v1
       kind: Ingress
@@ -59,6 +71,8 @@ kubernetes:
               nginx.ingress.kubernetes.io/auth-tls-match-cn: CN=invalid|cn
           name: test-ingress-invalid-cn
           namespace: default
+      spec:
+          ingressClassName: nginx
     - |-
       apiVersion: v1
       kind: Ingress
@@ -69,6 +83,8 @@ kubernetes:
                   injection_point
           name: test-ingress-suspicious-char-cn
           namespace: default
+      spec:
+          ingressClassName: nginx
     - |-
       apiVersion: v1
       kind: Ingress
@@ -77,6 +93,8 @@ kubernetes:
               nginx.ingress.kubernetes.io/mirror-target: http://example.com/invalid|url
           name: test-ingress-invalid-target
           namespace: default
+      spec:
+          ingressClassName: nginx
     - |-
       apiVersion: v1
       kind: Ingress
@@ -87,6 +105,8 @@ kubernetes:
                   injection_point
           name: test-ingress-suspicious-char-target
           namespace: default
+      spec:
+          ingressClassName: nginx
     - |-
       apiVersion: v1
       kind: Ingress
@@ -95,6 +115,8 @@ kubernetes:
               nginx.ingress.kubernetes.io/mirror-host: http://example.com/invalid|url
           name: test-ingress-invalid-host
           namespace: default
+      spec:
+          ingressClassName: nginx
     - |-
       apiVersion: v1
       kind: Ingress
@@ -105,3 +127,5 @@ kubernetes:
                   injection_point
           name: test-ingress-suspicious-char-host
           namespace: default
+      spec:
+          ingressClassName: nginx

--- a/checks/kubernetes/insecure_ingress_nginx.yaml
+++ b/checks/kubernetes/insecure_ingress_nginx.yaml
@@ -4,96 +4,104 @@ kubernetes:
       apiVersion: v1
       kind: Ingress
       metadata:
-        name: test-ingress-valid-url
-        namespace: default
-        annotations:
-          nginx.ingress.kubernetes.io/auth-url: "https://valid-url.com"
+          annotations:
+              nginx.ingress.kubernetes.io/auth-url: https://valid-url.com
+          name: test-ingress-valid-url
+          namespace: default
     - |-
       apiVersion: v1
       kind: Ingress
       metadata:
-        name: test-ingress-valid-cn
-        namespace: default
-        annotations:
-          nginx.ingress.kubernetes.io/auth-tls-match-cn: "CN=valid-cn"
+          annotations:
+              nginx.ingress.kubernetes.io/auth-tls-match-cn: CN=valid-cn
+          name: test-ingress-valid-cn
+          namespace: default
     - |-
       apiVersion: v1
       kind: Ingress
       metadata:
-        name: test-ingress-valid-target
-        namespace: default
-        annotations:
-          nginx.ingress.kubernetes.io/mirror-target: "https://valid-url.com"
+          annotations:
+              nginx.ingress.kubernetes.io/mirror-target: https://valid-url.com
+          name: test-ingress-valid-target
+          namespace: default
     - |-
       apiVersion: v1
       kind: Ingress
       metadata:
-        name: test-ingress-valid-host
-        namespace: default
-        annotations:
-          nginx.ingress.kubernetes.io/mirror-host: "https://valid-url.com"
+          annotations:
+              nginx.ingress.kubernetes.io/mirror-host: https://valid-url.com
+          name: test-ingress-valid-host
+          namespace: default
   bad:
     - |-
       apiVersion: v1
       kind: Ingress
       metadata:
-        name: test-ingress-invalid-url
-        namespace: default
-        annotations:
-          nginx.ingress.kubernetes.io/auth-url: "http://example.com/invalid|url"
+          annotations:
+              nginx.ingress.kubernetes.io/auth-url: http://example.com/invalid|url
+          name: test-ingress-invalid-url
+          namespace: default
     - |-
       apiVersion: v1
       kind: Ingress
       metadata:
-        name: test-ingress-suspicious-char
-        namespace: default
-        annotations:
-          nginx.ingress.kubernetes.io/auth-url: "http://example.com/#;\ninjection_point"
+          annotations:
+              nginx.ingress.kubernetes.io/auth-url: |-
+                  http://example.com/#;
+                  injection_point
+          name: test-ingress-suspicious-char
+          namespace: default
     - |-
       apiVersion: v1
       kind: Ingress
       metadata:
-        name: test-ingress-invalid-cn
-        namespace: default
-        annotations:
-          nginx.ingress.kubernetes.io/auth-tls-match-cn: "CN=invalid|cn"
+          annotations:
+              nginx.ingress.kubernetes.io/auth-tls-match-cn: CN=invalid|cn
+          name: test-ingress-invalid-cn
+          namespace: default
     - |-
       apiVersion: v1
       kind: Ingress
       metadata:
-        name: test-ingress-suspicious-char-cn
-        namespace: default
-        annotations:
-          nginx.ingress.kubernetes.io/auth-tls-match-cn: "CN=valid#;\ninjection_point"
+          annotations:
+              nginx.ingress.kubernetes.io/auth-tls-match-cn: |-
+                  CN=valid#;
+                  injection_point
+          name: test-ingress-suspicious-char-cn
+          namespace: default
     - |-
       apiVersion: v1
       kind: Ingress
       metadata:
-        name: test-ingress-invalid-target
-        namespace: default
-        annotations:
-          nginx.ingress.kubernetes.io/mirror-target: "http://example.com/invalid|url"
+          annotations:
+              nginx.ingress.kubernetes.io/mirror-target: http://example.com/invalid|url
+          name: test-ingress-invalid-target
+          namespace: default
     - |-
       apiVersion: v1
       kind: Ingress
       metadata:
-        name: test-ingress-suspicious-char-target
-        namespace: default
-        annotations:
-          nginx.ingress.kubernetes.io/mirror-target: "http://example.com/#;\ninjection_point"
+          annotations:
+              nginx.ingress.kubernetes.io/mirror-target: |-
+                  http://example.com/#;
+                  injection_point
+          name: test-ingress-suspicious-char-target
+          namespace: default
     - |-
       apiVersion: v1
       kind: Ingress
       metadata:
-        name: test-ingress-invalid-host
-        namespace: default
-        annotations:
-          nginx.ingress.kubernetes.io/mirror-host: "http://example.com/invalid|url"
+          annotations:
+              nginx.ingress.kubernetes.io/mirror-host: http://example.com/invalid|url
+          name: test-ingress-invalid-host
+          namespace: default
     - |-
       apiVersion: v1
       kind: Ingress
       metadata:
-        name: test-ingress-suspicious-char-host
-        namespace: default
-        annotations:
-          nginx.ingress.kubernetes.io/mirror-host: "http://example.com/#;\ninjection_point"
+          annotations:
+              nginx.ingress.kubernetes.io/mirror-host: |-
+                  http://example.com/#;
+                  injection_point
+          name: test-ingress-suspicious-char-host
+          namespace: default

--- a/lib/cloud/aws_s3.rego
+++ b/lib/cloud/aws_s3.rego
@@ -15,7 +15,6 @@ public_acls := {
 
 bucket_has_public_exposure_acl(bucket) if {
 	bucket.acl.value in public_acls
-	bucket.publicaccessblock
 	isManaged(bucket.publicaccessblock)
 	not bucket.publicaccessblock.ignorepublicacls.value
 	not bucket.publicaccessblock.blockpublicacls.value


### PR DESCRIPTION
This PR enables some rules from the `bugs` category for the linter that have not found issues or require minor fixes.