### PR TITLE
refactor: improve shell command splitting via sh.parse_commands

### DIFF
--- a/checks/docker/update_instruction_alone.yaml
+++ b/checks/docker/update_instruction_alone.yaml
@@ -5,6 +5,12 @@ dockerfile:
       RUN apt-get update && apt-get install -y --no-install-recommends mysql-client     && rm -rf /var/lib/apt/lists/* && apt-get clean
       USER mike
       ENTRYPOINT mysql
+    - |-
+      FROM debian:trixie
+      RUN <<EOF
+      apt-get update
+      apt-get install --no-install-recommends -y gettext
+      EOF
   bad:
     - |-
       FROM ubuntu:18.04

--- a/checks/docker/update_instruction_alone_test.rego
+++ b/checks/docker/update_instruction_alone_test.rego
@@ -127,25 +127,24 @@ test_allowed if {
 	count(r) == 0
 }
 
-# TODO: improve command splitting
-# test_allowed_cmds_separated_by_semicolon {
-# 	r := deny with input as {"Stages": [{"Name": "ubuntu:18.04", "Commands": [
-# 		{
-# 			"Cmd": "from",
-# 			"Value": ["ubuntu:18.04"],
-# 		},
-# 		{
-# 			"Cmd": "run",
-# 			"Value": ["apt-get update -y ; apt-get install -y curl"],
-# 		},
-# 		{
-# 			"Cmd": "entrypoint",
-# 			"Value": ["mysql"],
-# 		},
-# 	]}]}
+test_allowed_cmds_separated_by_semicolon if {
+	r := deny with input as {"Stages": [{"Name": "ubuntu:18.04", "Commands": [
+		{
+			"Cmd": "from",
+			"Value": ["ubuntu:18.04"],
+		},
+		{
+			"Cmd": "run",
+			"Value": ["apt-get update -y ; apt-get install -y curl"],
+		},
+		{
+			"Cmd": "entrypoint",
+			"Value": ["mysql"],
+		},
+	]}]}
 
-# 	count(r) == 0
-# }
+	count(r) == 0
+}
 
 test_allowed_multiple_install_cmds if {
 	r := deny with input as {"Stages": [{"Name": "ubuntu:18.04", "Commands": [

--- a/lib/docker/docker.rego
+++ b/lib/docker/docker.rego
@@ -78,10 +78,7 @@ healthcheck contains instruction if {
 	instruction.Cmd == "healthcheck"
 }
 
-split_cmd(s) := cmds if {
-	cmd_parts := regex.split(`\s*&&\s*`, s)
-	cmds := [split(cmd, " ") | cmd := cmd_parts[_]]
-}
+split_cmd(s) := sh.parse_commands(s)
 
 command_indexes(cmds, cmds_to_check, package_manager) := cmd_indexes if {
 	cmd_indexes = [idx |


### PR DESCRIPTION
This PR improves shell command splitting using the `sh.parse_commands` function. The function is registered in OPA and safe to use starting from bundle version v1.*.

Related issues:
- https://github.com/aquasecurity/trivy/issues/9340
