### PR TITLE
test: use ORAS image from GHCR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ docs-test:
 
 .PHONY: create-bundle
 create-bundle:
-	go run ./cmd/bundle -root .
+	go run ./cmd/bundle -root . -out ${BUNDLE_FILE}
 
 build-opa:
 	go build ./cmd/opa
@@ -89,7 +89,7 @@ stop-registry:
 push-bundle: create-bundle
 	@REPO=localhost:${REGISTRY_PORT}/trivy-checks:latest ;\
 	echo "Pushing to repository: $$REPO" ;\
-	docker run --rm -it --net=host -v $$PWD/${BUNDLE_FILE}:/${BUNDLE_FILE} bitnami/oras:latest push \
+	docker run --rm -it --net=host -v $$PWD/${BUNDLE_FILE}:/workspace/${BUNDLE_FILE} ghcr.io/oras-project/oras:v1.3.0 push \
 		$$REPO \
 		 --artifact-type application/vnd.cncf.openpolicyagent.config.v1+json \
 		"$(BUNDLE_FILE):application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip"

--- a/integration/check_examples_test.go
+++ b/integration/check_examples_test.go
@@ -225,7 +225,7 @@ func pushBundle(t *testing.T, ctx context.Context, path string, image string) {
 				{
 					Type:   mount.TypeBind,
 					Source: absPath,
-					Target: "/" + filepath.Base(path),
+					Target: "/workspace/" + filepath.Base(path),
 				}}
 		}),
 	)

--- a/integration/testcontainer/oras.go
+++ b/integration/testcontainer/oras.go
@@ -14,7 +14,7 @@ type OrasContainer struct {
 
 func RunOras(ctx context.Context, cmd []string, opts ...testcontainers.ContainerCustomizer) (*OrasContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:      "bitnami/oras:latest",
+		Image:      "ghcr.io/oras-project/oras:v1.3.0",
 		Cmd:        cmd,
 		WaitingFor: wait.ForExit(),
 	}


### PR DESCRIPTION
Bitnami [has discontinued support](https://github.com/bitnami/containers#%EF%B8%8F-important-notice-upcoming-changes-to-the-bitnami-catalog) for several images. As a result, the `bitnami/oras` image on Docker Hub no longer has any available tags. It has now been replaced with `ghcr.io/oras-project/oras` from GHCR.