### PR TITLE
fix: add avd_id to example check for raw tf

### DIFF
--- a/examples/terraform-raw/required-aws-tags.rego
+++ b/examples/terraform-raw/required-aws-tags.rego
@@ -6,6 +6,7 @@
 #   - input: schema["terraform-raw"]
 # custom:
 #   id:  USR-TFRAW-0001
+#   avd_id:  USR-TFRAW-0001
 #   severity: CRITICAL
 #   short_code: required-aws-resource-tags
 #   recommended_actions: "Add the required tags to AWS resources."


### PR DESCRIPTION
Since the commit adding an example check for raw Terraform without the avd_id field was merged in the same queue as the commit reverting metadata changes, a conflict occurred after merging. As a result, the integration test now fails because the avd_id field has become required again.
This PR fixes the issue.