### PR TITLE
fix: add support for workload_metadata_config.mode values in AVD-GCP-0057

### DIFF
--- a/avd_docs/google/gke/AVD-GCP-0057/Terraform.md
+++ b/avd_docs/google/gke/AVD-GCP-0057/Terraform.md
@@ -1,5 +1,5 @@
 
-Set node metadata to SECURE or GKE_METADATA_SERVER
+Set mode to GKE_METADATA
 
 ```hcl
 resource "google_container_cluster" "primary" {
@@ -14,7 +14,7 @@ resource "google_container_node_pool" "good_example" {
   cluster = google_container_cluster.primary.id
   node_config {
     workload_metadata_config {
-      node_metadata = "SECURE"
+      mode = "GKE_METADATA"
     }
   }
 }

--- a/avd_docs/google/gke/AVD-GCP-0057/docs.md
+++ b/avd_docs/google/gke/AVD-GCP-0057/docs.md
@@ -1,7 +1,9 @@
 
-If the <code>workload_metadata_config</code> block within <code>node_config</code> is included, the <code>node_metadata</code> attribute should be configured securely.
+In provider versions prior to 4:
+The attribute <code>workload_metadata_config.node_metadata</code> configures how node metadata is exposed to workloads. It should be set to <code>SECURE</code> to limit metadata exposure, or <code>GKE_METADATA_SERVER</code> if Workload Identity is enabled.
 
-The attribute should be set to <code>SECURE</code> to use metadata concealment, or <code>GKE_METADATA_SERVER</code> if workload identity is enabled. This ensures that the VM metadata is not unnecessarily exposed to pods.
+Starting with provider version 4:
+The attribute <code>node_metadata</code> has been removed. Instead, <code>workload_metadata_configuration.mode</code> controls node metadata exposure. When Workload Identity is enabled, it should be set to <code>GKE_METADATA</code> to prevent unnecessary exposure of the metadata API to workloads.
 
 
 ### Impact

--- a/checks/cloud/google/gke/node_metadata_security.rego
+++ b/checks/cloud/google/gke/node_metadata_security.rego
@@ -1,9 +1,11 @@
 # METADATA
 # title: Node metadata value disables metadata concealment.
 # description: |
-#   If the <code>workload_metadata_config</code> block within <code>node_config</code> is included, the <code>node_metadata</code> attribute should be configured securely.
+#   In provider versions prior to 4:
+#   The attribute <code>workload_metadata_config.node_metadata</code> configures how node metadata is exposed to workloads. It should be set to <code>SECURE</code> to limit metadata exposure, or <code>GKE_METADATA_SERVER</code> if Workload Identity is enabled.
 #
-#   The attribute should be set to <code>SECURE</code> to use metadata concealment, or <code>GKE_METADATA_SERVER</code> if workload identity is enabled. This ensures that the VM metadata is not unnecessarily exposed to pods.
+#   Starting with provider version 4:
+#   The attribute <code>node_metadata</code> has been removed. Instead, <code>workload_metadata_configuration.mode</code> controls node metadata exposure. When Workload Identity is enabled, it should be set to <code>GKE_METADATA</code> to prevent unnecessary exposure of the metadata API to workloads.
 # scope: package
 # schemas:
 #   - input: schema["cloud"]
@@ -16,7 +18,7 @@
 #   service: gke
 #   severity: HIGH
 #   short_code: node-metadata-security
-#   recommended_action: Set node metadata to SECURE or GKE_METADATA_SERVER
+#   recommended_action: Set mode to GKE_METADATA
 #   input:
 #     selector:
 #       - type: cloud
@@ -45,4 +47,7 @@ deny contains res if {
 	res := result.new("Cluster exposes node metadata of pools by default.", metadata)
 }
 
-is_exposes(metadata) := metadata in {"UNSPECIFIED", "EXPOSE"}
+is_exposes(metadata) := metadata in {
+	"UNSPECIFIED", "EXPOSE", # https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/NodeConfig#nodemetadata
+	"MODE_UNSPECIFIED", "GCE_METADATA", # https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/NodeConfig#mode
+}

--- a/checks/cloud/google/gke/node_metadata_security.yaml
+++ b/checks/cloud/google/gke/node_metadata_security.yaml
@@ -15,7 +15,7 @@ terraform:
         cluster = google_container_cluster.primary.id
         node_config {
           workload_metadata_config {
-            node_metadata = "SECURE"
+            mode = "GKE_METADATA"
           }
         }
       }
@@ -33,7 +33,7 @@ terraform:
         cluster = google_container_cluster.primary.id
         node_config {
           workload_metadata_config {
-            node_metadata = "EXPOSE"
+            mode = "GCE_METADATA"
           }
         }
       }


### PR DESCRIPTION
Related issues:
- https://github.com/aquasecurity/trivy/issues/8940

This PR adds support for values specific to the `workload_metadata_config.mode` attribute, which replaces the removed `workload_metadata_config.node_metadata`. The check description and example have also been updated accordingly.