### PR TITLE
feat(aws/iam): Add 7 IAM privilege escalation detection checks

### DIFF
--- a/avd_docs/aws/iam/AWS-0347/docs.md
+++ b/avd_docs/aws/iam/AWS-0347/docs.md
@@ -1,0 +1,19 @@
+
+A principal with iam:CreatePolicyVersion can create a new version of an IAM policy with
+unrestricted permissions (e.g., *:*) and set it as the default version. This effectively
+grants the principal full administrative access, bypassing the original policy restrictions.
+This is a well-known privilege escalation vector in AWS environments.
+
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://pathfinding.cloud/
+
+- https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
+
+

--- a/avd_docs/aws/iam/AWS-0348/docs.md
+++ b/avd_docs/aws/iam/AWS-0348/docs.md
@@ -1,0 +1,19 @@
+
+A principal with iam:PassRole, lambda:CreateFunction, and lambda:InvokeFunction can create
+a Lambda function with an administrative role attached, invoke it, and steal the role's
+credentials. This combination of permissions enables a well-known privilege escalation path
+through AWS Lambda.
+
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://pathfinding.cloud/
+
+- https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
+
+

--- a/avd_docs/aws/iam/AWS-0349/docs.md
+++ b/avd_docs/aws/iam/AWS-0349/docs.md
@@ -1,0 +1,18 @@
+
+A principal with iam:AttachUserPolicy, iam:AttachRolePolicy, or iam:AttachGroupPolicy
+and a wildcard resource can attach the AdministratorAccess managed policy to themselves
+or any other identity. This enables immediate privilege escalation to full admin access.
+
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://pathfinding.cloud/
+
+- https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
+
+

--- a/avd_docs/aws/iam/AWS-0350/docs.md
+++ b/avd_docs/aws/iam/AWS-0350/docs.md
@@ -1,0 +1,18 @@
+
+A principal with iam:PassRole and ec2:RunInstances can launch an EC2 instance with a
+privileged instance profile attached. By accessing the instance metadata service (IMDS),
+the attacker can steal the role credentials and escalate privileges.
+
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://pathfinding.cloud/
+
+- https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
+
+

--- a/avd_docs/aws/iam/AWS-0351/docs.md
+++ b/avd_docs/aws/iam/AWS-0351/docs.md
@@ -1,0 +1,18 @@
+
+A principal with iam:PutUserPolicy, iam:PutRolePolicy, or iam:PutGroupPolicy and a wildcard
+resource can write an inline policy with admin permissions on any IAM identity, including
+themselves. This enables immediate privilege escalation to full administrative access.
+
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://pathfinding.cloud/
+
+- https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
+
+

--- a/avd_docs/aws/iam/AWS-0352/docs.md
+++ b/avd_docs/aws/iam/AWS-0352/docs.md
@@ -1,0 +1,18 @@
+
+A principal with iam:UpdateAssumeRolePolicy and a wildcard resource can rewrite the trust
+policy of any IAM role to allow self-assumption. This enables lateral movement to any role
+in the account, including administrative roles, effectively granting full account compromise.
+
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://pathfinding.cloud/
+
+- https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
+
+

--- a/avd_docs/aws/iam/AWS-0353/docs.md
+++ b/avd_docs/aws/iam/AWS-0353/docs.md
@@ -1,0 +1,19 @@
+
+A principal with iam:DeleteUserPermissionsBoundary or iam:DeleteRolePermissionsBoundary
+can remove permissions boundaries that act as guardrails on IAM identities. Once boundaries
+are removed, the identity's full unconstrained permissions become active, which may include
+administrative access that was previously limited by the boundary.
+
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://pathfinding.cloud/
+
+- https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
+
+

