### PR TITLE
fix: skip images without registry in KSV0125

### DIFF
--- a/checks/kubernetes/uses_untrusted_registry_test.rego
+++ b/checks/kubernetes/uses_untrusted_registry_test.rego
@@ -14,6 +14,10 @@ test_check_registry[name] if {
 			"image": "foo.io/test:latest",
 			"expected": 1,
 		},
+		"without registry": {
+			"image": "test:latest",
+			"expected": 0,
+		},
 	}
 
 	inp := {
@@ -43,6 +47,10 @@ test_check_registry_custom_registries[name] if {
 		"untrusted registry": {
 			"image": "gcr.io/test:latest",
 			"expected": 1,
+		},
+		"without registry": {
+			"image": "test:latest",
+			"expected": 0,
 		},
 	}
 


### PR DESCRIPTION
KSV0125 should not trigger for images without a registry. See the added test case.