### PR TITLE
ci: migrate from StyraInc/setup-regal to open-policy-agent/setup-regal

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
         run: go run ./cmd/opa check lib checks --strict --v0-v1
 
       - name: Setup Regal
-        uses: StyraInc/setup-regal@33a142b1189004e0f14bf42b15972c67eecce776 # v1
+        uses: open-policy-agent/setup-regal@761188c3b435761fa254beca508a44875619648f # v2.0.0
         with:
           version: 0.34.1
 


### PR DESCRIPTION
Regal is now an official OPA project. The `StyraInc/setup-regal` action is no longer available.