### PR TITLE
ci: replace deploy token with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -11,8 +11,8 @@ jobs:
     with:
       nightly: true
     secrets:
-      TRIVY_CHECKS_DEPLOY_TOKEN: ${{ secrets.TRIVY_CHECKS_DEPLOY_TOKEN }}
       DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       contents: read
+      packages: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,8 @@ jobs:
     name: Release
     uses: ./.github/workflows/reusable-release.yaml
     secrets:
-      TRIVY_CHECKS_DEPLOY_TOKEN: ${{ secrets.TRIVY_CHECKS_DEPLOY_TOKEN }}
       DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       contents: read
+      packages: write

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -8,8 +8,6 @@ on:
         default: false
         description: "Run nightly release"
     secrets:
-      TRIVY_CHECKS_DEPLOY_TOKEN:
-        required: true
       DOCKERHUB_USER:
         required: true
       DOCKERHUB_TOKEN:
@@ -28,6 +26,7 @@ jobs:
     needs: integration-tests
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -49,7 +48,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ vars.GHCR_USER || env.GH_USER }}
-          password: ${{ secrets.TRIVY_CHECKS_DEPLOY_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0


### PR DESCRIPTION
This PR replaces the PAT with a `GITHUB_TOKEN` that is generated each time the workflow is started. The `GITHUB_TOKEN` in the reusable workflow gets permissions limited by the intersection of the caller's permissions and the permissions of the reusable job itself.

Test run: https://github.com/nikpivkin/trivy-checks/actions/runs/25147304983/job/73710010846 (the login in the registry was completed successfully)