### PR TITLE
test(ds031): correct env instruction argument order

### DIFF
--- a/checks/docker/leaked_secrets_test.rego
+++ b/checks/docker/leaked_secrets_test.rego
@@ -64,7 +64,7 @@ test_allow_secret_file_without_copy if {
 test_allow_secret_file_copy_with_other_base_path if {
 	inp := build_input([
 		instruction("copy", ["/src", "/src"]),
-		instruction("env", ["GOOGLE_APPLICATION_CREDENTIALS", "=", "./app/google-storage-service.json"]),
+		instruction("env", ["GOOGLE_APPLICATION_CREDENTIALS", "./app/google-storage-service.json", "="]),
 	])
 	res := check.deny with input as inp
 	count(res) = 0


### PR DESCRIPTION
Fix incorrect env instruction argument order in `test_allow_secret_file_copy_with_other_base_path` to match how Trivy actually parses ENV instructions (`["name", "value", "="]`).