### PR TITLE
test: skip unsupported checks for test bundles

### DIFF
--- a/cmd/bundle/bundle.sh
+++ b/cmd/bundle/bundle.sh
@@ -19,7 +19,7 @@ make_grep_pattern() {
 }
 
 grep_pattern=$(make_grep_pattern)
-echo "Patttern: $grep_pattern"
+echo "Pattern: $grep_pattern"
 
 rsync_with_content_filter() {
     local src="$1"

--- a/cmd/bundle/bundle.sh
+++ b/cmd/bundle/bundle.sh
@@ -4,9 +4,58 @@ rm -rf bundle || true
 rm bundle.tar.gz || true
 RELEASE_VERSION=${GITHUB_REF/refs\/tags\/v/}
 
+IDS=("$@")
+
+make_grep_pattern() {
+    local pattern=""
+    for id in "${IDS[@]}"; do
+        if [[ -z "$pattern" ]]; then
+            pattern="id: $id"
+        else
+            pattern="$pattern|id: $id"
+        fi
+    done
+    echo "$pattern"
+}
+
+grep_pattern=$(make_grep_pattern)
+echo "Patttern: $grep_pattern"
+
+rsync_with_content_filter() {
+    local src="$1"
+    local dst="$2"
+
+    if [ ${#IDS[@]} -eq 0 ]; then
+        echo "No IDs passed, skipping content filtering."
+        rsync -avr --exclude=README.md --exclude="*_test.rego" --exclude='*.'{go,yml,yaml} \
+            --exclude=compliance --exclude=test "$src" "$dst"
+        return
+    fi
+
+    EXCLUDES='README.md|.*_test\.rego$|.*\.(go|yml|yaml)$|compliance'
+    tmpfile=$(mktemp)
+
+    find "$src" -type f | while read -r absfile; do
+        relfile="${absfile#$src}"
+        if grep -qE "$grep_pattern" "$absfile"; then
+            continue
+        fi
+        if echo "$relfile" | grep -qE "$EXCLUDES"; then
+            continue
+        fi
+        echo "$relfile"
+    done > "$tmpfile"
+
+    cat $tmpfile
+
+    rsync -avr --files-from="$tmpfile" "$src" "$dst"
+
+    rm -f "$tmpfile"
+}
+
 for dir in kubernetes cloud docker; do
     mkdir -p bundle/policies/$dir/policies
-    rsync -avr --exclude=README.md --exclude="*_test.rego" --exclude='*.'{go,yml,yaml} --exclude=compliance --exclude=test checks/$dir/  bundle/policies/$dir/policies
+    rsync_with_content_filter "checks/$dir/" "bundle/policies/$dir/policies"
 done
 
 


### PR DESCRIPTION
In one of the [PRs](https://github.com/aquasecurity/trivy-checks/actions/runs/16751450375/job/47422496831?pr=465), tests failed due to exceeding the maximum allowed errors during Rego compilation. This PR addresses the issue by skipping certain checks when creating the bundle, filtering them based on the minimal supported Trivy version. This is necessary to maintain compatibility with older Trivy versions that do not yet support such filtering.

Fixes: https://github.com/aquasecurity/trivy-checks/actions/runs/16751450375/job/47422496831?pr=465