### PR TITLE
chore: mark GCP-0048 as deprecated

### DIFF
--- a/checks/cloud/google/gke/metadata_endpoints_disabled.rego
+++ b/checks/cloud/google/gke/metadata_endpoints_disabled.rego
@@ -23,6 +23,7 @@
 #   provider: google
 #   service: gke
 #   severity: HIGH
+#   deprecated: true
 #   recommended_action: Disable legacy metadata endpoints
 #   input:
 #     selector:


### PR DESCRIPTION
Related issue: https://github.com/aquasecurity/trivy/issues/10371