### PR TITLE
fix(kubernetes): allow missing rotate-certificates flag in KCV-0090

### DIFF
--- a/checks/kubernetes/kubelet_rotate_certificates.rego
+++ b/checks/kubernetes/kubelet_rotate_certificates.rego
@@ -34,13 +34,6 @@ validate_kubelet_rotate_certificates(sp) := {"kubeletRotateCertificatesArgumentS
 	count(violation) > 0
 }
 
-validate_kubelet_rotate_certificates(sp) := {"kubeletRotateCertificatesArgumentSet": rotate_certificates} if {
-	sp.kind == "NodeInfo"
-	sp.type == types[_]
-	count(sp.info.kubeletRotateCertificatesArgumentSet.values) == 0
-	rotate_certificates = {}
-}
-
 deny contains res if {
 	output := validate_kubelet_rotate_certificates(input)
 	msg := "Ensure that the --rotate-certificates argument is not set to false"

--- a/checks/kubernetes/kubelet_rotate_certificates_test.rego
+++ b/checks/kubernetes/kubelet_rotate_certificates_test.rego
@@ -32,5 +32,5 @@ test_validate_rotate_certificates_empty if {
 		"info": {"kubeletRotateCertificatesArgumentSet": {"values": []}},
 	}
 
-	count(r) == 1
+	count(r) == 0
 }


### PR DESCRIPTION
KCV-0090 fails if the `--rotate-certificates` flag is not present. But it should only fail if `--rotate-certificates=false`