--- a/checks/cloud/aws/iam/no_attach_policy_escalation.rego
+++ b/checks/cloud/aws/iam/no_attach_policy_escalation.rego
@@ -1,0 +1,63 @@
+# METADATA
+# title: "IAM policy grants Attach*Policy with wildcard resource enabling privilege escalation"
+# description: |
+#   A principal with iam:AttachUserPolicy, iam:AttachRolePolicy, or iam:AttachGroupPolicy
+#   and a wildcard resource can attach the AdministratorAccess managed policy to themselves
+#   or any other identity. This enables immediate privilege escalation to full admin access.
+# scope: package
+# schemas:
+#   - input: schema["cloud"]
+# related_resources:
+#   - https://pathfinding.cloud/
+#   - https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
+# custom:
+#   id: AWS-0349
+#   avd_id: AVD-AWS-0349
+#   provider: aws
+#   service: iam
+#   severity: HIGH
+#   recommended_action: "Restrict iam:Attach*Policy to specific target ARNs using resource conditions. Never grant on Resource: *. Use SCPs to deny attaching admin-level policies."
+#   input:
+#     selector:
+#       - type: cloud
+#         subtypes:
+#           - service: iam
+#             provider: aws
+package builtin.aws.iam.aws0349
+
+import rego.v1
+
+is_dangerous_action(action, target) if {
+	lower(action) == lower(target)
+}
+
+is_dangerous_action(action, target) if {
+	service := split(target, ":")[0]
+	lower(action) == concat(":", [lower(service), "*"])
+}
+
+is_dangerous_action(action, _) if {
+	action == "*"
+}
+
+attach_actions := [
+	"iam:AttachUserPolicy",
+	"iam:AttachRolePolicy",
+	"iam:AttachGroupPolicy",
+]
+
+deny contains res if {
+	policy := input.aws.iam.policies[_]
+	doc := json.unmarshal(policy.document.value)
+	statement := doc.Statement[_]
+	statement.Effect == "Allow"
+	action := statement.Action[_]
+	target := attach_actions[_]
+	is_dangerous_action(action, target)
+	resource := statement.Resource[_]
+	resource == "*"
+	res := result.new(
+		"IAM policy grants Attach*Policy with wildcard resource, enabling privilege escalation",
+		policy,
+	)
+}

--- a/checks/cloud/aws/iam/no_attach_policy_escalation_test.rego
+++ b/checks/cloud/aws/iam/no_attach_policy_escalation_test.rego
@@ -1,0 +1,103 @@
+package builtin.aws.iam.aws0349_test
+
+import rego.v1
+
+import data.builtin.aws.iam.aws0349 as check
+
+test_deny_attach_user_policy if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:AttachUserPolicy"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_deny_attach_role_policy if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:AttachRolePolicy"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_deny_attach_group_policy if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:AttachGroupPolicy"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_deny_iam_wildcard if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:*"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_allow_constrained_resource if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:AttachUserPolicy"],
+			"Resource": ["arn:aws:iam::123456789012:user/specific-user"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}
+
+test_allow_deny_effect if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Deny",
+			"Action": ["iam:AttachUserPolicy"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}
+
+test_allow_safe_action if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["s3:GetObject"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}

--- a/checks/cloud/aws/iam/no_create_policy_version_escalation.rego
+++ b/checks/cloud/aws/iam/no_create_policy_version_escalation.rego
@@ -1,0 +1,57 @@
+# METADATA
+# title: "IAM policy grants iam:CreatePolicyVersion permission enabling privilege escalation"
+# description: |
+#   A principal with iam:CreatePolicyVersion can create a new version of an IAM policy with
+#   unrestricted permissions (e.g., *:*) and set it as the default version. This effectively
+#   grants the principal full administrative access, bypassing the original policy restrictions.
+#   This is a well-known privilege escalation vector in AWS environments.
+# scope: package
+# schemas:
+#   - input: schema["cloud"]
+# related_resources:
+#   - https://pathfinding.cloud/
+#   - https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
+# custom:
+#   id: AWS-0347
+#   avd_id: AVD-AWS-0347
+#   provider: aws
+#   service: iam
+#   severity: CRITICAL
+#   recommended_action: "Remove iam:CreatePolicyVersion from IAM policies unless strictly required for infrastructure automation. Use permissions boundaries to limit policy modification scope."
+#   input:
+#     selector:
+#       - type: cloud
+#         subtypes:
+#           - service: iam
+#             provider: aws
+package builtin.aws.iam.aws0347
+
+import rego.v1
+
+is_dangerous_action(action, target) if {
+	lower(action) == lower(target)
+}
+
+is_dangerous_action(action, target) if {
+	service := split(target, ":")[0]
+	lower(action) == concat(":", [lower(service), "*"])
+}
+
+is_dangerous_action(action, _) if {
+	action == "*"
+}
+
+deny contains res if {
+	policy := input.aws.iam.policies[_]
+	doc := json.unmarshal(policy.document.value)
+	statement := doc.Statement[_]
+	statement.Effect == "Allow"
+	action := statement.Action[_]
+	is_dangerous_action(action, "iam:CreatePolicyVersion")
+	resource := statement.Resource[_]
+	resource == "*"
+	res := result.new(
+		"IAM policy grants iam:CreatePolicyVersion with wildcard resource, enabling privilege escalation",
+		policy,
+	)
+}

