### PR TITLE
chore: fix examples for GCP-0079

### DIFF
--- a/checks/cloud/google/iam/configure_audit_logging.rego
+++ b/checks/cloud/google/iam/configure_audit_logging.rego
@@ -37,13 +37,15 @@ import rego.v1
 deny contains res if {
 	project := input.google.iam.projects[_]
 	isManaged(project)
-	count(project.auditconfigs) == 0
+	not has_audit_confgis(project)
 
 	res := result.new(
 		"Project should have audit logging configured for security compliance.",
 		project,
 	)
 }
+
+has_audit_confgis(project) if count(project.auditconfigs) > 0
 
 deny contains res if {
 	project := input.google.iam.projects[_]

--- a/checks/cloud/google/iam/configure_audit_logging.yaml
+++ b/checks/cloud/google/iam/configure_audit_logging.yaml
@@ -41,9 +41,14 @@ terraform:
         project_id = "your-project-id"
       }
     - |-
+      resource "google_project" "test" {
+        name       = "My Project"
+        project_id = "your-project-id"
+      }
+
       # Missing required log types
       resource "google_project_iam_audit_config" "config" {
-        project = "your-project-id"
+        project = google_project.test.id
         service = "allServices"
         audit_log_config {
           log_type = "ADMIN_READ"
@@ -51,9 +56,14 @@ terraform:
         # Missing DATA_READ and DATA_WRITE
       }
     - |-
+      resource "google_project" "test" {
+        name       = "My Project"
+        project_id = "your-project-id"
+      }
+
       # Service scope too limited
       resource "google_project_iam_audit_config" "config" {
-        project = "your-project-id"
+        project = google_project.test.id
         service = "cloudresourcemanager.googleapis.com" # Should be "allServices"
         audit_log_config {
           log_type = "ADMIN_READ"


### PR DESCRIPTION
Fixes https://github.com/aquasecurity/trivy-checks/actions/runs/17555529207/job/49858590102?pr=478

Currently, the checks only work for `google_project_iam_audit_config` resources linked to projects. We might consider supporting resources where the project ID is provided as a literal rather than a reference to a project resource. I will address this in Trivy.