### PR TITLE
test: validate test_* rule inputs against schema

### DIFF
--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -41,3 +41,6 @@ rules:
       level: error
     sprintf-arguments-mismatch:
       level: error
+  testing:
+    identically-named-tests:
+      level: error

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifeq ($(shell uname), Darwin)
 endif
 
 .PHONY: test
-test:
+test: download-schemas
 	go test -v ./...
 
 .PHONY: integration-test

--- a/checks/cloud/aws/cloudfront/enable_waf_test.rego
+++ b/checks/cloud/aws/cloudfront/enable_waf_test.rego
@@ -6,7 +6,7 @@ import data.builtin.aws.cloudfront.aws0011 as check
 import data.lib.test
 
 test_allow_distribution_with_waf if {
-	test.assert_empty(check.deny) with input as {"aws": {"cloudfront": {"distributions": [{"wafid": {"value": true}}]}}}
+	test.assert_empty(check.deny) with input as {"aws": {"cloudfront": {"distributions": [{"wafid": {"value": "test"}}]}}}
 }
 
 test_deny_distribution_without_waf if {

--- a/checks/cloud/aws/ec2/no_public_ingress_sgr_test.rego
+++ b/checks/cloud/aws/ec2/no_public_ingress_sgr_test.rego
@@ -31,7 +31,7 @@ test_deny_ingress_sq_all_ips_for_ssh_port_and_uppercase_tcp if {
 
 test_deny_ingress_sq_all_ips_for_ssh_port_and_int_tcp if {
 	inp := build_input({
-		"protocol": {"value": 6},
+		"protocol": {"value": "6"},
 		"cidrs": [{"value": "0.0.0.0/0"}],
 		"fromport": {"value": net.ssh_port},
 		"toport": {"value": net.ssh_port},

--- a/checks/cloud/aws/ec2/specify_ami_owners_test.rego
+++ b/checks/cloud/aws/ec2/specify_ami_owners_test.rego
@@ -11,9 +11,9 @@ test_deny_missing_owners if {
 }
 
 test_allow_valid_owners if {
-	test.assert_empty(check.deny) with input as {"aws": {"ec2": {"requestedamis": [{"owners": ["self"]}]}}}
+	test.assert_empty(check.deny) with input as {"aws": {"ec2": {"requestedamis": [{"owners": [{"value": "self"}]}]}}}
 }
 
 test_allow_valid_multiple_owners if {
-	test.assert_empty(check.deny) with input as {"aws": {"ec2": {"requestedamis": [{"owners": ["amazon", "self"]}]}}}
+	test.assert_empty(check.deny) with input as {"aws": {"ec2": {"requestedamis": [{"owners": [{"value": "amazon"}, {"value": "self"}]}]}}}
 }

--- a/checks/cloud/aws/iam/disable_unused_credentials_test.rego
+++ b/checks/cloud/aws/iam/disable_unused_credentials_test.rego
@@ -53,7 +53,7 @@ test_allow_nonactive_user_access_key_not_used_100_days if {
 
 test_allow_user_access_key_used_today if {
 	test.assert_empty(check.deny) with input as build_input({
-		"name":{"value":  "test"},
+		"name": {"value": "test"},
 		"lastaccess": {"value": time.format(time.now_ns())},
 		"accesskeys": [{
 			"accesskeyid": {"value": "AKIACKCEVSQ6C2EXAMPLE"},

--- a/checks/cloud/aws/iam/disable_unused_credentials_test.rego
+++ b/checks/cloud/aws/iam/disable_unused_credentials_test.rego
@@ -8,7 +8,7 @@ import data.lib.test
 
 test_allow_user_logged_in_today if {
 	test.assert_empty(check.deny) with input as build_input({
-		"name": "test",
+		"name": {"value": "test"},
 		"lastaccess": {"value": time.format(time.now_ns())},
 	})
 }
@@ -41,7 +41,7 @@ test_disallow_user_access_key_not_used_100_days if {
 
 test_allow_nonactive_user_access_key_not_used_100_days if {
 	test.assert_empty(check.deny) with input as build_input({
-		"name": "test",
+		"name": {"value": "test"},
 		"lastaccess": {"value": time.format(time.now_ns())},
 		"accesskeys": [{
 			"accesskeyid": {"value": "AKIACKCEVSQ6C2EXAMPLE"},
@@ -53,7 +53,7 @@ test_allow_nonactive_user_access_key_not_used_100_days if {
 
 test_allow_user_access_key_used_today if {
 	test.assert_empty(check.deny) with input as build_input({
-		"name": "test",
+		"name":{"value":  "test"},
 		"lastaccess": {"value": time.format(time.now_ns())},
 		"accesskeys": [{
 			"accesskeyid": {"value": "AKIACKCEVSQ6C2EXAMPLE"},
@@ -65,7 +65,7 @@ test_allow_user_access_key_used_today if {
 
 test_disallow_one_of_the_user_access_key_used_100_days if {
 	test.assert_equal_message(`User access key "AKIACKCEVSQ6C2EXAMPLE" has not been used in >90 days`, check.deny) with input as build_input({
-		"name": "test",
+		"name": {"value": "test"},
 		"lastaccess": {"value": time.format(time.now_ns())},
 		"accesskeys": [
 			{

--- a/checks/cloud/aws/iam/enforce_root_hardware_mfa_test.rego
+++ b/checks/cloud/aws/iam/enforce_root_hardware_mfa_test.rego
@@ -22,7 +22,7 @@ test_allow_non_root_user_without_mfa if {
 
 test_allow_root_user_with_hardware_mfa if {
 	test.assert_empty(check.deny) with input as build_input({
-		"name": {"value": {"value": "root"}},
+		"name": {"value": "root"},
 		"mfadevices": [{"isvirtual": {"value": false}}],
 	})
 }

--- a/checks/cloud/aws/iam/enforce_root_mfa_test.rego
+++ b/checks/cloud/aws/iam/enforce_root_mfa_test.rego
@@ -15,7 +15,7 @@ test_allow_non_root_user_without_mfa if {
 
 test_allow_root_user_with_mfa if {
 	test.assert_empty(check.deny) with input as build_input({
-		"name": "root",
+		"name": {"value": "root"},
 		"mfadevices": [
 			{"isvirtual": {"value": false}},
 			{"isvirtual": {"value": true}},

--- a/checks/cloud/aws/iam/filter_iam_pass_role_test.rego
+++ b/checks/cloud/aws/iam/filter_iam_pass_role_test.rego
@@ -4,7 +4,7 @@ import rego.v1
 
 test_with_allow_iam_pass_role if {
 	policies := [{
-		"name": "policy_with_iam_pass_role",
+		"name": {"value": "policy_with_iam_pass_role"},
 		"document": {"value": "{\"Version\":\"2012-10-17\",\"Id\":\"\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{},\"NotPrincipal\":{},\"Action\":[\"iam:PassRole\"],\"NotAction\":null,\"Resource\":[\"arn:aws:iam::193063503752:role/atc-node\"],\"NotResource\":null,\"Condition\":{}}]}"},
 	}]
 
@@ -14,7 +14,7 @@ test_with_allow_iam_pass_role if {
 
 test_with_deny_iam_pass_role if {
 	policies := [{
-		"name": "policy_with_iam_pass_role",
+		"name": {"value": "policy_with_iam_pass_role"},
 		"document": {"value": "{\"Version\":\"2012-10-17\",\"Id\":\"\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Deny\",\"Principal\":{},\"NotPrincipal\":{},\"Action\":[\"iam:PassRole\"],\"NotAction\":null,\"Resource\":[\"arn:aws:iam::193063503752:role/atc-node\"],\"NotResource\":null,\"Condition\":{}}]}"},
 	}]
 
@@ -24,7 +24,7 @@ test_with_deny_iam_pass_role if {
 
 test_with_no_iam_pass_role if {
 	policies := [{
-		"name": "policy_without_iam_pass_role",
+		"name": {"value": "policy_without_iam_pass_role"},
 		"document": {"value": "{\"Version\":\"2012-10-17\",\"Id\":\"\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{},\"NotPrincipal\":{},\"Action\":[\"s3:GetObject\"],\"NotAction\":null,\"Resource\":[\"arn:aws:s3:::examplebucket/*\"],\"NotResource\":null,\"Condition\":{}}]}"},
 	}]
 

--- a/checks/cloud/aws/iam/limit_s3_full_access_test.rego
+++ b/checks/cloud/aws/iam/limit_s3_full_access_test.rego
@@ -4,7 +4,7 @@ import rego.v1
 
 test_with_allow_s3_full_access if {
 	policies := [{
-		"name": "policy_with_s3_full_access",
+		"name": {"Value": "policy_with_s3_full_access"},
 		"document": {"value": json.marshal({
 			"Version": "2012-10-17",
 			"Statement": [{
@@ -21,7 +21,7 @@ test_with_allow_s3_full_access if {
 
 test_with_allow_s3_full_access_with_verb_non_mixed if {
 	policies := [{
-		"name": "policy_with_s3_full_access",
+		"name": {"value": "policy_with_s3_full_access"},
 		"document": {"value": json.marshal({
 			"Version": "2012-10-17",
 			"Statement": [
@@ -45,7 +45,7 @@ test_with_allow_s3_full_access_with_verb_non_mixed if {
 
 test_with_allow_s3_full_access_overriden_by_deny if {
 	policies := [{
-		"name": "policy_with_s3_full_access",
+		"name": {"value": "policy_with_s3_full_access"},
 		"document": {"value": json.marshal({
 			"Version": "2012-10-17",
 			"Statement": [
@@ -69,7 +69,7 @@ test_with_allow_s3_full_access_overriden_by_deny if {
 
 test_with_deny_s3_full_access if {
 	policies := [{
-		"name": "policy_with_s3_full_access",
+		"name": {"value": "policy_with_s3_full_access"},
 		"document": {"value": json.marshal({
 			"Version": "2012-10-17",
 			"Statement": [{
@@ -85,7 +85,7 @@ test_with_deny_s3_full_access if {
 
 test_with_no_s3_full_access if {
 	policies := [{
-		"name": "policy_without_s3_full_access",
+		"name": {"value": "policy_without_s3_full_access"},
 		"document": {"value": json.marshal({
 			"Version": "2012-10-17",
 			"Statement": [{
@@ -102,7 +102,7 @@ test_with_no_s3_full_access if {
 
 test_with_role_using_amazon_s3_full_access_policy if {
 	roles := [{
-		"name": "role_with_amazon_s3_full_access",
+		"name": {"value": "role_with_amazon_s3_full_access"},
 		"policies": [{"document": {"value": json.marshal({
 			"Version": "2012-10-17",
 			"Statement": [{
@@ -119,7 +119,7 @@ test_with_role_using_amazon_s3_full_access_policy if {
 
 test_with_role_not_using_amazon_s3_full_access_policy if {
 	roles := [{
-		"name": "role_without_amazon_s3_full_access",
+		"name": {"value": "role_without_amazon_s3_full_access"},
 		"policies": [{"document": {"value": json.marshal({
 			"Version": "2012-10-17",
 			"Statement": [{

--- a/checks/cloud/aws/iam/require_numbers_in_passwords_test.rego
+++ b/checks/cloud/aws/iam/require_numbers_in_passwords_test.rego
@@ -6,7 +6,7 @@ import data.builtin.aws.iam.aws0059 as check
 import data.lib.test
 
 test_allow_policy_require_numbers_in_passwords if {
-	test.assert_empty(check.deny) with input.aws.iam.passwordpolicy.requirenumbers.value as true
+	test.assert_empty(check.deny) with input as {"aws": {"iam": {"passwordpolicy": {"requirenumbers": {"value": true}}}}}
 }
 
 test_disallow_policy_no_require_numbers_in_passwords if {

--- a/checks/cloud/aws/iam/require_symbols_in_passwords_test.rego
+++ b/checks/cloud/aws/iam/require_symbols_in_passwords_test.rego
@@ -6,7 +6,7 @@ import data.builtin.aws.iam.aws0060 as check
 import data.lib.test
 
 test_allow_policy_require_symbols_in_passwords if {
-	test.assert_empty(check.deny) with input.aws.iam.passwordpolicy.requiresymbols.value as true
+	test.assert_empty(check.deny) with input as {"aws": {"iam": {"passwordpolicy": {"requiresymbols": {"value": true}}}}}
 }
 
 test_disallow_policy_no_require_symbols_in_passwords if {

--- a/checks/cloud/aws/iam/require_uppercase_in_passwords_test.rego
+++ b/checks/cloud/aws/iam/require_uppercase_in_passwords_test.rego
@@ -6,7 +6,7 @@ import data.builtin.aws.iam.aws0061 as check
 import data.lib.test
 
 test_allow_policy_require_uppercase_in_passwords if {
-	test.assert_empty(check.deny) with input.aws.iam.passwordpolicy.requireuppercase.value as true
+	test.assert_empty(check.deny) with input as {"aws": {"iam": {"passwordpolicy": {"requireuppercase": {"value": true}}}}}
 }
 
 test_disallow_policy_no_require_uppercase_in_passwords if {

--- a/checks/cloud/aws/iam/unauthorized_bucket_access_test.rego
+++ b/checks/cloud/aws/iam/unauthorized_bucket_access_test.rego
@@ -6,7 +6,7 @@ import rego.v1
 
 test_deny_policy_with_s3_get_and_put_wildcards if {
 	policies := [{
-		"name": "policy_with_literal_get_and_put",
+		"name": {"value": "policy_with_literal_get_and_put"},
 		"document": {"value": json.marshal({
 			"Version": "2012-10-17",
 			"Statement": [{
@@ -23,7 +23,7 @@ test_deny_policy_with_s3_get_and_put_wildcards if {
 
 test_allow_policy_with_denied_actions_on_s3_wildcards if {
 	policies := [{
-		"name": "policy_with_literal_get_and_put",
+		"name": {"value": "policy_with_literal_get_and_put"},
 		"document": {"value": json.marshal({
 			"Version": "2012-10-17",
 			"Statement": [{
@@ -40,7 +40,7 @@ test_allow_policy_with_denied_actions_on_s3_wildcards if {
 
 test_allow_s3_only_get if {
 	policies := [{
-		"name": "policy_with_only_get",
+		"name": {"value": "policy_with_only_get"},
 		"document": {"value": json.marshal({
 			"Version": "2012-10-17",
 			"Statement": [{
@@ -57,7 +57,7 @@ test_allow_s3_only_get if {
 
 test_allow_s3_get_and_put_limited_resource if {
 	policies := [{
-		"name": "policy_with_get_and_put_limited_resource",
+		"name": {"value": "policy_with_get_and_put_limited_resource"},
 		"document": {"value": json.marshal({
 			"Version": "2012-10-17",
 			"Statement": [{

--- a/checks/cloud/google/bigquery/no_public_access_test.rego
+++ b/checks/cloud/google/bigquery/no_public_access_test.rego
@@ -14,5 +14,6 @@ test_deny_public_access if {
 test_allow_no_public_access if {
 	inp := {"google": {"bigquery": {"datasets": [{"accessgrants": [{"specialgroup": {"value": "anotherGroup"}}]}]}}}
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }

--- a/checks/cloud/google/dns/enable_dnssec_test.rego
+++ b/checks/cloud/google/dns/enable_dnssec_test.rego
@@ -20,7 +20,8 @@ test_allow_dns_sec_enabled if {
 		"dnssec": {"enabled": {"value": true}},
 	})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }
 
 test_allow_dns_sec_disabled_for_private_zone if {
@@ -29,7 +30,8 @@ test_allow_dns_sec_disabled_for_private_zone if {
 		"dnssec": {"enabled": {"value": false}},
 	})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }
 
 build_input(zone) := {"google": {"dns": {"managedzones": [zone]}}}

--- a/checks/cloud/google/dns/no_rsa_sha1_test.rego
+++ b/checks/cloud/google/dns/no_rsa_sha1_test.rego
@@ -14,7 +14,8 @@ test_deny_rsa_sha1 if {
 test_allow_rsa_sha512 if {
 	inp := build_input({"algorithm": {"value": "rsasha512"}})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }
 
 build_input(key_spec) := {"google": {"dns": {"managedzones": [{"dnssec": {"defaultkeyspecs": [key_spec]}}]}}}

--- a/checks/cloud/google/kms/rotate_kms_keys_test.rego
+++ b/checks/cloud/google/kms/rotate_kms_keys_test.rego
@@ -14,5 +14,6 @@ test_deny_key_rotation_period_greather_than_90_days if {
 test_allow_key_rotation_period_less_than_90_days if {
 	inp := {"google": {"kms": {"keyrings": [{"keys": [{"rotationperiodseconds": {"value": 2592000}}]}]}}} # 30 days
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }

--- a/checks/cloud/google/sql/no_contained_db_auth_test.rego
+++ b/checks/cloud/google/sql/no_contained_db_auth_test.rego
@@ -30,7 +30,7 @@ test_allow_db_auth_enabled_for_non_sqlserver if {
 		"settings": {"flags": {"containeddatabaseauthentication": {"value": true}}},
 	})
 
-	res := check.deny with input as input
+	res := check.deny with input as inp
 	res == set()
 }
 

--- a/checks/cloud/google/sql/no_contained_db_auth_test.rego
+++ b/checks/cloud/google/sql/no_contained_db_auth_test.rego
@@ -10,7 +10,8 @@ test_allow_db_auth_disabled if {
 		"settings": {"flags": {"containeddatabaseauthentication": {"value": false}}},
 	})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }
 
 test_deny_db_auth_enabled if {
@@ -29,7 +30,8 @@ test_allow_db_auth_enabled_for_non_sqlserver if {
 		"settings": {"flags": {"containeddatabaseauthentication": {"value": true}}},
 	})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as input
+	res == set()
 }
 
 build_input(instance) := {"google": {"sql": {"instances": [instance]}}}

--- a/checks/cloud/google/sql/no_cross_db_ownership_chaining_test.rego
+++ b/checks/cloud/google/sql/no_cross_db_ownership_chaining_test.rego
@@ -26,7 +26,7 @@ test_allow_cross_database_ownership_chaining_disabled if {
 
 test_allow_cross_database_ownership_chaining_enabled_for_non_sql_servers if {
 	inp := build_input({
-		"databaseversion": {"value": "SQLSERVER_2017_STANDARD"},
+		"databaseversion": {"value": "POSTGRES_15"},
 		"settings": {"flags": {"crossdbownershipchaining": {"value": true}}},
 	})
 

--- a/checks/cloud/google/sql/no_cross_db_ownership_chaining_test.rego
+++ b/checks/cloud/google/sql/no_cross_db_ownership_chaining_test.rego
@@ -20,7 +20,8 @@ test_allow_cross_database_ownership_chaining_disabled if {
 		"settings": {"flags": {"crossdbownershipchaining": {"value": false}}},
 	})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }
 
 test_allow_cross_database_ownership_chaining_enabled_for_non_sql_servers if {
@@ -29,7 +30,8 @@ test_allow_cross_database_ownership_chaining_enabled_for_non_sql_servers if {
 		"settings": {"flags": {"crossdbownershipchaining": {"value": true}}},
 	})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }
 
 build_input(instance) := {"google": {"sql": {"instances": [instance]}}}

--- a/checks/cloud/google/sql/no_public_access_test.rego
+++ b/checks/cloud/google/sql/no_public_access_test.rego
@@ -14,7 +14,8 @@ test_deny_ipv4_enabled if {
 test_allow_ipv4_disabled if {
 	inp := build_input({"settings": {"ipconfiguration": {"enableipv4": {"value": false}}}})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }
 
 build_input(instance) := {"google": {"sql": {"instances": [instance]}}}

--- a/checks/cloud/google/sql/pg_log_checkpoints_test.rego
+++ b/checks/cloud/google/sql/pg_log_checkpoints_test.rego
@@ -20,7 +20,8 @@ test_allow_log_checkpoints_enabled if {
 		"settings": {"flags": {"logcheckpoints": {"value": true}}},
 	})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }
 
 test_allow_log_checkpoints_disabled_for_non_postgres if {
@@ -29,7 +30,8 @@ test_allow_log_checkpoints_disabled_for_non_postgres if {
 		"settings": {"flags": {"logcheckpoints": {"value": false}}},
 	})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }
 
 build_input(instance) := {"google": {"sql": {"instances": [instance]}}}

--- a/checks/cloud/google/sql/pg_log_connections_test.rego
+++ b/checks/cloud/google/sql/pg_log_connections_test.rego
@@ -20,7 +20,8 @@ test_allow_connections_logging_enabled if {
 		"settings": {"flags": {"logconnections": {"value": true}}},
 	})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }
 
 test_allow_connections_logging_disabled_for_non_postgres if {
@@ -29,7 +30,8 @@ test_allow_connections_logging_disabled_for_non_postgres if {
 		"settings": {"flags": {"logconnections": {"value": false}}},
 	})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }
 
 build_input(instance) := {"google": {"sql": {"instances": [instance]}}}

--- a/checks/cloud/google/sql/pg_log_disconnections_test.rego
+++ b/checks/cloud/google/sql/pg_log_disconnections_test.rego
@@ -20,7 +20,8 @@ test_allow_disconnections_logging_enabled if {
 		"settings": {"flags": {"logdisconnections": {"value": true}}},
 	})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }
 
 test_allow_disconnections_logging_disabled_for_non_postgres if {
@@ -29,7 +30,8 @@ test_allow_disconnections_logging_disabled_for_non_postgres if {
 		"settings": {"flags": {"logdisconnections": {"value": false}}},
 	})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }
 
 build_input(instance) := {"google": {"sql": {"instances": [instance]}}}

--- a/checks/cloud/google/sql/pg_log_errors_test.rego
+++ b/checks/cloud/google/sql/pg_log_errors_test.rego
@@ -20,7 +20,8 @@ test_allow_minimum_log_level_is_error if {
 		"settings": {"flags": {"logminmessages": {"value": "ERROR"}}},
 	})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }
 
 test_allow_minimum_log_level_is_not_error_for_non_postgres if {
@@ -29,7 +30,8 @@ test_allow_minimum_log_level_is_not_error_for_non_postgres if {
 		"settings": {"flags": {"logminmessages": {"value": "PANIC"}}},
 	})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }
 
 build_input(instance) := {"google": {"sql": {"instances": [instance]}}}

--- a/checks/cloud/google/sql/pg_log_lock_waits_test.rego
+++ b/checks/cloud/google/sql/pg_log_lock_waits_test.rego
@@ -20,7 +20,8 @@ test_allow_lock_waits_loggging_enabled if {
 		"settings": {"flags": {"loglockwaits": {"value": true}}},
 	})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }
 
 test_allow_lock_waits_loggging_disabled_for_non_postgres if {
@@ -29,7 +30,8 @@ test_allow_lock_waits_loggging_disabled_for_non_postgres if {
 		"settings": {"flags": {"loglockwaits": {"value": false}}},
 	})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }
 
 build_input(instance) := {"google": {"sql": {"instances": [instance]}}}

--- a/checks/cloud/google/sql/pg_log_lock_waits_test.rego
+++ b/checks/cloud/google/sql/pg_log_lock_waits_test.rego
@@ -26,7 +26,7 @@ test_allow_lock_waits_loggging_enabled if {
 
 test_allow_lock_waits_loggging_disabled_for_non_postgres if {
 	inp := build_input({
-		"databaseversion": {"value": "POSTGRES_11"},
+		"databaseversion": {"value": "SQLSERVER_2017_STANDARD"},
 		"settings": {"flags": {"loglockwaits": {"value": false}}},
 	})
 

--- a/checks/cloud/google/sql/pg_no_min_statement_logging_test.rego
+++ b/checks/cloud/google/sql/pg_no_min_statement_logging_test.rego
@@ -20,7 +20,8 @@ test_allow_logging_disabled_for_all_statements if {
 		"settings": {"flags": {"logmindurationstatement": {"value": false}}},
 	})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }
 
 test_allow_logging_enabled_for_all_statements_for_non_postgres if {
@@ -29,7 +30,8 @@ test_allow_logging_enabled_for_all_statements_for_non_postgres if {
 		"settings": {"flags": {"logmindurationstatement": {"value": true}}},
 	})
 
-	check.deny with input as inp == set()
+	res := check.deny with input as inp
+	res == set()
 }
 
 build_input(instance) := {"google": {"sql": {"instances": [instance]}}}

--- a/checks/cloud/google/sql/pg_no_min_statement_logging_test.rego
+++ b/checks/cloud/google/sql/pg_no_min_statement_logging_test.rego
@@ -7,7 +7,7 @@ import data.builtin.google.sql.google0021 as check
 test_deny_logging_enabled_for_all_statements if {
 	inp := build_input({
 		"databaseversion": {"value": "POSTGRES_12"},
-		"settings": {"flags": {"logmindurationstatement": {"value": true}}},
+		"settings": {"flags": {"logmindurationstatement": {"value": 1}}},
 	})
 
 	res := check.deny with input as inp
@@ -17,7 +17,7 @@ test_deny_logging_enabled_for_all_statements if {
 test_allow_logging_disabled_for_all_statements if {
 	inp := build_input({
 		"databaseversion": {"value": "POSTGRES_12"},
-		"settings": {"flags": {"logmindurationstatement": {"value": false}}},
+		"settings": {"flags": {"logmindurationstatement": {"value": -1}}},
 	})
 
 	res := check.deny with input as inp
@@ -27,7 +27,7 @@ test_allow_logging_disabled_for_all_statements if {
 test_allow_logging_enabled_for_all_statements_for_non_postgres if {
 	inp := build_input({
 		"databaseversion": {"value": "MYSQL_8_0"},
-		"settings": {"flags": {"logmindurationstatement": {"value": true}}},
+		"settings": {"flags": {"logmindurationstatement": {"value": 1}}},
 	})
 
 	res := check.deny with input as inp

--- a/checks/docker/leaked_secrets_test.rego
+++ b/checks/docker/leaked_secrets_test.rego
@@ -128,33 +128,29 @@ test_allow_secret_in_set_command_with_secret_mount if {
 }
 
 test_deny_secret_key if {
-	# starts with uppercase secret token
-	case1 := check.deny with input as build_simple_input("env", ["SECRET_PASSPHRASE", "test", "="])
-	count(case1) = 1
+	tc := {
+		build_simple_input("env", ["SECRET_PASSPHRASE", "test", "="]),
+		build_simple_input("env", ["password", "test", "="]),
+		build_simple_input("arg", ["AWS_SECRET_ACCESS_KEY"]),
+		build_simple_input("arg", ["ARTIFACTORY_USR"]),
+		build_simple_input("arg", ["ARTIFACTORY_PSW"]),
+	}
 
-	# starts with lowercase secret token
-	case2 := check.deny with input as build_simple_input("env", ["password", "test", "="])
-	count(case2) = 1
-
-	# contains uppercase secret token after underscore
-	case3 := check.deny with input as build_simple_input("arg", ["AWS_SECRET_ACCESS_KEY"])
-	count(case3) = 1
-
-	case4 := check.deny with input as build_simple_input("arg", ["ARTIFACTORY_USR"])
-	count(case4) = 1
-
-	case5 := check.deny with input as build_simple_input("arg", ["ARTIFACTORY_PSW"])
-	count(case5) = 1
+	every tt in tc {
+		res := check.deny with input as tt
+		count(res) = 1
+	}
 }
 
 test_allow_secret_key if {
-	# starts with uppercase secret token
-	case1 := check.deny with input as build_simple_input("env", ["PUBLIC_KEY", "test", "="])
-	count(case1) = 0
-
-	# starts with lowercase secret token
-	case2 := check.deny with input as build_simple_input("arg", ["public_token"])
-	count(case2) = 0
+	tc := {
+		build_simple_input("env", ["PUBLIC_KEY", "test", "="]),
+		build_simple_input("arg", ["public_token"]),
+	}
+	every tt in tc {
+		res := check.deny with input as tt
+		count(res) = 0
+	}
 }
 
 instruction(cmd, val) := {

--- a/checks/docker/root_user_test.rego
+++ b/checks/docker/root_user_test.rego
@@ -43,7 +43,7 @@ test_no_user_cmd_denied if {
 		"Name": "alpine:3.13",
 		"Commands": [{
 			"Cmd": "expose",
-			"Value": [22],
+			"Value": ["22"],
 			"StartLine": 1,
 			"Stage": 1,
 		}],

--- a/checks/kubernetes/allowing_to_update_a_malicious_pod_test.rego
+++ b/checks/kubernetes/allowing_to_update_a_malicious_pod_test.rego
@@ -146,7 +146,7 @@ test_update_malicious_pod_deployment if {
 	count(r) > 0
 }
 
-test_update_malicious_pod_daemonsets if {
+test_update_malicious_pod_daemonsets_2 if {
 	r := deny with input as {
 		"apiVersion": "rbac.authorization.k8s.io/v1",
 		"kind": "Role",
@@ -164,7 +164,7 @@ test_update_malicious_pod_daemonsets if {
 	count(r) > 0
 }
 
-test_update_malicious_pod_statefulsets if {
+test_update_malicious_pod_statefulsets_2 if {
 	r := deny with input as {
 		"apiVersion": "rbac.authorization.k8s.io/v1",
 		"kind": "Role",
@@ -182,7 +182,7 @@ test_update_malicious_pod_statefulsets if {
 	count(r) > 0
 }
 
-test_update_malicious_pod_replicationcontrollers if {
+test_update_malicious_pod_replicationcontrollers_2 if {
 	r := deny with input as {
 		"apiVersion": "rbac.authorization.k8s.io/v1",
 		"kind": "Role",
@@ -200,7 +200,7 @@ test_update_malicious_pod_replicationcontrollers if {
 	count(r) > 0
 }
 
-test_update_malicious_pod_replicasets if {
+test_update_malicious_pod_replicasets_2 if {
 	r := deny with input as {
 		"apiVersion": "rbac.authorization.k8s.io/v1",
 		"kind": "Role",
@@ -236,7 +236,7 @@ test_update_malicious_pod_jobs if {
 	count(r) > 0
 }
 
-test_update_malicious_pod_cronjobs if {
+test_update_malicious_pod_cronjobs_2 if {
 	r := deny with input as {
 		"apiVersion": "rbac.authorization.k8s.io/v1",
 		"kind": "Role",

--- a/checks/kubernetes/kubelet_authorization_mode_argument_test.rego
+++ b/checks/kubernetes/kubelet_authorization_mode_argument_test.rego
@@ -24,7 +24,7 @@ test_validate_kubelet_authorization_mode_not_set if {
 	count(r) == 1
 }
 
-test_validate_kubelet_authorization_mode_set_alwaysAllow if {
+test_validate_kubelet_authorization_mode_set_RBAC if {
 	r := deny with input as {
 		"apiVersion": "v1",
 		"kind": "NodeInfo",

--- a/checks/kubernetes/manage_kubernetes_rbac_resources_test.rego
+++ b/checks/kubernetes/manage_kubernetes_rbac_resources_test.rego
@@ -20,7 +20,7 @@ test_manage_K8s_RBAC_resources_create if {
 	count(r) > 0
 }
 
-test_manage_K8s_RBAC_resources_create if {
+test_manage_K8s_RBAC_resources_create_2 if {
 	r := deny with input as {
 		"apiVersion": "rbac.authorization.k8s.io/v1",
 		"kind": "Role",
@@ -74,7 +74,7 @@ test_manage_K8s_RBAC_resources_deletecollection if {
 	count(r) > 0
 }
 
-test_manage_K8s_RBAC_resources_deletecollection if {
+test_manage_K8s_RBAC_resources_deletecollection_2 if {
 	r := deny with input as {
 		"apiVersion": "rbac.authorization.k8s.io/v1",
 		"kind": "Role",
@@ -110,7 +110,7 @@ test_manage_K8s_RBAC_resources_all if {
 	count(r) > 0
 }
 
-test_manage_K8s_RBAC_resources_all if {
+test_manage_K8s_RBAC_resources_all_2 if {
 	r := deny with input as {
 		"apiVersion": "rbac.authorization.k8s.io/v1",
 		"kind": "Role",

--- a/checks/kubernetes/masters_group_bind_test.rego
+++ b/checks/kubernetes/masters_group_bind_test.rego
@@ -111,7 +111,7 @@ test_cluster_role_binding_with_non_system_masters_group_binding if {
 	count(r) == 0
 }
 
-test_role_binding_with_system_masters_group_binding if {
+test_role_binding_with_system_masters_group_binding_2 if {
 	r := deny with input as {
 		"apiVersion": "rbac.authorization.k8s.io/v1",
 		"kind": "RoleBinding",

--- a/checks/kubernetes/privilege_escalation_from_node_proxy_test.rego
+++ b/checks/kubernetes/privilege_escalation_from_node_proxy_test.rego
@@ -56,7 +56,7 @@ test_privilege_escalation_from_node_proxy_not_secret_resource if {
 	count(r) == 0
 }
 
-test_privilege_escalation_from_node_proxy_not_secret_resource if {
+test_privilege_escalation_from_node_proxy_not_secret_resource_2 if {
 	r := deny with input as {
 		"apiVersion": "rbac.authorization.k8s.io/v1",
 		"kind": "Role",

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.37.1-0.20250602105123-1720acdcb24e
 	github.com/testcontainers/testcontainers-go/modules/registry v0.37.0
+	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/text v0.26.0
 	gopkg.in/yaml.v3 v3.0.1
 	mvdan.cc/sh/v3 v3.11.0

--- a/go.sum
+++ b/go.sum
@@ -302,6 +302,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
@@ -322,10 +323,13 @@ github.com/vektah/gqlparser/v2 v2.5.26 h1:REqqFkO8+SOEgZHR/eHScjjVjGS8Nk3RMO/jui
 github.com/vektah/gqlparser/v2 v2.5.26/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yashtewari/glob-intersection v0.2.0 h1:8iuHdN88yYuCzCdjt0gDe+6bAhUwBeEWqThExu54RFg=

--- a/test/test_input_schema_test.go
+++ b/test/test_input_schema_test.go
@@ -56,6 +56,7 @@ func TestTestInputsConformToSchema(t *testing.T) {
 }
 
 func collectModules(t *testing.T) map[string]*ast.Module {
+	t.Helper()
 	res1, err := loadModules(trivy_checks.EmbeddedPolicyFileSystem)
 	require.NoError(t, err)
 
@@ -69,6 +70,7 @@ func collectModules(t *testing.T) map[string]*ast.Module {
 }
 
 func buildEvalInputRules(t *testing.T, modules map[string]*ast.Module) map[string]string {
+	t.Helper()
 	queries := make(map[string]string)
 
 	for path, module := range modules {
@@ -105,6 +107,7 @@ func isTestRule(r *ast.Rule) bool {
 }
 
 func compileModules(t *testing.T, modules map[string]*ast.Module) *ast.Compiler {
+	t.Helper()
 	c := ast.NewCompiler()
 	c.Compile(modules)
 	require.Empty(t, c.Errors)
@@ -112,6 +115,7 @@ func compileModules(t *testing.T, modules map[string]*ast.Module) *ast.Compiler 
 }
 
 func loadSchemaLoaders(t *testing.T) map[string]gojsonschema.JSONLoader {
+	t.Helper()
 	load := func(filename string) gojsonschema.JSONLoader {
 		bytes, err := os.ReadFile(filepath.Join("..", "schemas", filename))
 		require.NoError(t, err)

--- a/test/test_input_schema_test.go
+++ b/test/test_input_schema_test.go
@@ -23,7 +23,7 @@ import (
 	_ "github.com/aquasecurity/trivy/pkg/iac/rego" // register Built-in Functions from Trivy
 )
 
-func TestTestInputsConformToSchema(t *testing.T) {
+func TestInputsConformToSchema(t *testing.T) {
 	modules := collectModules(t)
 	queries := buildEvalInputRules(t, modules)
 

--- a/test/test_input_schema_test.go
+++ b/test/test_input_schema_test.go
@@ -1,0 +1,210 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/loader"
+	"github.com/open-policy-agent/opa/v1/rego"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xeipuuv/gojsonschema"
+
+	trivy_checks "github.com/aquasecurity/trivy-checks"
+	_ "github.com/aquasecurity/trivy/pkg/iac/rego" // register Built-in Functions from Trivy
+)
+
+func TestTestInputsConformToSchema(t *testing.T) {
+	modules := collectModules(t)
+	queries := buildEvalInputRules(t, modules)
+
+	compiler := compileModules(t, modules)
+	schemaLoaders := loadSchemaLoaders(t)
+
+	for query, loc := range queries {
+		ruleName := lo.LastOrEmpty(strings.Split(query, "."))
+		t.Run(ruleName, func(t *testing.T) {
+			res, err := evalRuleInput(t.Context(), compiler, query)
+			require.NoError(t, err, query)
+
+			schemaLoader, err := loaderByPackage(schemaLoaders, query)
+			require.NoError(t, err)
+
+			documentLoader := gojsonschema.NewGoLoader(res)
+			result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+			require.NoError(t, err)
+
+			if !result.Valid() {
+				errs := lo.Map(result.Errors(), func(err gojsonschema.ResultError, _ int) string {
+					return err.String()
+				})
+				assert.True(t, false, fmt.Sprintf("%s\nAt %s", strings.Join(errs, "\n"), loc))
+			}
+		})
+	}
+}
+
+func collectModules(t *testing.T) map[string]*ast.Module {
+	res1, err := loadModules(trivy_checks.EmbeddedPolicyFileSystem)
+	require.NoError(t, err)
+
+	res2, err := loadModules(trivy_checks.EmbeddedLibraryFileSystem)
+	require.NoError(t, err)
+
+	modules := make(map[string]*ast.Module)
+	maps.Copy(modules, res1.ParsedModules())
+	maps.Copy(modules, res2.ParsedModules())
+	return modules
+}
+
+func buildEvalInputRules(t *testing.T, modules map[string]*ast.Module) map[string]string {
+	queries := make(map[string]string)
+
+	for path, module := range modules {
+		if !testRegoFile(path) {
+			continue
+		}
+
+		if !module.Package.Path[1].Equal(ast.StringTerm("builtin")) {
+			continue
+		}
+
+		copied := module.Copy()
+		for _, r := range module.Rules {
+			if !strings.HasPrefix(r.Head.Name.String(), "test_") {
+				continue
+			}
+			newRule := generateEvalInpRule(t, r)
+			if newRule == nil {
+				continue
+			}
+
+			copied.Rules = append(copied.Rules, newRule)
+			query := module.Package.Path.String() + "." + newRule.Head.Name.String()
+			queries[query] = r.Head.Location.String()
+		}
+		modules[path] = copied
+	}
+	return queries
+}
+
+func compileModules(t *testing.T, modules map[string]*ast.Module) *ast.Compiler {
+	c := ast.NewCompiler()
+	c.Compile(modules)
+	require.Empty(t, c.Errors)
+	return c
+}
+
+func loadSchemaLoaders(t *testing.T) map[string]gojsonschema.JSONLoader {
+	load := func(filename string) gojsonschema.JSONLoader {
+		bytes, err := os.ReadFile(filepath.Join("..", "schemas", filename))
+		require.NoError(t, err)
+		return gojsonschema.NewBytesLoader(bytes)
+	}
+	return map[string]gojsonschema.JSONLoader{
+		"cloud":      load("cloud.json"),
+		"kubernetes": load("kubernetes.json"),
+		"dockerfile": load("dockerfile.json"),
+	}
+}
+
+func loaderByPackage(loaders map[string]gojsonschema.JSONLoader, pkg string) (gojsonschema.JSONLoader, error) {
+	parts := strings.Split(pkg, ".")
+	switch parts[2] {
+	case "aws", "azure", "google", "cloudstack", "oracle",
+		"nifcloud", "openstack", "digitalocean", "github":
+		return loaders["cloud"], nil
+	case "kubernetes", "kube":
+		return loaders["kubernetes"], nil
+	case "dockerfile":
+		return loaders["dockerfile"], nil
+	default:
+		return nil, fmt.Errorf("unknown source: %s", parts[2])
+	}
+}
+
+func evalRuleInput(ctx context.Context, c *ast.Compiler, query string) (any, error) {
+	r := rego.New(
+		rego.Query(query),
+		rego.Compiler(c),
+	)
+
+	rs, err := r.Eval(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(rs) == 0 || len(rs[0].Expressions) == 0 {
+		return nil, fmt.Errorf("bad result: %v", rs)
+	}
+
+	return rs[0].Expressions[0].Value, nil
+}
+
+func loadModules(fsys fs.FS) (*loader.Result, error) {
+	return loader.NewFileLoader().
+		WithFS(fsys).
+		Filtered([]string{"."}, func(abspath string, info fs.FileInfo, depth int) bool {
+			return isNotRegoFile(info)
+		})
+}
+
+func generateEvalInpRule(t *testing.T, rule *ast.Rule) *ast.Rule {
+	if lo.CountBy(rule.Body, func(expr *ast.Expr) bool {
+		return slices.ContainsFunc(expr.With, func(w *ast.With) bool {
+			return w.Target.String() == "input"
+		})
+	}) > 1 {
+		t.Logf("Skip rule %q because it has more than one `with input as` clause", rule.Head.Name.String())
+		return nil
+	}
+
+	for i, expr := range rule.Body {
+		for k, w := range expr.With {
+			if w.Target.String() == "input" {
+				newBody := ast.NewBody()
+				for j := 0; j <= i-1; j++ {
+					newBody.Append(rule.Body[j])
+				}
+				term := ast.MustParseExpr(fmt.Sprintf("res := %s", w.Value.String()))
+				newBody.Append(term)
+				newName := rule.Head.Name.String() + strconv.Itoa(k) + "_eval_inp"
+				newRule := &ast.Rule{
+					Head: &ast.Head{
+						Name:  ast.Var(newName),
+						Value: ast.NewTerm(ast.Var("res")),
+					},
+					Body: newBody,
+				}
+				return newRule
+			}
+		}
+	}
+
+	return nil
+}
+
+func isNotRegoFile(fi fs.FileInfo) bool {
+	return !fi.IsDir() && (!isRegoFile(fi.Name()) || isDotFile(fi.Name()))
+}
+
+func isRegoFile(name string) bool {
+	return strings.HasSuffix(name, ".rego")
+}
+
+func testRegoFile(name string) bool {
+	return strings.HasSuffix(name, "_test.rego")
+}
+
+func isDotFile(name string) bool {
+	return strings.HasPrefix(name, ".")
+}


### PR DESCRIPTION
This PR adds a Go test that checks that the inputs in Rego-tests (test_* rules) match JSON schemas.
This helps to:
- detect errors in tests during the development phase;
- make it easier to write new tests;
- increase reliability and consistency of test data.