--- a/checks/cloud/aws/iam/no_create_policy_version_escalation_test.rego
+++ b/checks/cloud/aws/iam/no_create_policy_version_escalation_test.rego
@@ -1,0 +1,89 @@
+package builtin.aws.iam.aws0347_test
+
+import rego.v1
+
+import data.builtin.aws.iam.aws0347 as check
+
+test_deny_create_policy_version if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:CreatePolicyVersion"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_deny_iam_wildcard if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:*"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_deny_full_wildcard if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["*"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_allow_no_dangerous_action if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["s3:GetObject"],
+			"Resource": ["arn:aws:s3:::my-bucket/*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}
+
+test_allow_deny_effect if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Deny",
+			"Action": ["iam:CreatePolicyVersion"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}
+
+test_allow_constrained_resource if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:CreatePolicyVersion"],
+			"Resource": ["arn:aws:iam::123456789012:policy/MyPolicy"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}

--- a/checks/cloud/aws/iam/no_delete_permissions_boundary_escalation.rego
+++ b/checks/cloud/aws/iam/no_delete_permissions_boundary_escalation.rego
@@ -1,0 +1,61 @@
+# METADATA
+# title: "IAM policy grants Delete*PermissionsBoundary enabling privilege escalation"
+# description: |
+#   A principal with iam:DeleteUserPermissionsBoundary or iam:DeleteRolePermissionsBoundary
+#   can remove permissions boundaries that act as guardrails on IAM identities. Once boundaries
+#   are removed, the identity's full unconstrained permissions become active, which may include
+#   administrative access that was previously limited by the boundary.
+# scope: package
+# schemas:
+#   - input: schema["cloud"]
+# related_resources:
+#   - https://pathfinding.cloud/
+#   - https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
+# custom:
+#   id: AWS-0353
+#   avd_id: AVD-AWS-0353
+#   provider: aws
+#   service: iam
+#   severity: MEDIUM
+#   recommended_action: "Restrict boundary-deletion permissions to a dedicated security automation role. Add SCP deny rules preventing boundary removal except by break-glass principals."
+#   input:
+#     selector:
+#       - type: cloud
+#         subtypes:
+#           - service: iam
+#             provider: aws
+package builtin.aws.iam.aws0353
+
+import rego.v1
+
+is_dangerous_action(action, target) if {
+	lower(action) == lower(target)
+}
+
+is_dangerous_action(action, target) if {
+	service := split(target, ":")[0]
+	lower(action) == concat(":", [lower(service), "*"])
+}
+
+is_dangerous_action(action, _) if {
+	action == "*"
+}
+
+boundary_actions := [
+	"iam:DeleteUserPermissionsBoundary",
+	"iam:DeleteRolePermissionsBoundary",
+]
+
+deny contains res if {
+	policy := input.aws.iam.policies[_]
+	doc := json.unmarshal(policy.document.value)
+	statement := doc.Statement[_]
+	statement.Effect == "Allow"
+	action := statement.Action[_]
+	target := boundary_actions[_]
+	is_dangerous_action(action, target)
+	res := result.new(
+		"IAM policy grants Delete*PermissionsBoundary, enabling privilege escalation by removing guardrails",
+		policy,
+	)
+}

--- a/checks/cloud/aws/iam/no_delete_permissions_boundary_escalation_test.rego
+++ b/checks/cloud/aws/iam/no_delete_permissions_boundary_escalation_test.rego
@@ -1,0 +1,89 @@
+package builtin.aws.iam.aws0353_test
+
+import rego.v1
+
+import data.builtin.aws.iam.aws0353 as check
+
+test_deny_delete_user_permissions_boundary if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:DeleteUserPermissionsBoundary"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_deny_delete_role_permissions_boundary if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:DeleteRolePermissionsBoundary"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_deny_scoped_resource if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:DeleteUserPermissionsBoundary"],
+			"Resource": ["arn:aws:iam::123456789012:user/specific-user"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_deny_iam_wildcard if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:*"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_allow_deny_effect if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Deny",
+			"Action": ["iam:DeleteUserPermissionsBoundary"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}
+
+test_allow_safe_action if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:CreateUser"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}

--- a/checks/cloud/aws/iam/no_passrole_ec2_escalation.rego
+++ b/checks/cloud/aws/iam/no_passrole_ec2_escalation.rego
@@ -1,0 +1,60 @@
+# METADATA
+# title: "IAM policy grants iam:PassRole with ec2:RunInstances enabling privilege escalation"
+# description: |
+#   A principal with iam:PassRole and ec2:RunInstances can launch an EC2 instance with a
+#   privileged instance profile attached. By accessing the instance metadata service (IMDS),
+#   the attacker can steal the role credentials and escalate privileges.
+# scope: package
+# schemas:
+#   - input: schema["cloud"]
+# related_resources:
+#   - https://pathfinding.cloud/
+#   - https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
+# custom:
+#   id: AWS-0350
+#   avd_id: AVD-AWS-0350
+#   provider: aws
+#   service: iam
+#   severity: HIGH
+#   recommended_action: "Constrain iam:PassRole with iam:PassedToService condition key set to ec2.amazonaws.com. Limit role ARNs that can be passed using resource-level permissions on PassRole."
+#   input:
+#     selector:
+#       - type: cloud
+#         subtypes:
+#           - service: iam
+#             provider: aws
+package builtin.aws.iam.aws0350
+
+import rego.v1
+
+is_dangerous_action(action, target) if {
+	lower(action) == lower(target)
+}
+
+is_dangerous_action(action, target) if {
+	service := split(target, ":")[0]
+	lower(action) == concat(":", [lower(service), "*"])
+}
+
+is_dangerous_action(action, _) if {
+	action == "*"
+}
+
+has_action(statements, target) if {
+	statement := statements[_]
+	statement.Effect == "Allow"
+	action := statement.Action[_]
+	is_dangerous_action(action, target)
+}
+
+deny contains res if {
+	policy := input.aws.iam.policies[_]
+	doc := json.unmarshal(policy.document.value)
+	statements := doc.Statement
+	has_action(statements, "iam:PassRole")
+	has_action(statements, "ec2:RunInstances")
+	res := result.new(
+		"IAM policy grants iam:PassRole + ec2:RunInstances, enabling privilege escalation via EC2 instance profile",
+		policy,
+	)
+}

--- a/checks/cloud/aws/iam/no_passrole_ec2_escalation_test.rego
+++ b/checks/cloud/aws/iam/no_passrole_ec2_escalation_test.rego
@@ -1,0 +1,96 @@
+package builtin.aws.iam.aws0350_test
+
+import rego.v1
+
+import data.builtin.aws.iam.aws0350 as check
+
+test_deny_passrole_ec2_combo if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:PassRole", "ec2:RunInstances"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_deny_passrole_ec2_separate_statements if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Effect": "Allow",
+				"Action": ["iam:PassRole"],
+				"Resource": ["*"],
+			},
+			{
+				"Effect": "Allow",
+				"Action": ["ec2:RunInstances"],
+				"Resource": ["*"],
+			},
+		],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_deny_with_wildcards if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:*", "ec2:*"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_allow_missing_passrole if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["ec2:RunInstances"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}
+
+test_allow_missing_ec2 if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:PassRole"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}
+
+test_allow_deny_effect if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Deny",
+			"Action": ["iam:PassRole", "ec2:RunInstances"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}

--- a/checks/cloud/aws/iam/no_passrole_lambda_escalation.rego
+++ b/checks/cloud/aws/iam/no_passrole_lambda_escalation.rego
@@ -1,0 +1,62 @@
+# METADATA
+# title: "IAM policy grants iam:PassRole with Lambda create and invoke enabling privilege escalation"
+# description: |
+#   A principal with iam:PassRole, lambda:CreateFunction, and lambda:InvokeFunction can create
+#   a Lambda function with an administrative role attached, invoke it, and steal the role's
+#   credentials. This combination of permissions enables a well-known privilege escalation path
+#   through AWS Lambda.
+# scope: package
+# schemas:
+#   - input: schema["cloud"]
+# related_resources:
+#   - https://pathfinding.cloud/
+#   - https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
+# custom:
+#   id: AWS-0348
+#   avd_id: AVD-AWS-0348
+#   provider: aws
+#   service: iam
+#   severity: CRITICAL
+#   recommended_action: "Separate iam:PassRole from Lambda creation/invocation permissions into different policies with different principals. Use iam:PassedToService condition key to restrict PassRole to lambda.amazonaws.com only."
+#   input:
+#     selector:
+#       - type: cloud
+#         subtypes:
+#           - service: iam
+#             provider: aws
+package builtin.aws.iam.aws0348
+
+import rego.v1
+
+is_dangerous_action(action, target) if {
+	lower(action) == lower(target)
+}
+
+is_dangerous_action(action, target) if {
+	service := split(target, ":")[0]
+	lower(action) == concat(":", [lower(service), "*"])
+}
+
+is_dangerous_action(action, _) if {
+	action == "*"
+}
+
+has_action(statements, target) if {
+	statement := statements[_]
+	statement.Effect == "Allow"
+	action := statement.Action[_]
+	is_dangerous_action(action, target)
+}
+
+deny contains res if {
+	policy := input.aws.iam.policies[_]
+	doc := json.unmarshal(policy.document.value)
+	statements := doc.Statement
+	has_action(statements, "iam:PassRole")
+	has_action(statements, "lambda:CreateFunction")
+	has_action(statements, "lambda:InvokeFunction")
+	res := result.new(
+		"IAM policy grants iam:PassRole + lambda:CreateFunction + lambda:InvokeFunction, enabling privilege escalation via Lambda",
+		policy,
+	)
+}

--- a/checks/cloud/aws/iam/no_passrole_lambda_escalation_test.rego
+++ b/checks/cloud/aws/iam/no_passrole_lambda_escalation_test.rego
@@ -1,0 +1,96 @@
+package builtin.aws.iam.aws0348_test
+
+import rego.v1
+
+import data.builtin.aws.iam.aws0348 as check
+
+test_deny_passrole_lambda_combo if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:PassRole", "lambda:CreateFunction", "lambda:InvokeFunction"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_deny_passrole_lambda_separate_statements if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Effect": "Allow",
+				"Action": ["iam:PassRole"],
+				"Resource": ["*"],
+			},
+			{
+				"Effect": "Allow",
+				"Action": ["lambda:CreateFunction", "lambda:InvokeFunction"],
+				"Resource": ["*"],
+			},
+		],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_deny_with_wildcards if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:*", "lambda:*"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_allow_missing_passrole if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["lambda:CreateFunction", "lambda:InvokeFunction"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}
+
+test_allow_missing_invoke if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:PassRole", "lambda:CreateFunction"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}
+
+test_allow_deny_effect if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Deny",
+			"Action": ["iam:PassRole", "lambda:CreateFunction", "lambda:InvokeFunction"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}

