### PR TITLE
fix: check only managed account in AVD-AZU-0012

### DIFF
--- a/checks/cloud/azure/storage/default_action_deny.rego
+++ b/checks/cloud/azure/storage/default_action_deny.rego
@@ -38,6 +38,7 @@ deny contains res if {
 
 deny contains res if {
 	some account in input.azure.storage.accounts
+	isManaged(account)
 	not has_networks(account)
 
 	# Default 'Allow' rule is applied when no network rules are defined.


### PR DESCRIPTION
Trivy always creates a [dummy account](https://github.com/aquasecurity/trivy/blob/cff91acdef91fbce22306a72000c43a26ac8d79b/pkg/iac/adapters/terraform/azure/storage/adapt.go#L14-L24) for network resources, containers, etc. without an associated account. We should skip such accounts, as they are not managed by the user and lead to false positives.

### Before
```bash
❯ trivy conf main.tf -q | grep AVD-AZU-0012
AVD-AZU-0012 (CRITICAL): No network rules defined and default action allows access.
```


### After:
```bash
trivy conf main.tf --checks-bundle-repository localhost:5111/trivy-checks:latest -q | grep AVD-AZU-0012
```