### PR TITLE
ci: declare workflow-level `contents: read` on test-go, test-rego, verify-docs

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -3,6 +3,9 @@ on:
   pull_request:
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Test

--- a/.github/workflows/test-rego.yaml
+++ b/.github/workflows/test-rego.yaml
@@ -13,6 +13,9 @@ on:
   merge_group:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   opa-tests:
     name: OPA tests

--- a/.github/workflows/verify-docs.yaml
+++ b/.github/workflows/verify-docs.yaml
@@ -3,6 +3,9 @@ on:
   pull_request:
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Verify Docs


### PR DESCRIPTION
All three workflows are pure test/verify steps; no GitHub API writes from the workflows. Workflow-level `contents: read` is the right cap.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening shape. YAML validated locally with `yaml.safe_load` on each touched file.