--- a/checks/cloud/aws/iam/no_put_policy_escalation.rego
+++ b/checks/cloud/aws/iam/no_put_policy_escalation.rego
@@ -1,0 +1,63 @@
+# METADATA
+# title: "IAM policy grants Put*Policy with wildcard resource enabling privilege escalation"
+# description: |
+#   A principal with iam:PutUserPolicy, iam:PutRolePolicy, or iam:PutGroupPolicy and a wildcard
+#   resource can write an inline policy with admin permissions on any IAM identity, including
+#   themselves. This enables immediate privilege escalation to full administrative access.
+# scope: package
+# schemas:
+#   - input: schema["cloud"]
+# related_resources:
+#   - https://pathfinding.cloud/
+#   - https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
+# custom:
+#   id: AWS-0351
+#   avd_id: AVD-AWS-0351
+#   provider: aws
+#   service: iam
+#   severity: HIGH
+#   recommended_action: "Never grant iam:Put*Policy with unrestricted resources. Use permissions boundaries on all principals. Implement SCPs limiting inline policy creation."
+#   input:
+#     selector:
+#       - type: cloud
+#         subtypes:
+#           - service: iam
+#             provider: aws
+package builtin.aws.iam.aws0351
+
+import rego.v1
+
+is_dangerous_action(action, target) if {
+	lower(action) == lower(target)
+}
+
+is_dangerous_action(action, target) if {
+	service := split(target, ":")[0]
+	lower(action) == concat(":", [lower(service), "*"])
+}
+
+is_dangerous_action(action, _) if {
+	action == "*"
+}
+
+put_actions := [
+	"iam:PutUserPolicy",
+	"iam:PutRolePolicy",
+	"iam:PutGroupPolicy",
+]
+
+deny contains res if {
+	policy := input.aws.iam.policies[_]
+	doc := json.unmarshal(policy.document.value)
+	statement := doc.Statement[_]
+	statement.Effect == "Allow"
+	action := statement.Action[_]
+	target := put_actions[_]
+	is_dangerous_action(action, target)
+	resource := statement.Resource[_]
+	resource == "*"
+	res := result.new(
+		"IAM policy grants Put*Policy with wildcard resource, enabling privilege escalation",
+		policy,
+	)
+}

