### PR TITLE
fix(AZU-0026): allow TLS 1.3

### DIFF
--- a/checks/cloud/azure/database/secure_tls_policy.rego
+++ b/checks/cloud/azure/database/secure_tls_policy.rego
@@ -30,9 +30,9 @@ import rego.v1
 import data.lib.azure.database
 import data.lib.cloud.metadata
 
-recommended_tls_version := "TLS1_2"
+recommended_tls_versions := {"TLS1_2", "TLS1_3"}
 
-recommended_mssql_tls_version := "1.2"
+recommended_mssql_tls_versions := {"1.2", "1.3"}
 
 deny contains res if {
 	some server in database.servers(["mysqlservers", "postgresqlservers"])
@@ -52,6 +52,6 @@ deny contains res if {
 	)
 }
 
-is_recommended_tls(server) := server.minimumtlsversion.value == recommended_tls_version
+is_recommended_tls(server) if server.minimumtlsversion.value in recommended_tls_versions
 
-is_recommended_mssql_tls(server) := server.minimumtlsversion.value == recommended_mssql_tls_version
+is_recommended_mssql_tls(server) if server.minimumtlsversion.value in recommended_mssql_tls_versions

--- a/checks/cloud/azure/database/secure_tls_policy_test.rego
+++ b/checks/cloud/azure/database/secure_tls_policy_test.rego
@@ -25,11 +25,29 @@ test_deny_postgresql_server_minimum_tls_version_is_1_0 if {
 	count(res) == 1
 }
 
+test_deny_mysql_server_minimum_tls_version_is_1_1 if {
+	inp := {"azure": {"database": {"mysqlservers": [build_server("TLS1_1")]}}}
+
+	res := check.deny with input as inp
+	count(res) == 1
+}
+
 test_allow_servers_with_minimum_tls_version_1_2 if {
 	inp := {"azure": {"database": {
-		"mssqlservers": [build_server(check.recommended_mssql_tls_version)],
-		"mysqlservers": [build_server(check.recommended_tls_version)],
-		"postgresqlservers": [build_server(check.recommended_tls_version)],
+		"mssqlservers": [build_server("1.2")],
+		"mysqlservers": [build_server("TLS1_2")],
+		"postgresqlservers": [build_server("TLS1_2")],
+	}}}
+
+	res := check.deny with input as inp
+	count(res) == 0
+}
+
+test_allow_servers_with_minimum_tls_version_1_3 if {
+	inp := {"azure": {"database": {
+		"mssqlservers": [build_server("1.3")],
+		"mysqlservers": [build_server("TLS1_3")],
+		"postgresqlservers": [build_server("TLS1_3")],
 	}}}
 
 	res := check.deny with input as inp


### PR DESCRIPTION
AZU-0026 compared the minimum TLS version against `TLS1_2` exactly, so a server that requires TLS 1.3 was reported as using an insecure version. It now accepts a set of versions, the same way `azure-storage-use-secure-tls-policy` already does.

### Relates issues:
- https://github.com/aquasecurity/trivy/issues/11068