### PR TITLE
fix(GCP-0039): allow TLS 1.3

### DIFF
--- a/avd_docs/google/compute/GCP-0039/Terraform.md
+++ b/avd_docs/google/compute/GCP-0039/Terraform.md
@@ -8,6 +8,13 @@ resource "google_compute_ssl_policy" "good_example" {
   min_tls_version = "TLS_1_2"
 }
 ```
+```hcl
+resource "google_compute_ssl_policy" "good_example" {
+  name            = "production-ssl-policy"
+  profile         = "RESTRICTED"
+  min_tls_version = "TLS_1_3"
+}
+```
 
 #### Remediation Links
  - https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_ssl_policy#min_tls_version

--- a/checks/cloud/google/compute/use_secure_tls_policy.rego
+++ b/checks/cloud/google/compute/use_secure_tls_policy.rego
@@ -27,10 +27,13 @@ package builtin.google.compute.google0039
 
 import rego.v1
 
-tls_v_1_2 := "TLS_1_2"
+import data.lib.cloud.value
+
+allowed_tls_versions := {"TLS_1_2", "TLS_1_3"}
 
 deny contains res if {
 	some policy in input.google.compute.sslpolicies
-	policy.minimumtlsversion.value != tls_v_1_2
+	value.is_known(policy.minimumtlsversion)
+	not policy.minimumtlsversion.value in allowed_tls_versions
 	res := result.new("TLS policy does not specify a minimum of TLS 1.2", policy.minimumtlsversion)
 }

--- a/checks/cloud/google/compute/use_secure_tls_policy.yaml
+++ b/checks/cloud/google/compute/use_secure_tls_policy.yaml
@@ -8,6 +8,12 @@ terraform:
         profile         = "MODERN"
         min_tls_version = "TLS_1_2"
       }
+    - |-
+      resource "google_compute_ssl_policy" "good_example" {
+        name            = "production-ssl-policy"
+        profile         = "RESTRICTED"
+        min_tls_version = "TLS_1_3"
+      }
   bad:
     - |-
       resource "google_compute_ssl_policy" "bad_example" {

--- a/checks/cloud/google/compute/use_secure_tls_policy_test.rego
+++ b/checks/cloud/google/compute/use_secure_tls_policy_test.rego
@@ -4,15 +4,36 @@ import rego.v1
 
 import data.builtin.google.compute.google0039 as check
 
-test_deny_ssl_policy_minimum_tls_version_is_1 if {
+test_deny_ssl_policy_minimum_tls_version_is_1_0 if {
 	inp := {"google": {"compute": {"sslpolicies": [{"minimumtlsversion": {"value": "TLS_1_0"}}]}}}
 
 	res := check.deny with input as inp
 	count(res) == 1
 }
 
+test_deny_ssl_policy_minimum_tls_version_is_1_1 if {
+	inp := {"google": {"compute": {"sslpolicies": [{"minimumtlsversion": {"value": "TLS_1_1"}}]}}}
+
+	res := check.deny with input as inp
+	count(res) == 1
+}
+
 test_allow_ssl_policy_minimum_tls_version_is_1_2 if {
-	inp := {"google": {"compute": {"sslpolicies": [{"minimumtlsversion": {"value": check.tls_v_1_2}}]}}}
+	inp := {"google": {"compute": {"sslpolicies": [{"minimumtlsversion": {"value": "TLS_1_2"}}]}}}
+
+	res := check.deny with input as inp
+	res == set()
+}
+
+test_allow_ssl_policy_minimum_tls_version_is_1_3 if {
+	inp := {"google": {"compute": {"sslpolicies": [{"minimumtlsversion": {"value": "TLS_1_3"}}]}}}
+
+	res := check.deny with input as inp
+	res == set()
+}
+
+test_allow_ssl_policy_minimum_tls_version_is_unresolvable if {
+	inp := {"google": {"compute": {"sslpolicies": [{"minimumtlsversion": {"value": "", "unresolvable": true}}]}}}
 
 	res := check.deny with input as inp
 	res == set()


### PR DESCRIPTION
## Description

- treat `TLS_1_3` as a secure minimum TLS version for GCP SSL policies
- skip findings when `min_tls_version` is unresolved
- cover TLS 1.0, 1.1, 1.2, 1.3, and unresolved values in policy tests
- add a TLS 1.3 Terraform example and regenerate the policy documentation

Fixes aquasecurity/trivy#11112

## Testing

- `make test-rego` (`1943/1943` passed)
- `go run ./cmd/opa check lib checks --strict --v0-v1`
- `make check-rego-matrix` (latest, v0.67.0, v0.63.0)
- `make lint-rego` (1125 files, no violations)
- `go test -v ./...`
- `make docs` (idempotent)
- `make test-integration` with the Colima Docker socket (Trivy 0.61.0, latest, and canary)

## AI assistance

Developed with assistance from OpenAI Codex. The final diff was reviewed against the issue requirements and validated with the repository test suite.