--- a/checks/cloud/aws/iam/no_put_policy_escalation_test.rego
+++ b/checks/cloud/aws/iam/no_put_policy_escalation_test.rego
@@ -1,0 +1,103 @@
+package builtin.aws.iam.aws0351_test
+
+import rego.v1
+
+import data.builtin.aws.iam.aws0351 as check
+
+test_deny_put_user_policy if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:PutUserPolicy"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_deny_put_role_policy if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:PutRolePolicy"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_deny_put_group_policy if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:PutGroupPolicy"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_deny_iam_wildcard if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:*"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_allow_constrained_resource if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:PutUserPolicy"],
+			"Resource": ["arn:aws:iam::123456789012:user/specific-user"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}
+
+test_allow_deny_effect if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Deny",
+			"Action": ["iam:PutUserPolicy"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}
+
+test_allow_safe_action if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["s3:PutObject"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}

--- a/checks/cloud/aws/iam/no_update_assume_role_escalation.rego
+++ b/checks/cloud/aws/iam/no_update_assume_role_escalation.rego
@@ -1,0 +1,56 @@
+# METADATA
+# title: "IAM policy grants iam:UpdateAssumeRolePolicy with wildcard resource enabling privilege escalation"
+# description: |
+#   A principal with iam:UpdateAssumeRolePolicy and a wildcard resource can rewrite the trust
+#   policy of any IAM role to allow self-assumption. This enables lateral movement to any role
+#   in the account, including administrative roles, effectively granting full account compromise.
+# scope: package
+# schemas:
+#   - input: schema["cloud"]
+# related_resources:
+#   - https://pathfinding.cloud/
+#   - https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/
+# custom:
+#   id: AWS-0352
+#   avd_id: AVD-AWS-0352
+#   provider: aws
+#   service: iam
+#   severity: HIGH
+#   recommended_action: "Restrict iam:UpdateAssumeRolePolicy to specific role ARNs. This permission should only be held by identity management automation, never human users or application roles."
+#   input:
+#     selector:
+#       - type: cloud
+#         subtypes:
+#           - service: iam
+#             provider: aws
+package builtin.aws.iam.aws0352
+
+import rego.v1
+
+is_dangerous_action(action, target) if {
+	lower(action) == lower(target)
+}
+
+is_dangerous_action(action, target) if {
+	service := split(target, ":")[0]
+	lower(action) == concat(":", [lower(service), "*"])
+}
+
+is_dangerous_action(action, _) if {
+	action == "*"
+}
+
+deny contains res if {
+	policy := input.aws.iam.policies[_]
+	doc := json.unmarshal(policy.document.value)
+	statement := doc.Statement[_]
+	statement.Effect == "Allow"
+	action := statement.Action[_]
+	is_dangerous_action(action, "iam:UpdateAssumeRolePolicy")
+	resource := statement.Resource[_]
+	resource == "*"
+	res := result.new(
+		"IAM policy grants iam:UpdateAssumeRolePolicy with wildcard resource, enabling privilege escalation via trust policy hijacking",
+		policy,
+	)
+}

