### PR TITLE
fix: rego_type_error: undefined ref requestedamis

### DIFF
--- a/checks/cloud/aws/ec2/specify_ami_owners.rego
+++ b/checks/cloud/aws/ec2/specify_ami_owners.rego
@@ -29,7 +29,7 @@ package builtin.aws.ec2.aws0344
 import rego.v1
 
 deny contains res if {
-	some ami in input.aws.ec2.requestedamis
+	some ami in input.aws.ec2.instances
 	owners_not_specified(ami)
 	res := result.new("AWS AMI data source should specify owners to ensure AMIs come from trusted sources", ami)
 }


### PR DESCRIPTION
See bug report at [trivy-aws #329](https://github.com/aquasecurity/trivy-aws/issues/329)

It seems this was added in PR #352 