### PR TITLE
fix(gcp): support default ports for compute firewall

### DIFF
--- a/checks/cloud/google/compute/disable_allow_all_ports_firewall_rule.rego
+++ b/checks/cloud/google/compute/disable_allow_all_ports_firewall_rule.rego
@@ -68,6 +68,12 @@ allows_all_ports(rule) if {
 	port.end.value == 65535
 }
 
+# If no ports are specified, this rule applies to connections through any port.
+# See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall#ports-1
+allows_all_ports(rule) if {
+	not rule.firewallrule.ports
+}
+
 # Rule allows all ports if protocol is set to "all" or "-1"
 allows_all_ports(rule) if {
 	net.protocol(rule.firewallrule.protocol.value) in net.all_protocols

--- a/checks/cloud/google/compute/disable_allow_all_ports_firewall_rule_test.rego
+++ b/checks/cloud/google/compute/disable_allow_all_ports_firewall_rule_test.rego
@@ -19,6 +19,20 @@ test_deny_firewall_rule_allows_all_ports if {
 	count(res) == 1
 }
 
+test_deny_firewall_rule_allows_all_ports_implicitly if {
+	inp := {"google": {"compute": {"networks": [{"firewall": {"ingressrules": [{
+		"firewallrule": {
+			"isallow": {"value": true},
+			"enforced": {"value": true},
+			"protocol": {"value": "tcp"},
+		},
+		"sourceranges": [{"value": "0.0.0.0/0"}],
+	}]}}]}}}
+
+	res := check.deny with input as inp
+	count(res) == 1
+}
+
 test_allow_firewall_rule_specific_ports if {
 	inp := {"google": {"compute": {"networks": [{"firewall": {"ingressrules": [{
 		"firewallrule": {


### PR DESCRIPTION
This PR adds support for the documented default behavior of google_compute_firewall, where omitted ports imply all ports are allowed. See [Terraform docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall#ports-1) for reference.

### Before:
```bash
Report Summary

┌────────┬───────────┬───────────────────┐
│ Target │   Type    │ Misconfigurations │
├────────┼───────────┼───────────────────┤
│ .      │ terraform │         0         │
└────────┴───────────┴───────────────────┘
```

### After:
```bash
main.tf (terraform)

Tests: 1 (SUCCESSES: 0, FAILURES: 1)
Failures: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

 (MEDIUM): Firewall rule allows access to all ports.
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Firewall rules should not be wide open to all ports. Lock down rules to only required ports.


See https://avd.aquasec.com/misconfig/avd-gcp-0072
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 main.tf:1-11
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1 ┌ resource "google_compute_firewall" "allow-all-tcp" {
   2 │   name    = "allow-all-tcp"
   3 │   network = "default"
   4 │ 
   5 │   allow {
   6 │     protocol = "tcp"
   7 │   }
   8 │ 
   9 └   source_ranges = ["192.168.1.0/24"]
  ..   
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```