### PR TITLE
test(integration): support running check examples against a local trivy binary

### DIFF
--- a/integration/check_examples_test.go
+++ b/integration/check_examples_test.go
@@ -75,9 +75,9 @@ func TestScanCheckExamples(t *testing.T) {
 				"conf",
 				"--checks-bundle-repository", bundleImage,
 				"--format", "json",
-				"--output", filepath.Join(target.BasePath(), reportFileName),
+				"--output", target.Path(reportFileName),
 				"--include-deprecated-checks=false",
-				filepath.Join(target.BasePath(), "examples"),
+				target.Path("examples"),
 			}
 
 			out, err := target.Run(args)

--- a/integration/check_examples_test.go
+++ b/integration/check_examples_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -23,7 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/registry"
-	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/aquasecurity/go-version/pkg/semver"
 	"github.com/aquasecurity/trivy-checks/integration/testcontainer"
@@ -50,19 +48,26 @@ func TestScanCheckExamples(t *testing.T) {
 
 	bundleImage := registryHost + "/" + "trivy-checks:latest"
 
-	for _, version := range trivyVersions {
+	versions := trivyVersions
+	if localTrivyBinary != "" {
+		versions = []string{"local"}
+	}
+
+	for _, version := range versions {
 		t.Run(version, func(t *testing.T) {
 			verDir := filepath.Join(tmpDir, version)
 			examplesPath := filepath.Join(verDir, "examples")
 
-			trivyVer := getActualTrivyVersion(t, version)
+			targetDir, err := filepath.Abs(verDir)
+			require.NoError(t, err)
+
+			target := newTrivyTarget(ctx, version, targetDir)
+
+			trivyVer := getActualTrivyVersion(t, target)
 			checksMetadata, skipped := setupTarget(t, examplesPath, trivyVer)
 
 			bundlePath := buildBundle(t, verDir, skipped, trivyVer)
 			pushBundle(t, ctx, bundlePath, bundleImage)
-
-			targetDir, err := filepath.Abs(verDir)
-			require.NoError(t, err)
 
 			reportFileName := version + "_" + "report.json"
 
@@ -70,51 +75,21 @@ func TestScanCheckExamples(t *testing.T) {
 				"conf",
 				"--checks-bundle-repository", bundleImage,
 				"--format", "json",
-				"--output", "/testdata/" + reportFileName,
+				"--output", filepath.Join(target.BasePath(), reportFileName),
 				"--include-deprecated-checks=false",
-				"/testdata/examples",
+				filepath.Join(target.BasePath(), "examples"),
 			}
-			trivy, err := testcontainer.RunTrivy(ctx, "aquasec/trivy:"+version, args,
-				testcontainers.CustomizeRequest(testcontainers.GenericContainerRequest{
-					ContainerRequest: testcontainers.ContainerRequest{
-						AlwaysPullImage: false,
-					},
-				}),
-				testcontainers.WithHostConfigModifier(func(hc *container.HostConfig) {
-					hc.NetworkMode = "host"
-					hc.Mounts = []mount.Mount{
-						{
-							Type:   mount.TypeBind,
-							Source: targetDir,
-							Target: "/testdata",
-						},
-					}
-				}),
-			)
-			require.NoError(t, err)
-			t.Cleanup(func() { trivy.Terminate(ctx) })
 
-			rc, err := trivy.Logs(ctx)
-			require.NoError(t, err)
-
-			b, err := io.ReadAll(rc)
-			require.NoError(t, err)
-
-			state, err := trivy.State(t.Context())
-			require.NoError(t, err)
-
-			if state.ExitCode != 0 {
-				t.Fatal(string(b))
+			out, err := target.Run(args)
+			if err != nil {
+				t.Fatalf("trivy run failed: %v\n%s", err, out)
 			}
 
 			// trivy switches to embedded checks if the bundle load fails, so we should check this out
-			if bytes.Contains(b, []byte("Falling back to embedded checks")) {
-				t.Log(string(b))
+			if bytes.Contains(out, []byte("Falling back to embedded checks")) {
+				t.Log(string(out))
 				t.Fatal("Failed to load checks from the bundle")
 			}
-
-			require.NoError(t, err)
-			require.NoError(t, trivy.Terminate(ctx))
 
 			reportPath := filepath.Join(targetDir, reportFileName)
 			report := readTrivyReport(t, reportPath)
@@ -125,32 +100,13 @@ func TestScanCheckExamples(t *testing.T) {
 	}
 }
 
-func getActualTrivyVersion(t *testing.T, version string) semver.Version {
+func getActualTrivyVersion(t *testing.T, target trivyTarget) semver.Version {
 	t.Helper()
 
-	args := []string{
-		"version",
-		"-f", "json",
-		"-q",
-	}
-
-	trivy, err := testcontainer.RunTrivy(t.Context(), "aquasec/trivy:"+version, args,
-		testcontainers.CustomizeRequest(testcontainers.GenericContainerRequest{
-			ContainerRequest: testcontainers.ContainerRequest{
-				WaitingFor: wait.ForExit(),
-			},
-		}),
-	)
-	defer trivy.Terminate(t.Context())
-
-	rc, err := trivy.Logs(t.Context())
-	require.NoError(t, err)
-
-	b, err := io.ReadAll(rc)
+	b, err := target.VersionJSON()
 	require.NoError(t, err)
 
 	t.Logf("Version response: %q", string(b))
-	require.NoError(t, err)
 
 	var resp struct {
 		Version string `json:"Version"`

--- a/integration/trivy_target_test.go
+++ b/integration/trivy_target_test.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path"
+	"path/filepath"
 
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
@@ -32,8 +34,9 @@ type trivyTarget interface {
 	// Run executes trivy with the given args and returns the combined output,
 	// with a non-nil error when trivy exits with a non-zero code.
 	Run(args []string) ([]byte, error)
-	// BasePath is the path prefix used for --output and the scan target.
-	BasePath() string
+	// Path builds a path under the target's working directory, using the
+	// separator appropriate for where trivy runs (Linux container vs host).
+	Path(elem ...string) string
 }
 
 // newTrivyTarget selects the target based on the TRIVY_BINARY environment variable.
@@ -58,7 +61,9 @@ func (l localTrivy) Run(args []string) ([]byte, error) {
 	return exec.Command(l.binary, args...).CombinedOutput()
 }
 
-func (l localTrivy) BasePath() string { return l.targetDir }
+func (l localTrivy) Path(elem ...string) string {
+	return filepath.Join(append([]string{l.targetDir}, elem...)...)
+}
 
 // containerTrivy runs trivy in a container pinned to a released version.
 // targetDir is mounted at /testdata.
@@ -68,7 +73,9 @@ type containerTrivy struct {
 	targetDir string
 }
 
-func (c containerTrivy) BasePath() string { return "/testdata" }
+func (c containerTrivy) Path(elem ...string) string {
+	return path.Join(append([]string{"/testdata"}, elem...)...)
+}
 
 func (c containerTrivy) VersionJSON() ([]byte, error) {
 	trivy, err := testcontainer.RunTrivy(c.ctx, "aquasec/trivy:"+c.version,
@@ -88,6 +95,8 @@ func (c containerTrivy) VersionJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rc.Close()
+
 	return io.ReadAll(rc)
 }
 
@@ -118,6 +127,8 @@ func (c containerTrivy) Run(args []string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rc.Close()
+
 	b, err := io.ReadAll(rc)
 	if err != nil {
 		return nil, err

--- a/integration/trivy_target_test.go
+++ b/integration/trivy_target_test.go
@@ -1,0 +1,134 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/mount"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/aquasecurity/trivy-checks/integration/testcontainer"
+)
+
+// localTrivyBinary points to a locally built trivy binary. When set, the test
+// runs against that binary instead of pulling release images, which simplifies
+// local development against unreleased trivy changes.
+var localTrivyBinary = os.Getenv("TRIVY_BINARY")
+
+// trivyTarget abstracts how trivy is invoked: either via a locally built
+// binary (TRIVY_BINARY) or in a container pinned to a released version. The
+// mode is selected once by newTrivyTarget, so the test body stays free of
+// per-call branching.
+type trivyTarget interface {
+	// VersionJSON returns the output of `trivy version -f json`.
+	VersionJSON() ([]byte, error)
+	// Run executes trivy with the given args and returns the combined output,
+	// with a non-nil error when trivy exits with a non-zero code.
+	Run(args []string) ([]byte, error)
+	// BasePath is the path prefix used for --output and the scan target.
+	BasePath() string
+}
+
+// newTrivyTarget selects the target based on the TRIVY_BINARY environment variable.
+func newTrivyTarget(ctx context.Context, version, targetDir string) trivyTarget {
+	if localTrivyBinary != "" {
+		return localTrivy{binary: localTrivyBinary, targetDir: targetDir}
+	}
+	return containerTrivy{ctx: ctx, version: version, targetDir: targetDir}
+}
+
+// localTrivy runs trivy via a local binary on the host.
+type localTrivy struct {
+	binary    string
+	targetDir string
+}
+
+func (l localTrivy) VersionJSON() ([]byte, error) {
+	return exec.Command(l.binary, "version", "-f", "json", "-q").Output()
+}
+
+func (l localTrivy) Run(args []string) ([]byte, error) {
+	return exec.Command(l.binary, args...).CombinedOutput()
+}
+
+func (l localTrivy) BasePath() string { return l.targetDir }
+
+// containerTrivy runs trivy in a container pinned to a released version.
+// targetDir is mounted at /testdata.
+type containerTrivy struct {
+	ctx       context.Context
+	version   string
+	targetDir string
+}
+
+func (c containerTrivy) BasePath() string { return "/testdata" }
+
+func (c containerTrivy) VersionJSON() ([]byte, error) {
+	trivy, err := testcontainer.RunTrivy(c.ctx, "aquasec/trivy:"+c.version,
+		[]string{"version", "-f", "json", "-q"},
+		testcontainers.CustomizeRequest(testcontainers.GenericContainerRequest{
+			ContainerRequest: testcontainers.ContainerRequest{
+				WaitingFor: wait.ForExit(),
+			},
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer trivy.Terminate(c.ctx)
+
+	rc, err := trivy.Logs(c.ctx)
+	if err != nil {
+		return nil, err
+	}
+	return io.ReadAll(rc)
+}
+
+func (c containerTrivy) Run(args []string) ([]byte, error) {
+	trivy, err := testcontainer.RunTrivy(c.ctx, "aquasec/trivy:"+c.version, args,
+		testcontainers.CustomizeRequest(testcontainers.GenericContainerRequest{
+			ContainerRequest: testcontainers.ContainerRequest{
+				AlwaysPullImage: false,
+			},
+		}),
+		testcontainers.WithHostConfigModifier(func(hc *container.HostConfig) {
+			hc.NetworkMode = "host"
+			hc.Mounts = []mount.Mount{
+				{
+					Type:   mount.TypeBind,
+					Source: c.targetDir,
+					Target: "/testdata",
+				},
+			}
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer trivy.Terminate(c.ctx)
+
+	rc, err := trivy.Logs(c.ctx)
+	if err != nil {
+		return nil, err
+	}
+	b, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, err
+	}
+
+	state, err := trivy.State(c.ctx)
+	if err != nil {
+		return b, err
+	}
+	if state.ExitCode != 0 {
+		return b, fmt.Errorf("trivy exited with code %d", state.ExitCode)
+	}
+	return b, nil
+}

--- a/integration/trivy_target_test.go
+++ b/integration/trivy_target_test.go
@@ -58,6 +58,10 @@ func (l localTrivy) VersionJSON() ([]byte, error) {
 }
 
 func (l localTrivy) Run(args []string) ([]byte, error) {
+	// Use an isolated cache dir so a stale policy bundle from the default
+	// cache (e.g. ~/.cache/trivy) is never reused after a check changes.
+	cacheDir := filepath.Join(l.targetDir, "trivy-cache")
+	args = append([]string{args[0], "--cache-dir", cacheDir}, args[1:]...)
 	return exec.Command(l.binary, args...).CombinedOutput()
 }
 


### PR DESCRIPTION
## Description

Adds the ability to run the check examples integration test against a locally built Trivy binary, so changes that depend on unreleased changes can be validated locally without building and pushing a Trivy image.

When `TRIVY_BINARY` is set, the test runs a single local pass that invokes the binary directly via `os/exec`. Otherwise it  behaves exactly as before, running the pinned release images in containers. The bundle registry is used in both modes, and  the local binary pulls the bundle from it over localhost.

The container and local invocation paths are unified behind a small interface, so the test body has no per-call branching and the container path is unchanged.

## Usage

`TRIVY_BINARY=/path/to/trivy go test -tags=integration -run TestScanCheckExamples ./integration/`

The binary's reported version drives the existing `minimum_trivy_version` filtering, so a prerelease build is treated like canary and unreleased checks are not skipped.