### PR TITLE
misconf: Revise KSV-0022 to allow valid capabilities

### DIFF
--- a/checks/kubernetes/drop_all_capabilities_only_add_net_bind_service.rego
+++ b/checks/kubernetes/drop_all_capabilities_only_add_net_bind_service.rego
@@ -25,6 +25,8 @@ import rego.v1
 
 import data.lib.kubernetes
 
+allowed_caps := {"NET_BIND_SERVICE"}
+
 hasDropAll(container) if {
 	upper(container.securityContext.capabilities.drop[_]) == "ALL"
 }
@@ -40,15 +42,15 @@ containersWithDropAll contains container if {
 }
 
 deny contains res if {
-	container := containersWithoutDropAll[_]
-	msg := "container should drop all"
-	res := result.new(msg, container)
+    container := containersWithoutDropAll[_]
+    msg := sprintf("Container '%s' does not drop all capabilities", [container.name])
+    res := result.new(msg, container)
 }
 
 deny contains res if {
-	container := containersWithDropAll[_]
-	add := container.securityContext.capabilities.add[_]
-	add != "NET_BIND_SERVICE"
-	msg := "container should not add stuff"
-	res := result.new(msg, container.securityContext.capabilities)
+    container := containersWithDropAll[_]
+    disallowed := {cap | cap := container.securityContext.capabilities.add[_]; not cap in allowed_caps}
+    count(disallowed) > 0
+    msg := sprintf("Container '%s' adds disallowed capabilities: %s", [container.name, concat(", ", disallowed)])
+    res := result.new(msg, container.securityContext.capabilities)
 }

--- a/checks/kubernetes/drop_all_capabilities_only_add_net_bind_service_test.rego
+++ b/checks/kubernetes/drop_all_capabilities_only_add_net_bind_service_test.rego
@@ -80,6 +80,7 @@ test_drop_other_denied if {
 	}
 
 	count(r) == 1
