### PR TITLE
test: disallow extra fields in cloud schema validation

### DIFF
--- a/checks/cloud/aws/apigateway/no_public_access_test.rego
+++ b/checks/cloud/aws/apigateway/no_public_access_test.rego
@@ -15,7 +15,7 @@ test_allow_option_method if {
 }
 
 test_allow_get_method_with_auth if {
-	test.assert_empty(check.deny) with input as input_with_method({"methods": [{"httpmethod": {"value": "GET"}, "authorizationtype": {"value": "AWS_IAM"}}]})
+	test.assert_empty(check.deny) with input as input_with_method({"httpmethod": {"value": "GET"}, "authorizationtype": {"value": "AWS_IAM"}})
 }
 
 test_allow_if_api_required if {

--- a/checks/cloud/aws/cloudfront/enforce_https_test.rego
+++ b/checks/cloud/aws/cloudfront/enforce_https_test.rego
@@ -16,7 +16,7 @@ test_deny_ordered_cache_behaviors_with_allow_all if {
 }
 
 test_allow_default_cache_behavior_with_https if {
-	inp := build_input({"defaultcachebehavior": {"viewerprotocolpolicy": {"value": "https-only"}}})
+	inp := build_input({"defaultcachebehaviour": {"viewerprotocolpolicy": {"value": "https-only"}}})
 	test.assert_empty(check.deny) with input as inp
 }
 

--- a/checks/cloud/aws/dynamodb/table_customer_key_test.rego
+++ b/checks/cloud/aws/dynamodb/table_customer_key_test.rego
@@ -6,37 +6,28 @@ import data.builtin.aws.dynamodb.aws0025 as check
 import data.lib.test
 
 test_allow_table_with_cmk if {
-	inp := {"aws": {"dynamodb": {"tables": [{
-		"name": "test",
-		"serversideencryption": {
-			"enabled": {"value": true},
-			"kmskeyid": {"value": "alias/test"},
-		},
-	}]}}}
+	inp := {"aws": {"dynamodb": {"tables": [{"serversideencryption": {
+		"enabled": {"value": true},
+		"kmskeyid": {"value": "alias/test"},
+	}}]}}}
 
 	test.assert_empty(check.deny) with input as inp
 }
 
 test_deny_table_without_cmk if {
-	inp := {"aws": {"dynamodb": {"tables": [{
-		"name": "test",
-		"serversideencryption": {
-			"enabled": {"value": true},
-			"kmskeyid": {"value": ""},
-		},
-	}]}}}
+	inp := {"aws": {"dynamodb": {"tables": [{"serversideencryption": {
+		"enabled": {"value": true},
+		"kmskeyid": {"value": ""},
+	}}]}}}
 
 	test.assert_equal_message("Table encryption explicitly uses the default KMS key.", check.deny) with input as inp
 }
 
 test_deny_table_sse_disabled if {
-	inp := {"aws": {"dynamodb": {"tables": [{
-		"name": "test",
-		"serversideencryption": {
-			"enabled": {"value": false},
-			"kmskeyid": {"value": ""},
-		},
-	}]}}}
+	inp := {"aws": {"dynamodb": {"tables": [{"serversideencryption": {
+		"enabled": {"value": false},
+		"kmskeyid": {"value": ""},
+	}}]}}}
 
 	test.assert_equal_message("Table encryption does not use a customer-managed KMS key.", check.deny) with input as inp
 }

--- a/checks/cloud/aws/iam/limit_s3_full_access_test.rego
+++ b/checks/cloud/aws/iam/limit_s3_full_access_test.rego
@@ -4,7 +4,7 @@ import rego.v1
 
 test_with_allow_s3_full_access if {
 	policies := [{
-		"name": {"Value": "policy_with_s3_full_access"},
+		"name": {"value": "policy_with_s3_full_access"},
 		"document": {"value": json.marshal({
 			"Version": "2012-10-17",
 			"Statement": [{

--- a/checks/cloud/aws/kinesis/enable_in_transit_encryption_test.rego
+++ b/checks/cloud/aws/kinesis/enable_in_transit_encryption_test.rego
@@ -6,37 +6,28 @@ import data.builtin.aws.kinesis.aws0064 as check
 import data.lib.test
 
 test_deny_unecrypted if {
-	inp := {"aws": {"kinesis": {"streams": [{
-		"name": "test",
-		"encryption": {
-			"type": {"value": ""},
-			"kmskeyid": {"value": ""},
-		},
-	}]}}}
+	inp := {"aws": {"kinesis": {"streams": [{"encryption": {
+		"type": {"value": ""},
+		"kmskeyid": {"value": ""},
+	}}]}}}
 
 	test.assert_equal_message("Stream does not use KMS encryption.", check.deny) with input as inp
 }
 
 test_deny_with_kms_but_without_key if {
-	inp := {"aws": {"kinesis": {"streams": [{
-		"name": "test",
-		"encryption": {
-			"type": {"value": "KMS"},
-			"kmskeyid": {"value": ""},
-		},
-	}]}}}
+	inp := {"aws": {"kinesis": {"streams": [{"encryption": {
+		"type": {"value": "KMS"},
+		"kmskeyid": {"value": ""},
+	}}]}}}
 
 	test.assert_equal_message("Stream does not use a custom-managed KMS key.", check.deny) with input as inp
 }
 
 test_allow_encrypted if {
-	inp := {"aws": {"kinesis": {"streams": [{
-		"name": "test",
-		"encryption": {
-			"type": {"value": "KMS"},
-			"kmskeyid": {"value": "test"},
-		},
-	}]}}}
+	inp := {"aws": {"kinesis": {"streams": [{"encryption": {
+		"type": {"value": "KMS"},
+		"kmskeyid": {"value": "test"},
+	}}]}}}
 
 	test.assert_empty(check.deny) with input as inp
 }

--- a/checks/cloud/aws/rds/enable_cluster_deletion_protection_test.rego
+++ b/checks/cloud/aws/rds/enable_cluster_deletion_protection_test.rego
@@ -14,6 +14,6 @@ test_allow_deletion_protection_enabled if {
 
 # If there is no cluster for database instances, they are added to an empty cluster.
 test_allow_deletion_protection_disabled_but_instances_orphaned if {
-	r := deny with input as {"aws": {"rds": {"clusters": [{"deletionprotection": {"__defsec_metadata": {"managed": false}, "value": false}}]}}}
+	r := deny with input as {"aws": {"rds": {"clusters": [{"deletionprotection": {"managed": false, "value": false}}]}}}
 	count(r) == 0
 }

--- a/checks/cloud/aws/rds/encrypt_instance_storage_data.rego
+++ b/checks/cloud/aws/rds/encrypt_instance_storage_data.rego
@@ -42,9 +42,9 @@ deny contains res if {
 	)
 }
 
-without_replication_source_arn(instance) if value.is_empty(instance.replciationsourcearn)
+without_replication_source_arn(instance) if value.is_empty(instance.replicationsourcearn)
 
-without_replication_source_arn(instance) if not instance.replciationsourcearn
+without_replication_source_arn(instance) if not instance.replicationsourcearn
 
 encryption_disabled(instance) if value.is_false(instance.encryption.encryptstorage)
 

--- a/checks/cloud/aws/rds/encrypt_instance_storage_data_test.rego
+++ b/checks/cloud/aws/rds/encrypt_instance_storage_data_test.rego
@@ -7,7 +7,7 @@ import data.lib.test
 
 test_deny_unencrypted_storage if {
 	inp := {"aws": {"rds": {"instances": [{
-		"replciationsourcearn": {"value": ""},
+		"replicationsourcearn": {"value": ""},
 		"encryption": {"encryptstorage": {"value": false}},
 	}]}}}
 
@@ -16,7 +16,7 @@ test_deny_unencrypted_storage if {
 
 test_allow_encrypted_storage if {
 	inp := {"aws": {"rds": {"instances": [{
-		"replciationsourcearn": {"value": ""},
+		"replicationsourcearn": {"value": ""},
 		"encryption": {"encryptstorage": {"value": true}},
 	}]}}}
 

--- a/checks/cloud/aws/s3/enable_logging_test.rego
+++ b/checks/cloud/aws/s3/enable_logging_test.rego
@@ -34,10 +34,7 @@ test_allow_logging_disabled_but_bucket_has_server_logging_access_grant if {
 		"acl": {"value": "log-delivery-write"},
 		"grants": [
 			{
-				"grantee": {
-					"id": {"value": "111122223333"},
-					"type": {"value": "CanonicalUser"},
-				},
+				"grantee": {"type": {"value": "CanonicalUser"}},
 				"permissions": [{"value": "FULL_CONTROL"}],
 			},
 			{

--- a/checks/cloud/aws/s3/encryption_customer_key_test.rego
+++ b/checks/cloud/aws/s3/encryption_customer_key_test.rego
@@ -29,11 +29,13 @@ test_allow_log_bucket_without_kms_key if {
 }
 
 test_allow_log_bucket_with_grant if {
-	inp := {"aws": {"s3": {"buckets": [{"grants": [{
+	inp := {"aws": {"s3": {"buckets": [{
 		"encryption": {},
-		"grantee": {"uri": {"value": "http://acs.amazonaws.com/groups/s3/LogDelivery"}},
-		"permissions": [{"value": "WRITE"}],
-	}]}]}}}
+		"grants": [{
+			"grantee": {"uri": {"value": "http://acs.amazonaws.com/groups/s3/LogDelivery"}},
+			"permissions": [{"value": "WRITE"}],
+		}],
+	}]}}}
 
 	res := check.deny with input as inp
 	count(res) == 0

--- a/checks/cloud/aws/sqs/queue_encryption_with_cmk_test.rego
+++ b/checks/cloud/aws/sqs/queue_encryption_with_cmk_test.rego
@@ -6,19 +6,13 @@ import data.builtin.aws.sqs.aws0135 as check
 import data.lib.test
 
 test_allow_encrypted_with_cmk if {
-	inp := {"aws": {"sqs": {"queues": [{
-		"name": "test-queue",
-		"encryption": {"kmskeyid": {"value": "key-id"}},
-	}]}}}
+	inp := {"aws": {"sqs": {"queues": [{"encryption": {"kmskeyid": {"value": "key-id"}}}]}}}
 
 	test.assert_empty(check.deny) with input as inp
 }
 
 test_deny_unencrypted_with_cmk if {
-	inp := {"aws": {"sqs": {"queues": [{
-		"name": "test-queue",
-		"encryption": {"kmskeyid": {"value": "alias/aws/sqs"}},
-	}]}}}
+	inp := {"aws": {"sqs": {"queues": [{"encryption": {"kmskeyid": {"value": "alias/aws/sqs"}}}]}}}
 
 	test.assert_equal_message("Queue is not encrypted with a customer managed key.", check.deny) with input as inp
 }

--- a/checks/cloud/azure/storage/allow_microsoft_service_bypass_test.rego
+++ b/checks/cloud/azure/storage/allow_microsoft_service_bypass_test.rego
@@ -6,10 +6,7 @@ import data.builtin.azure.storage.azure0010 as check
 import data.lib.test
 
 test_deny_rule_does_not_allow_bypass_access if {
-	inp := {"azure": {"storage": {"accounts": [{
-		"name": "test",
-		"networkrules": [{"bypass": []}],
-	}]}}}
+	inp := {"azure": {"storage": {"accounts": [{"networkrules": [{"bypass": []}]}]}}}
 
 	test.assert_count(check.deny, 1) with input as inp
 }

--- a/checks/cloud/google/compute/disable_allow_all_ports_firewall_rule.rego
+++ b/checks/cloud/google/compute/disable_allow_all_ports_firewall_rule.rego
@@ -64,8 +64,8 @@ deny contains res if {
 # Rule allows all ports if it covers the entire port range
 allows_all_ports(rule) if {
 	some port in rule.firewallrule.ports
-	port.fromport.value == 0
-	port.toport.value == 65535
+	port.start.value == 0
+	port.end.value == 65535
 }
 
 # Rule allows all ports if protocol is set to "all" or "-1"

--- a/checks/cloud/google/compute/disable_allow_all_ports_firewall_rule_test.rego
+++ b/checks/cloud/google/compute/disable_allow_all_ports_firewall_rule_test.rego
@@ -10,7 +10,7 @@ test_deny_firewall_rule_allows_all_ports if {
 			"isallow": {"value": true},
 			"enforced": {"value": true},
 			"protocol": {"value": "tcp"},
-			"ports": [{"fromport": {"value": 0}, "toport": {"value": 65535}}],
+			"ports": [{"start": {"value": 0}, "end": {"value": 65535}}],
 		},
 		"sourceranges": [{"value": "0.0.0.0/0"}],
 	}]}}]}}}
@@ -25,7 +25,7 @@ test_allow_firewall_rule_specific_ports if {
 			"isallow": {"value": true},
 			"enforced": {"value": true},
 			"protocol": {"value": "tcp"},
-			"ports": [{"fromport": {"value": 80}, "toport": {"value": 80}}],
+			"ports": [{"start": {"value": 80}, "end": {"value": 80}}],
 		},
 		"sourceranges": [{"value": "0.0.0.0/0"}],
 	}]}}]}}}

--- a/checks/cloud/google/compute/restrict_ssh_access.rego
+++ b/checks/cloud/google/compute/restrict_ssh_access.rego
@@ -53,5 +53,5 @@ deny contains res if {
 
 is_ssh_port(rule) if {
 	some port in rule.firewallrule.ports
-	net.is_port_range_include(port.fromport.value, port.toport.value, net.ssh_port)
+	net.is_port_range_include(port.start.value, port.end.value, net.ssh_port)
 }

--- a/checks/cloud/google/compute/restrict_ssh_access_test.rego
+++ b/checks/cloud/google/compute/restrict_ssh_access_test.rego
@@ -10,7 +10,7 @@ test_deny_ssh_access_from_anywhere if {
 			"isallow": {"value": true},
 			"enforced": {"value": true},
 			"protocol": {"value": "tcp"},
-			"ports": [{"fromport": {"value": 22}, "toport": {"value": 22}}],
+			"ports": [{"start": {"value": 22}, "end": {"value": 22}}],
 		},
 		"sourceranges": [{"value": "0.0.0.0/0"}],
 	}]}}]}}}
