### PR TITLE
fix(k8s): correct RKE2 CIS 1.24 audit paths

### DIFF
--- a/commands/kubernetes/adminConfFileOwnership.yaml
+++ b/commands/kubernetes/adminConfFileOwnership.yaml
@@ -6,4 +6,3 @@
   audit: stat -c %U:%G /etc/kubernetes/admin.conf
   platforms:
     - k8s
-    - rke2

--- a/commands/kubernetes/adminConfFileOwnershipRancher.yaml
+++ b/commands/kubernetes/adminConfFileOwnershipRancher.yaml
@@ -1,0 +1,8 @@
+---
+- id: CMD-0052
+  key: adminConfFileOwnership-rke2
+  title: admin.conf file ownership
+  nodeType: master
+  audit: stat -c %U:%G /var/lib/rancher/rke2/server/cred/admin.kubeconfig
+  platforms:
+    - rke2

--- a/commands/kubernetes/adminConfFilePermissions.yaml
+++ b/commands/kubernetes/adminConfFilePermissions.yaml
@@ -6,4 +6,3 @@
   audit: stat -c %a /etc/kubernetes/admin.conf
   platforms:
     - k8s
-    - rke2

--- a/commands/kubernetes/adminConfFilePermissionsRancher.yaml
+++ b/commands/kubernetes/adminConfFilePermissionsRancher.yaml
@@ -1,0 +1,8 @@
+---
+- id: CMD-0051
+  key: adminConfFilePermissions-rke2
+  title: admin.conf file permissions
+  nodeType: master
+  audit: stat -c permissions=%a /var/lib/rancher/rke2/server/cred/admin.kubeconfig
+  platforms:
+    - rke2

--- a/commands/kubernetes/controllerManagerConfFileOwnership.yaml
+++ b/commands/kubernetes/controllerManagerConfFileOwnership.yaml
@@ -6,4 +6,3 @@
   audit: stat -c %U:%G $controllermanager.kubeconfig
   platforms:
     - k8s
-    - rke2

--- a/commands/kubernetes/controllerManagerConfFileOwnershipRancher.yaml
+++ b/commands/kubernetes/controllerManagerConfFileOwnershipRancher.yaml
@@ -1,0 +1,8 @@
+---
+- id: CMD-0054
+  key: controllerManagerConfFileOwnership-rke2
+  title: controller-manager.conf file ownership
+  nodeType: master
+  audit: stat -c %U:%G /var/lib/rancher/rke2/server/cred/controller.kubeconfig
+  platforms:
+    - rke2

--- a/commands/kubernetes/controllerManagerConfFilePermissions.yaml
+++ b/commands/kubernetes/controllerManagerConfFilePermissions.yaml
@@ -6,4 +6,3 @@
   audit: stat -c %a $controllermanager.kubeconfig
   platforms:
     - k8s
-    - rke2

--- a/commands/kubernetes/controllerManagerConfFilePermissionsRancher.yaml
+++ b/commands/kubernetes/controllerManagerConfFilePermissionsRancher.yaml
@@ -1,0 +1,8 @@
+---
+- id: CMD-0053
+  key: controllerManagerConfFilePermissions-rke2
+  title: controller-manager.conf file permissions
+  nodeType: master
+  audit: stat -c %a /var/lib/rancher/rke2/server/cred/controller.kubeconfig
+  platforms:
+    - rke2

--- a/commands/kubernetes/etcdDataDirectoryOwnershipRancher.yaml
+++ b/commands/kubernetes/etcdDataDirectoryOwnershipRancher.yaml
@@ -3,6 +3,6 @@
   key: etcdDataDirectoryOwnership
   title: Etcd data directory Ownership
   nodeType: master
-  audit: stat -c %U:%G /node/var/lib/etcd
+  audit: stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd
   platforms:
     - rke2

--- a/commands/kubernetes/etcdDataDirectoryPermissionsRancher.yaml
+++ b/commands/kubernetes/etcdDataDirectoryPermissionsRancher.yaml
@@ -3,6 +3,6 @@
   key: etcdDataDirectoryPermissions
   title: Etcd data directory permissions
   nodeType: master
-  audit: stat -c %a /node/var/lib/etcd
+  audit: stat -c %a /var/lib/rancher/rke2/server/db/etcd
   platforms:
     - rke2

--- a/commands/kubernetes/kubePKIDirectoryFileOwnershipRancher.yaml
+++ b/commands/kubernetes/kubePKIDirectoryFileOwnershipRancher.yaml
@@ -3,7 +3,6 @@
   key: kubePKIDirectoryFileOwnership
   title: Kubernetes PKI directory and file ownership
   nodeType: master
-  audit: stat -c %U:%G $(ls -R /node/etc/kubernetes/ssl | awk
-    '/:$/&&f{s=$0;f=0}/:$/&&!f{sub(/:$/,"");s=$0;f=1;next}NF&&f{print s"/"$0 }')
+  audit: stat -c %U:%G /var/lib/rancher/rke2/server/tls
   platforms:
     - rke2

--- a/commands/kubernetes/kubePKIKeyFilePermissionsRancher.yaml
+++ b/commands/kubernetes/kubePKIKeyFilePermissionsRancher.yaml
@@ -3,8 +3,8 @@
   key: kubePKIKeyFilePermissions
   title: Kubernetes PKI certificate file permissions
   nodeType: master
