### PR TITLE
fix(azure): allow TLS 1.3 for database minimum TLS version check

### DIFF
--- a/checks/cloud/azure/database/secure_tls_policy.rego
+++ b/checks/cloud/azure/database/secure_tls_policy.rego
@@ -30,7 +30,7 @@ import rego.v1
 import data.lib.azure.database
 import data.lib.cloud.metadata
 
-recommended_tls_version := "TLS1_2"
+recommended_tls_versions := {"TLS1_2", "TLS1_3"}
 
 recommended_mssql_tls_version := "1.2"
 
@@ -52,6 +52,6 @@ deny contains res if {
 	)
 }
 
-is_recommended_tls(server) := server.minimumtlsversion.value == recommended_tls_version
+is_recommended_tls(server) := server.minimumtlsversion.value in recommended_tls_versions
 
 is_recommended_mssql_tls(server) := server.minimumtlsversion.value == recommended_mssql_tls_version

--- a/checks/cloud/azure/database/secure_tls_policy_test.rego
+++ b/checks/cloud/azure/database/secure_tls_policy_test.rego
@@ -28,8 +28,18 @@ test_deny_postgresql_server_minimum_tls_version_is_1_0 if {
 test_allow_servers_with_minimum_tls_version_1_2 if {
 	inp := {"azure": {"database": {
 		"mssqlservers": [build_server(check.recommended_mssql_tls_version)],
-		"mysqlservers": [build_server(check.recommended_tls_version)],
-		"postgresqlservers": [build_server(check.recommended_tls_version)],
+		"mysqlservers": [build_server("TLS1_2")],
+		"postgresqlservers": [build_server("TLS1_2")],
+	}}}
+
+	res := check.deny with input as inp
+	count(res) == 0
+}
+
+test_allow_servers_with_minimum_tls_version_1_3 if {
+	inp := {"azure": {"database": {
+		"mysqlservers": [build_server("TLS1_3")],
+		"postgresqlservers": [build_server("TLS1_3")],
 	}}}
 
 	res := check.deny with input as inp


### PR DESCRIPTION
Fixes #11068 (rego side)

## Problem

`secure_tls_policy.rego` (AZU-0026) required an exact equality match of `minimumtlsversion` against `TLS1_2` for MySQL/PostgreSQL servers, so a server configured with TLS 1.3 was incorrectly reported as insecure. The check should accept TLS 1.2 **or higher** (the trivy adapter normalizes flexible-server values to `TLS1_2`/`TLS1_3`).

## Changes

- `secure_tls_policy.rego` — replaced the single `recommended_tls_version` constant with a `recommended_tls_versions` set `{"TLS1_2", "TLS1_3"}` and changed `is_recommended_tls` to use set membership.
- `secure_tls_policy_test.rego` — updated the existing TLS1.2 allow-test to literal values and added `test_allow_servers_with_minimum_tls_version_1_3`.

MSSQL keeps its existing `1.2` exact-match behavior, matching `minimum_tls_version` on `azurerm_mssql_server`, which does not expose 1.3.

## Verification

- `go run ./cmd/opa test --explain=fails lib/ checks/ examples/ --ignore '*.yaml'` → PASS 1939/1939
- `go run ./cmd/opa fmt --fail -l` on both changed files → clean