### PR TITLE
feat(misconf): add ephemeral container support to KSV017

### DIFF
--- a/checks/kubernetes/drop_all_capabilities_only_add_net_bind_service.rego
+++ b/checks/kubernetes/drop_all_capabilities_only_add_net_bind_service.rego
@@ -15,7 +15,7 @@
 #     - drop-caps-add-bind-svc
 #     - kubernetes-drop-caps-add-bind-svc
 #   severity: LOW
-#   recommended_action: "Set 'spec.containers[*].securityContext.capabilities.drop' to 'ALL' and only add 'NET_BIND_SERVICE' to 'spec.containers[*].securityContext.capabilities.add'."
+#   recommended_action: "Set 'spec.containers[*].securityContext.capabilities.drop', 'spec.initContainers[*].securityContext.capabilities.drop' and 'spec.ephemeralContainers[*].securityContext.capabilities.drop' to 'ALL' and only add 'NET_BIND_SERVICE'."
 #   input:
 #     selector:
 #     - type: kubernetes
@@ -30,13 +30,33 @@ hasDropAll(container) if {
 }
 
 containersWithoutDropAll contains container if {
-	container := kubernetes.containers[_]
-	not hasDropAll(container)
+        container := kubernetes.containers[_]
+        not hasDropAll(container)
+}
+
+containersWithoutDropAll contains container if {
+        container := kubernetes.initContainers[_]
+        not hasDropAll(container)
+}
+
+containersWithoutDropAll contains container if {
+        container := kubernetes.ephemeralContainers[_]
+        not hasDropAll(container)
 }
 
 containersWithDropAll contains container if {
-	container := kubernetes.containers[_]
-	hasDropAll(container)
+        container := kubernetes.containers[_]
+        hasDropAll(container)
+}
+
+containersWithDropAll contains container if {
+        container := kubernetes.initContainers[_]
+        hasDropAll(container)
+}
+
+containersWithDropAll contains container if {
+        container := kubernetes.ephemeralContainers[_]
+        hasDropAll(container)
 }
 
 deny contains res if {

--- a/checks/kubernetes/drop_all_capabilities_only_add_net_bind_service_test.rego
+++ b/checks/kubernetes/drop_all_capabilities_only_add_net_bind_service_test.rego
@@ -120,3 +120,62 @@ test_drop_all_add_other_denied if {
 
 	count(r) == 1
 }
+test_drop_all_denied_init_container if {
+        r := deny with input as {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {"name": "hello-seccomp"},
+                "spec": {"initContainers": [{
+                        "image": "busybox",
+                        "name": "hello-init",
+                        "securityContext": {"capabilities": {"drop": ["OTHER"]}},
+                }]},
+        }
+
+        count(r) == 1
+}
+
+test_drop_all_allowed_init_container if {
+        r := deny with input as {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {"name": "hello-seccomp"},
+                "spec": {"initContainers": [{
+                        "image": "busybox",
+                        "name": "hello-init",
+                        "securityContext": {"capabilities": {"drop": ["ALL"]}},
+                }]},
+        }
+
+        count(r) == 0
+}
+
+test_drop_all_denied_ephemeral_container if {
+        r := deny with input as {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {"name": "hello-seccomp"},
+                "spec": {"ephemeralContainers": [{
+                        "image": "busybox",
+                        "name": "hello-ephemeral",
+                        "securityContext": {"capabilities": {"drop": ["OTHER"]}},
+                }]},
+        }
+
+        count(r) == 1
+}
+
+test_drop_all_allowed_ephemeral_container if {
+        r := deny with input as {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {"name": "hello-seccomp"},
+                "spec": {"ephemeralContainers": [{
+                        "image": "busybox",
+                        "name": "hello-ephemeral",
+                        "securityContext": {"capabilities": {"drop": ["ALL"]}},
+                }]},
+        }
+
+        count(r) == 0
+}

--- a/checks/kubernetes/privileged.rego
+++ b/checks/kubernetes/privileged.rego
@@ -15,7 +15,7 @@
 #     - no-privileged-containers
 #     - kubernetes-no-privileged-containers
 #   severity: HIGH
-#   recommended_action: "Change 'containers[].securityContext.privileged' to 'false'."
+#   recommended_action: "Change 'containers[].securityContext.privileged', 'initContainers[].securityContext.privileged' and 'ephemeralContainers[].securityContext.privileged' to 'false'."
 #   input:
 #     selector:
 #     - type: kubernetes
@@ -44,7 +44,15 @@ getPrivilegedContainers contains container if {
 	container := kubernetes.containers[_]
 	container.securityContext.privileged == true
 }
+getPrivilegedContainers contains container if {
+        container := kubernetes.initContainers[_]
+        container.securityContext.privileged == true
+}
 
+getPrivilegedContainers contains container if {
+        container := kubernetes.ephemeralContainers[_]
+        container.securityContext.privileged == true
+}
 deny contains res if {
 	output := getPrivilegedContainers[_]
 	msg := kubernetes.format(sprintf("Container '%s' of %s '%s' should set 'securityContext.privileged' to false", [output.name, kubernetes.kind, kubernetes.name]))

--- a/checks/kubernetes/privileged_test.rego
+++ b/checks/kubernetes/privileged_test.rego
@@ -61,3 +61,58 @@ test_privileged_is_false_allowed if {
 
 	count(r) == 0
 }
+test_privileged_is_true_denied_init_container if {
+        r := deny with input as {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {"name": "hello-privileged"},
+                "spec": {"initContainers": [{
+                        "image": "busybox",
+                        "name": "hello-init",
+                        "securityContext": {"privileged": true},
+                }]},
+        }
+        count(r) == 1
+}
+
+test_privileged_is_false_allowed_init_container if {
+        r := deny with input as {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {"name": "hello-privileged"},
+                "spec": {"initContainers": [{
+                        "image": "busybox",
+                        "name": "hello-init",
+                        "securityContext": {"privileged": false},
+                }]},
+        }
+        count(r) == 0
+}
+
+test_privileged_is_true_denied_ephemeral_container if {
+        r := deny with input as {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {"name": "hello-privileged"},
+                "spec": {"ephemeralContainers": [{
+                        "image": "busybox",
+                        "name": "hello-ephemeral",
+                        "securityContext": {"privileged": true},
+                }]},
+        }
+        count(r) == 1
+}
+
+test_privileged_is_false_allowed_ephemeral_container if {
+        r := deny with input as {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {"name": "hello-privileged"},
+                "spec": {"ephemeralContainers": [{
+                        "image": "busybox",
+                        "name": "hello-ephemeral",
+                        "securityContext": {"privileged": false},
+                }]},
+        }
+        count(r) == 0
+}

--- a/checks/kubernetes/specific_capabilities_added.rego
+++ b/checks/kubernetes/specific_capabilities_added.rego
@@ -15,7 +15,7 @@
 #     - no-non-default-capabilities
 #     - kubernetes-no-non-default-capabilities
 #   severity: MEDIUM
-#   recommended_action: "Do not set spec.containers[*].securityContext.capabilities.add and spec.initContainers[*].securityContext.capabilities.add."
+#   recommended_action: "Do not set spec.containers[*].securityContext.capabilities.add and spec.initContainers[*].securityContext.capabilities.add and spec.ephemeralContainers[*].securityContext.capabilities.add."
 #   input:
 #     selector:
 #     - type: kubernetes
@@ -44,10 +44,24 @@ allowed_caps := set()
 # getContainersWithDisallowedCaps returns a list of containers which have
 # additional capabilities not included in the allowed capabilities list
 getContainersWithDisallowedCaps contains container if {
-	container := kubernetes.containers[_]
-	set_caps := {cap | cap := container.securityContext.capabilities.add[_]}
-	caps_not_allowed := set_caps - allowed_caps
-	count(caps_not_allowed) > 0
+        container := kubernetes.containers[_]
+        set_caps := {cap | cap := container.securityContext.capabilities.add[_]}
+        caps_not_allowed := set_caps - allowed_caps
+        count(caps_not_allowed) > 0
+}
+
+getContainersWithDisallowedCaps contains container if {
+        container := kubernetes.initContainers[_]
+        set_caps := {cap | cap := container.securityContext.capabilities.add[_]}
+        caps_not_allowed := set_caps - allowed_caps
+        count(caps_not_allowed) > 0
+}
+
+getContainersWithDisallowedCaps contains container if {
+        container := kubernetes.ephemeralContainers[_]
+        set_caps := {cap | cap := container.securityContext.capabilities.add[_]}
+        caps_not_allowed := set_caps - allowed_caps
+        count(caps_not_allowed) > 0
 }
 
 # cap_msg is a string of allowed capabilities to be print as part of deny message

--- a/checks/kubernetes/specific_capabilities_added_test.rego
+++ b/checks/kubernetes/specific_capabilities_added_test.rego
@@ -82,3 +82,35 @@ test_no_capabilities_allowed if {
 
 	count(r) == 0
 }
+
+test_capabilities_add_denied_init_container if {
+        r := deny with input as {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {"name": "hello-add-capabilities"},
+                "spec": {"initContainers": [{
+                        "image": "busybox",
+                        "name": "hello-init",
+                        "securityContext": {"capabilities": {"add": ["NET_BIND_SERVICE"]}},
+                }]},
+        }
+
+        count(r) == 1
+        r[_].msg == "Container 'hello-init' of Pod 'hello-add-capabilities' should not set 'securityContext.capabilities.add'"
+}
+
+test_capabilities_add_denied_ephemeral_container if {
+        r := deny with input as {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {"name": "hello-add-capabilities"},
+                "spec": {"ephemeralContainers": [{
+                        "image": "busybox",
+                        "name": "hello-ephemeral",
+                        "securityContext": {"capabilities": {"add": ["NET_BIND_SERVICE"]}},
+                }]},
+        }
+
+        count(r) == 1
+        r[_].msg == "Container 'hello-ephemeral' of Pod 'hello-add-capabilities' should not set 'securityContext.capabilities.add'"
+}


### PR DESCRIPTION
## Summary
KSV017 currently checks only `containers` for privileged mode, 
but Pod Security Standards also require `initContainers` and 
`ephemeralContainers` to be checked.

A privileged ephemeral container is a critical security risk as it 
shares the host namespace and can be injected into any running pod.

## Changes
- Extended `getPrivilegedContainers` in KSV017 to include `initContainers` 
  and `ephemeralContainers`
- Updated `recommended_action` metadata to reflect the change
- Added test cases for `initContainers` and `ephemeralContainers`

## Related Issue
Related to #9936