--- a/checks/cloud/aws/iam/no_update_assume_role_escalation_test.rego
+++ b/checks/cloud/aws/iam/no_update_assume_role_escalation_test.rego
@@ -1,0 +1,89 @@
+package builtin.aws.iam.aws0352_test
+
+import rego.v1
+
+import data.builtin.aws.iam.aws0352 as check
+
+test_deny_update_assume_role_policy if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:UpdateAssumeRolePolicy"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_deny_iam_wildcard if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:*"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_deny_full_wildcard if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["*"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) > 0
+}
+
+test_allow_constrained_resource if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["iam:UpdateAssumeRolePolicy"],
+			"Resource": ["arn:aws:iam::123456789012:role/specific-role"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}
+
+test_allow_deny_effect if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Deny",
+			"Action": ["iam:UpdateAssumeRolePolicy"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}
+
+test_allow_safe_action if {
+	inp := {"aws": {"iam": {"policies": [{"document": {"value": json.marshal({
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["sts:AssumeRole"],
+			"Resource": ["*"],
+		}],
+	})}}]}}}
+
+	results := check.deny with input as inp
+	count(results) == 0
+}


### PR DESCRIPTION
## Summary

Adds 7 Rego-based checks detecting dangerous IAM permission combinations that enable
privilege escalation. These detect attack paths documented in the
[pathfinding.cloud](https://pathfinding.cloud/) and
[hackingthe.cloud](https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/)
taxonomies.

## Gap

Trivy currently has zero coverage for IAM privilege escalation paths. Existing IAM checks
(AWS-0057 through AWS-0342) cover password policies, MFA, wildcards, and credential
hygiene — but none detect dangerous permission *combinations* like PassRole + service
creation that attackers use to escalate to admin.

## Checks Added

| ID | Severity | Attack Path |
|----|----------|-------------|
| AWS-0347 | CRITICAL | iam:CreatePolicyVersion self-escalation to admin |
| AWS-0348 | CRITICAL | PassRole + Lambda CreateFunction + InvokeFunction |
| AWS-0349 | HIGH | Attach*Policy with wildcard resource |
| AWS-0350 | HIGH | PassRole + EC2 RunInstances (IMDS theft) |
| AWS-0351 | HIGH | Put*Policy with wildcard resource |
| AWS-0352 | HIGH | UpdateAssumeRolePolicy trust hijacking |
| AWS-0353 | MEDIUM | Delete*PermissionsBoundary guardrail removal |

## Testing

- All 7 checks + 7 test files (42 test cases total) pass make test-rego
- All 14 files pass regal lint with zero violations
- make docs generates AVD documentation for all 7 checks

## References

- Attack taxonomy: https://pathfinding.cloud/
- Exploitation techniques: https://hackingthe.cloud/aws/exploitation/iam_privilege_escalation/