### PR TITLE
ci: add 3-day cooldown for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
     ignore:
       - dependency-name: "github.com/aquasecurity/trivy" ## `trivy` are updated manually
     groups:


### PR DESCRIPTION
Follow-up https://github.com/aquasecurity/trivy/pull/9475