### PR TITLE
fix(gcp): properly check if bucket has logging

### DIFF
--- a/checks/cloud/google/storage/enable_bucket_logging.rego
+++ b/checks/cloud/google/storage/enable_bucket_logging.rego
@@ -40,10 +40,12 @@ buckets_for_logging := {name |
 deny contains res if {
 	some bucket in input.google.storage.buckets
 	not bucket.name.value in buckets_for_logging
-	not bucket.logging.logbucket.value
+	not has_logging(bucket)
 
 	res := result.new(
 		"Storage bucket logging is not configured with a target log bucket.",
 		metadata.obj_by_path(bucket, ["logging", "logbucket"]),
 	)
 }
+
+has_logging(bucket) if bucket.logging.logbucket.value != ""

--- a/checks/cloud/google/storage/enable_bucket_logging.rego
+++ b/checks/cloud/google/storage/enable_bucket_logging.rego
@@ -16,7 +16,7 @@
 #   provider: google
 #   service: storage
 #   severity: MEDIUM
-#   minimum_trivy_version: 0.65.0
+#   minimum_trivy_version: 0.66.0
 #   recommended_action: |
 #     Enable Access and Storage logs for Cloud Storage buckets by configuring a log sink or specifying a `log_bucket` in Terraform.
 #   input:


### PR DESCRIPTION
The expression `not bucket.logging.logbucket.value` is true when the `value` field is missing, but by default Trivy fills the `logbucket` with empty values:

```json
"logging": {
...
              "logbucket": {
                "endline": 6,
                "explicit": false,
                "filepath": "main.tf",
                "fskey": "fd569cbde7899a2c12c7fa8a4c51c3777becfc1797289d3e1c9e960fd56802a2",
                "managed": true,
                "resource": "google_storage_bucket.default",
                "sourceprefix": "",
                "startline": 1,
                "unresolvable": false,
                "value": ""
              },
...
```

which is why this expression is never true:
```
| | Fail not bucket.logging.logbucket.value
```


Fixes:
https://github.com/aquasecurity/trivy-checks/actions/runs/16662841182/job/47163530682