### PR TITLE
fix(KSV104): add ephemeralContainers support to seccomp profile check

### DIFF
--- a/checks/kubernetes/seccomp_profile_unconfined.rego
+++ b/checks/kubernetes/seccomp_profile_unconfined.rego
@@ -15,7 +15,7 @@
 #     - no-seccomp-unconfined
 #     - kubernetes-no-seccomp-unconfined
 #   severity: MEDIUM
-#   recommended_action: "Specify seccomp either by annotation or by seccomp profile type having allowed values as per pod security standards"
+#   recommended_action: "Specify seccomp either by annotation or by seccomp profile type having allowed values as per pod security standards for containers, initContainers, and ephemeralContainers"
 #   input:
 #     selector:
 #     - type: kubernetes

--- a/checks/kubernetes/seccomp_profile_unconfined_test.rego
+++ b/checks/kubernetes/seccomp_profile_unconfined_test.rego
@@ -251,3 +251,56 @@ test_deployment_annotations_seccomp_profile_unconfined_allowed if {
 	}
 	count(r) == 0
 }
+test_init_container_seccomp_profile_unconfined_denied if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "hello-sysctls"},
+		"spec": {
+			"containers": [{"name": "hello", "image": "busybox", "securityContext": {"seccompProfile": {"type": "RuntimeDefault"}}}],
+			"initContainers": [{"name": "init-hello", "image": "busybox", "securityContext": {"seccompProfile": {"type": "Unconfined"}}}],
+		},
+	}
+	count(r) == 1
+	contains(r[_].msg, "init-hello")
+}
+
+test_init_container_seccomp_profile_unconfined_allowed if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "hello-sysctls"},
+		"spec": {
+			"containers": [{"name": "hello", "image": "busybox", "securityContext": {"seccompProfile": {"type": "RuntimeDefault"}}}],
+			"initContainers": [{"name": "init-hello", "image": "busybox", "securityContext": {"seccompProfile": {"type": "RuntimeDefault"}}}],
+		},
+	}
+	count(r) == 0
+}
+
+test_ephemeral_container_seccomp_profile_unconfined_denied if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "hello-sysctls"},
+		"spec": {
+			"containers": [{"name": "hello", "image": "busybox", "securityContext": {"seccompProfile": {"type": "RuntimeDefault"}}}],
+			"ephemeralContainers": [{"name": "ephemeral-hello", "image": "busybox", "securityContext": {"seccompProfile": {"type": "Unconfined"}}}],
+		},
+	}
+	count(r) == 1
+	contains(r[_].msg, "ephemeral-hello")
+}
+
+test_ephemeral_container_seccomp_profile_unconfined_allowed if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "hello-sysctls"},
+		"spec": {
+			"containers": [{"name": "hello", "image": "busybox", "securityContext": {"seccompProfile": {"type": "RuntimeDefault"}}}],
+			"ephemeralContainers": [{"name": "ephemeral-hello", "image": "busybox", "securityContext": {"seccompProfile": {"type": "RuntimeDefault"}}}],
+		},
+	}
+	count(r) == 0
+}

--- a/lib/kubernetes/kubernetes.rego
+++ b/lib/kubernetes/kubernetes.rego
@@ -97,19 +97,19 @@ split_image(image) := [image_name, tag] if {
 }
 
 pod_containers(pod) := all_containers if {
-	keys = {"containers", "initContainers"}
-	all_containers = [c |
-		keys[k]
-		some container in pod.spec[k]
-		c := json.patch(
-			container,
-			[{
-				"op": "add",
-				"path": "securityContext",
-				"value": k8s_sec_context.resolve_container_sec_context(pod, container),
-			}],
-		)
-	]
+        keys = {"containers", "initContainers", "ephemeralContainers"}
+        all_containers = [c |
+                keys[k]
+                some container in pod.spec[k]
+                c := json.patch(
+                        container,
+                        [{
+                                "op": "add",
+                                "path": "securityContext",
+                                "value": k8s_sec_context.resolve_container_sec_context(pod, container),
+                        }],
+                )
+        ]
 }
 
 containers contains container if {


### PR DESCRIPTION
## Summary
KSV104 currently checks only `containers` for seccomp profile, but Pod Security Standards also require `initContainers` and `ephemeralContainers` to be checked.

## Changes
- Added `ephemeralContainers` to `pod_containers` in `lib/kubernetes/kubernetes.rego` — benefits all checks using the lib
- Updated `recommended_action` metadata in `seccomp_profile_unconfined.rego`
- Added 4 test cases for `initContainers` and `ephemeralContainers`

## Test Results
All 1955 tests pass locally.

## Related Issue
Fixes #9936