@@ -25,7 +25,7 @@ test_allow_ssh_access_from_specific_ip if {
 			"isallow": {"value": true},
 			"enforced": {"value": true},
 			"protocol": {"value": "tcp"},
-			"ports": [{"fromport": {"value": 22}, "toport": {"value": 22}}],
+			"ports": [{"start": {"value": 22}, "end": {"value": 22}}],
 		},
 		"sourceranges": [{"value": "192.168.1.0/24"}],
 	}]}}]}}}

--- a/checks/cloud/google/compute/vm_disk_encryption_customer_key_test.rego
+++ b/checks/cloud/google/compute/vm_disk_encryption_customer_key_test.rego
@@ -19,10 +19,10 @@ test_deny_instance_attached_disk_is_not_encrypted if {
 }
 
 test_allow_instance_disks_is_encrypted if {
-	inp := {"google": {"compute": {
+	inp := {"google": {"compute": {"instances": [{
 		"bootdisks": [{"encryption": {"kmskeylink": {"value": "kms-key-link"}}}],
-		"attacheddisks": [{"disk": {"encryption": {"kmskeylink": {"value": "kms-key-link"}}}}],
-	}}}
+		"attacheddisks": [{"encryption": {"kmskeylink": {"value": "kms-key-link"}}}],
+	}]}}}
 
 	res := check.deny with input as inp
 	res == set()

--- a/checks/cloud/google/iam/no_privileged_service_accounts.rego
+++ b/checks/cloud/google/iam/no_privileged_service_accounts.rego
@@ -32,7 +32,6 @@ import data.lib.google.iam
 
 deny contains res if {
 	some member in iam.all_members
-	print(member)
 	iam.is_service_account(member.member.value)
 	iam.is_role_privileged(member.role.value)
 	res := result.new("Service account is granted a privileged role.", member.role)

--- a/checks/cloud/google/iam/no_user_granted_permissions.rego
+++ b/checks/cloud/google/iam/no_user_granted_permissions.rego
@@ -43,7 +43,6 @@ deny contains res if {
 
 deny contains res if {
 	some binding in iam.all_bindings
-	print(binding)
 	some member in binding.members
 	startswith(member.value, "user:")
 	res := result.new("Permissions are granted directly to a user.", member)

--- a/checks/cloud/google/iam/no_user_granted_permissions_test.rego
+++ b/checks/cloud/google/iam/no_user_granted_permissions_test.rego
@@ -25,7 +25,6 @@ test_deny_permissions_granted_to_folder_users if {
 	inp := {"google": {"iam": {"folders": [{"bindings": [{"members": [user_member]}]}]}}}
 
 	res := check.deny with input as inp
-	print(res)
 	count(res) == 1
 }
 

--- a/checks/cloud/google/sql/encrypt_in_transit_data_test.rego
+++ b/checks/cloud/google/sql/encrypt_in_transit_data_test.rego
@@ -17,11 +17,11 @@ test_deny_tls_not_required if {
 	count(res) == 1
 }
 
-test_deny_tls_not_required_but_ssl_mode_require_ssl if {
-	inp := build_input({"requiretls": {"value": false}, "ssl_mode": {"value": check.ssl_mode_trusted_client_certificate_required}})
+test_allow_tls_not_required_but_ssl_mode_require_ssl if {
+	inp := build_input({"requiretls": {"value": false}, "sslmode": {"value": check.ssl_mode_trusted_client_certificate_required}})
 
 	res := check.deny with input as inp
-	count(res) == 1
+	res == set()
 }
 
 build_input(ipconfig) := {"google": {"sql": {"instances": [{"settings": {"ipconfiguration": ipconfig}}]}}}

--- a/checks/cloud/nifcloud/network/http_not_used_test.rego
+++ b/checks/cloud/nifcloud/network/http_not_used_test.rego
@@ -6,7 +6,7 @@ import data.builtin.nifcloud.network.nifcloud0021 as check
 
 test_deny_elastic_lb_with_http_protocol_on_global if {
 	inp := build_elb_input({
-		"networkinterfaces": [{"networkid": {"value": "net-COMMON_GLOBAL", "isvipnetwork": {"value": true}}}, {"networkid": {"value": "some-network"}}],
+		"networkinterfaces": [{"networkid": {"value": "net-COMMON_GLOBAL"}, "isvipnetwork": {"value": true}}, {"networkid": {"value": "some-network"}}],
 		"listeners": [{"protocol": {"value": "HTTP"}}],
 	})
 


### PR DESCRIPTION
This PR adds the `additionalProperties` property (set to `false`) to all Cloud objects in the schema, except for `iac.types.MapValue`, which is a map and is expected to accept arbitrary keys. This makes the validation stricter and helps catch unexpected fields in test inputs.