-  audit: stat -c %a $(ls -aR /node/etc/kubernetes/ssl | awk
+  audit: stat -c %a $(ls -aR /var/lib/rancher/rke2/server/tls | awk
     '/:$/&&f{s=$0;f=0}/:$/&&!f{sub(/:$/,"");s=$0;f=1;next}NF&&f{print s"/"$0}' |
     grep \.key$)
   platforms:
-    - rke
+    - rke2

--- a/commands/kubernetes/kubernetesPKICertificateFilePermissionsRancher.yaml
+++ b/commands/kubernetes/kubernetesPKICertificateFilePermissionsRancher.yaml
@@ -3,7 +3,7 @@
   key: kubernetesPKICertificateFilePermissions
   title: Kubernetes PKI certificate file permissions
   nodeType: master
-  audit: stat -c %a $(ls -aR /node/etc/kubernetes/ssl |
+  audit: stat -c %a $(ls -aR /var/lib/rancher/rke2/server/tls |
     awk'/:$/&&f{s=$0;f=0}/:$/&&!f{sub(/:$/,"");s=$0;f=1;next}NF&&f{print
     s"/"$0}' | grep \.crt$)
   platforms:

--- a/commands/kubernetes/schedulerConfFileOwnership.yaml
+++ b/commands/kubernetes/schedulerConfFileOwnership.yaml
@@ -6,4 +6,3 @@
   audit: stat -c %U:%G $scheduler.kubeconfig
   platforms:
     - k8s
-    - rke2

--- a/commands/kubernetes/schedulerConfFileOwnershipRancher.yaml
+++ b/commands/kubernetes/schedulerConfFileOwnershipRancher.yaml
@@ -1,0 +1,8 @@
+---
+- id: CMD-0056
+  key: schedulerConfFileOwnership-rke2
+  title: scheduler.conf file ownership
+  nodeType: master
+  audit: stat -c %U:%G /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig
+  platforms:
+    - rke2

--- a/commands/kubernetes/schedulerConfFilePermissions.yaml
+++ b/commands/kubernetes/schedulerConfFilePermissions.yaml
@@ -6,4 +6,3 @@
   audit: stat -c %a $scheduler.kubeconfig
   platforms:
     - k8s
-    - rke2

--- a/commands/kubernetes/schedulerConfFilePermissionsRancher.yaml
+++ b/commands/kubernetes/schedulerConfFilePermissionsRancher.yaml
@@ -1,0 +1,8 @@
+---
+- id: CMD-0055
+  key: schedulerConfFilePermissions-rke2
+  title: scheduler.conf file permissions
+  nodeType: master
+  audit: stat -c %a /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig
+  platforms:
+    - rke2

--- a/pkg/compliance/rke2-cis-1.24.yaml
+++ b/pkg/compliance/rke2-cis-1.24.yaml
@@ -131,16 +131,16 @@ spec:
       description: Ensure that the admin.conf file has permissions of 600
       checks:
         - id: KCV-0060
-      commands: 
-        - id: CMD-0013
+      commands:
+        - id: CMD-0051
       severity: CRITICAL
     - id: 1.1.14
       name: Ensure that the admin.conf file ownership is set to root:root
       description: Ensure that the admin.conf file ownership is set to root:root
       checks:
         - id: KCV-0061
-      commands: 
-        - id: CMD-0014
+      commands:
+        - id: CMD-0052
       severity: CRITICAL
     - id: 1.1.15
       name: Ensure that the scheduler.conf file permissions are set to 600 or more
@@ -150,7 +150,7 @@ spec:
       checks:
         - id: KCV-0062
       commands:
-        - id: CMD-0015
+        - id: CMD-0055
       severity: HIGH
     - id: 1.1.16
       name: Ensure that the scheduler.conf file ownership is set to root:root
@@ -158,7 +158,7 @@ spec:
       checks:
         - id: KCV-0063
       commands:
-        - id: CMD-0016
+        - id: CMD-0056
       severity: HIGH
     - id: 1.1.17
       name: Ensure that the controller-manager.conf file permissions are set to 600 or
@@ -168,7 +168,7 @@ spec:
       checks:
         - id: KCV-0064
       commands:
-        - id: CMD-0017
+        - id: CMD-0053
       severity: HIGH
     - id: 1.1.18
       name: Ensure that the controller-manager.conf file ownership is set to root:root
@@ -177,7 +177,7 @@ spec:
       checks:
         - id: KCV-0065
       commands:
-        - id: CMD-0018
+        - id: CMD-0054
       severity: HIGH
     - id: 1.1.19
       name: Ensure that the Kubernetes PKI directory and file ownership is set to


### PR DESCRIPTION
Fixes #10167

The audit definitions contained incorrect paths for RKE2 platform. All commands specifying RKE2 platform required path updates per the official RKE2 CIS 1.24 documentation.

Path corrections:
- /node/var/lib/etcd → /var/lib/rancher/rke2/server/db/etcd (etcd)
- /node/etc/kubernetes/ssl → /var/lib/rancher/rke2/server/tls (PKI)
- /etc/kubernetes/admin.conf → /var/lib/rancher/rke2/server/cred/admin.kubeconfig

Platform separation:
- Removed rke2 from 6 k8s commands (admin.conf, controller-manager.conf, scheduler.conf permissions/ownership)
- Created 6 RKE2-specific commands (CMD-0051 through CMD-0056) with proper paths and unique keys
- Fixed kubePKIKeyFilePermissionsRancher.yaml platform: rke → rke2
- Updated rke2-cis-1.24.yaml compliance spec with new command IDs