+	r[_].msg == "Container 'hello' does not drop all capabilities"
 }
 
 test_drop_undefined_denied if {
@@ -99,6 +100,7 @@ test_drop_undefined_denied if {
 	}
 
 	count(r) == 1
+	r[_].msg == "Container 'hello' does not drop all capabilities"
 }
 
 test_drop_all_add_other_denied if {
@@ -119,4 +121,39 @@ test_drop_all_add_other_denied if {
 	}
 
 	count(r) == 1
+	r[_].msg == "Container 'hello' adds disallowed capabilities: SOMETHING"
+}
+
+test_drop_all_add_multiple_disallowed_denied if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "hello-seccomp"},
+		"spec": {"containers": [{
+			"command": ["sh", "-c", "echo 'Hello' && sleep 1h"],
+			"image": "busybox",
+			"name": "hello",
+			"securityContext": {"capabilities": {"drop": ["ALL"], "add": ["SYS_ADMIN", "NET_RAW"]}},
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Container 'hello' adds disallowed capabilities: NET_RAW, SYS_ADMIN"
+}
+
+test_drop_all_add_net_bind_service_and_disallowed_denied if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "hello-seccomp"},
+		"spec": {"containers": [{
+			"command": ["sh", "-c", "echo 'Hello' && sleep 1h"],
+			"image": "busybox",
+			"name": "hello",
+			"securityContext": {"capabilities": {"drop": ["ALL"], "add": ["NET_BIND_SERVICE", "SYS_ADMIN"]}},
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Container 'hello' adds disallowed capabilities: SYS_ADMIN"
 }

--- a/checks/kubernetes/specific_capabilities_added.rego
+++ b/checks/kubernetes/specific_capabilities_added.rego
@@ -15,7 +15,7 @@
 #     - no-non-default-capabilities
 #     - kubernetes-no-non-default-capabilities
 #   severity: MEDIUM
-#   recommended_action: "Do not set spec.containers[*].securityContext.capabilities.add and spec.initContainers[*].securityContext.capabilities.add."
+#   recommended_action: "Do not set capabilities beyond the default set. Allowed capabilities: AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT."
 #   input:
 #     selector:
 #     - type: kubernetes
@@ -39,26 +39,29 @@ import data.lib.kubernetes
 default failAdditionalCaps := false
 
 # Add allowed capabilities to this set
-allowed_caps := set()
-
-# getContainersWithDisallowedCaps returns a list of containers which have
-# additional capabilities not included in the allowed capabilities list
-getContainersWithDisallowedCaps contains container if {
-	container := kubernetes.containers[_]
-	set_caps := {cap | cap := container.securityContext.capabilities.add[_]}
-	caps_not_allowed := set_caps - allowed_caps
-	count(caps_not_allowed) > 0
-}
-
-# cap_msg is a string of allowed capabilities to be print as part of deny message
-caps_msg := "" if {
-	count(allowed_caps) == 0
-} else := msg if {
-	msg := sprintf(" or set it to the following allowed values: %s", [concat(", ", allowed_caps)])
+allowed_caps := {
+    "AUDIT_WRITE",
+    "CHOWN",
+    "DAC_OVERRIDE",
+    "FOWNER",
+    "FSETID",
+    "KILL",
+    "MKNOD",
+    "NET_BIND_SERVICE",
+    "SETFCAP",
+    "SETGID",
+    "SETPCAP",
+    "SETUID",
+    "SYS_CHROOT",
 }
 
 deny contains res if {
-	output := getContainersWithDisallowedCaps[_]
-	msg := sprintf("Container '%s' of %s '%s' should not set 'securityContext.capabilities.add'%s", [output.name, kubernetes.kind, kubernetes.name, caps_msg])
-	res := result.new(msg, output)
+    container := kubernetes.containers[_]
+    disallowed := {cap | cap := container.securityContext.capabilities.add[_]; not cap in allowed_caps}
+    count(disallowed) > 0
+    msg := sprintf(
+        "Container '%s' of %s '%s' adds disallowed capabilities: %s",
+        [container.name, kubernetes.kind, kubernetes.name, concat(", ", disallowed)],
+    )
+    res := result.new(msg, container)
 }

--- a/checks/kubernetes/specific_capabilities_added.yaml
+++ b/checks/kubernetes/specific_capabilities_added.yaml
@@ -30,4 +30,4 @@ kubernetes:
                 securityContext:
                   capabilities:
                       add:
-                          - NET_BIND_SERVICE
+                          - SYS_ADMIN

--- a/checks/kubernetes/specific_capabilities_added_test.rego
+++ b/checks/kubernetes/specific_capabilities_added_test.rego
@@ -2,7 +2,28 @@ package builtin.kubernetes.KSV022
 
 import rego.v1
 
-test_capabilities_add_denied if {
+test_non_default_capability_denied  if {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "hello-add-capabilities"},
+		"spec": {"containers": [{
+			"command": [
+				"sh",
+				"-c",
+				"echo 'Hello' && sleep 1h",
+			],
+			"image": "busybox",
+			"name": "hello",
+			"securityContext": {"capabilities": {"add": ["SYS_ADMIN"]}},
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Container 'hello' of Pod 'hello-add-capabilities' adds disallowed capabilities: SYS_ADMIN"
+}
+
+test_capabilities_net_bind_cap_allowed if {
 	r := deny with input as {
 		"apiVersion": "v1",
 		"kind": "Pod",
@@ -19,8 +40,7 @@ test_capabilities_add_denied if {
 		}]},
 	}
 
-	count(r) == 1
-	r[_].msg == "Container 'hello' of Pod 'hello-add-capabilities' should not set 'securityContext.capabilities.add'"
+	count(r) == 0
 }
 
 test_capabilities_add_empty_allowed if {


### PR DESCRIPTION
Currently, the KSV-0022 check flags all added capabilities, even those allowed by the Pod Security Standard, such as `NET_BIND_SERVICE`. We need to review and update this check to ensure it aligns with compliance requirements, allows valid capabilities, and provides a clearer, more informative message that specifies which capabilities are causing violations.

Closes: https://github.com/aquasecurity/trivy/issues/9844