### PR TITLE
fix(GCP-0039): allow TLS 1.3

### DIFF
--- a/avd_docs/google/compute/GCP-0039/Terraform.md
+++ b/avd_docs/google/compute/GCP-0039/Terraform.md
@@ -8,6 +8,13 @@ resource "google_compute_ssl_policy" "good_example" {
   min_tls_version = "TLS_1_2"
 }
 ```
+```hcl
+resource "google_compute_ssl_policy" "good_example_tls13" {
+  name            = "production-ssl-policy"
+  profile         = "RESTRICTED"
+  min_tls_version = "TLS_1_3"
+}
+```
 
 #### Remediation Links
  - https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_ssl_policy#min_tls_version

--- a/checks/cloud/google/compute/use_secure_tls_policy.rego
+++ b/checks/cloud/google/compute/use_secure_tls_policy.rego
@@ -27,10 +27,13 @@ package builtin.google.compute.google0039
 
 import rego.v1
 
-tls_v_1_2 := "TLS_1_2"
+import data.lib.cloud.value
+
+allowed_tls_versions := {"TLS_1_2", "TLS_1_3"}
 
 deny contains res if {
 	some policy in input.google.compute.sslpolicies
-	policy.minimumtlsversion.value != tls_v_1_2
+	value.is_known(policy.minimumtlsversion)
+	not policy.minimumtlsversion.value in allowed_tls_versions
 	res := result.new("TLS policy does not specify a minimum of TLS 1.2", policy.minimumtlsversion)
 }

--- a/checks/cloud/google/compute/use_secure_tls_policy.yaml
+++ b/checks/cloud/google/compute/use_secure_tls_policy.yaml
@@ -8,6 +8,12 @@ terraform:
         profile         = "MODERN"
         min_tls_version = "TLS_1_2"
       }
+    - |-
+      resource "google_compute_ssl_policy" "good_example_tls13" {
+        name            = "production-ssl-policy"
+        profile         = "RESTRICTED"
+        min_tls_version = "TLS_1_3"
+      }
   bad:
     - |-
       resource "google_compute_ssl_policy" "bad_example" {

--- a/checks/cloud/google/compute/use_secure_tls_policy_test.rego
+++ b/checks/cloud/google/compute/use_secure_tls_policy_test.rego
@@ -4,15 +4,36 @@ import rego.v1
 
 import data.builtin.google.compute.google0039 as check
 
-test_deny_ssl_policy_minimum_tls_version_is_1 if {
+test_deny_ssl_policy_minimum_tls_version_is_1_0 if {
 	inp := {"google": {"compute": {"sslpolicies": [{"minimumtlsversion": {"value": "TLS_1_0"}}]}}}
 
 	res := check.deny with input as inp
 	count(res) == 1
 }
 
+test_deny_ssl_policy_minimum_tls_version_is_1_1 if {
+	inp := {"google": {"compute": {"sslpolicies": [{"minimumtlsversion": {"value": "TLS_1_1"}}]}}}
+
+	res := check.deny with input as inp
+	count(res) == 1
+}
+
 test_allow_ssl_policy_minimum_tls_version_is_1_2 if {
-	inp := {"google": {"compute": {"sslpolicies": [{"minimumtlsversion": {"value": check.tls_v_1_2}}]}}}
+	inp := {"google": {"compute": {"sslpolicies": [{"minimumtlsversion": {"value": "TLS_1_2"}}]}}}
+
+	res := check.deny with input as inp
+	res == set()
+}
+
+test_allow_ssl_policy_minimum_tls_version_is_1_3 if {
+	inp := {"google": {"compute": {"sslpolicies": [{"minimumtlsversion": {"value": "TLS_1_3"}}]}}}
+
+	res := check.deny with input as inp
+	res == set()
+}
+
+test_allow_ssl_policy_minimum_tls_version_is_unknown if {
+	inp := {"google": {"compute": {"sslpolicies": [{"minimumtlsversion": {"value": "", "unresolvable": true}}]}}}
 
 	res := check.deny with input as inp
 	res == set()


### PR DESCRIPTION
## What

Fixes aquasecurity/trivy#11112.

`checks/cloud/google/compute/use_secure_tls_policy.rego` (GCP-0039) required `min_tls_version` to equal `TLS_1_2` exactly:

```rego
tls_v_1_2 := "TLS_1_2"

deny contains res if {
    some policy in input.google.compute.sslpolicies
    policy.minimumtlsversion.value != tls_v_1_2
    ...
}
```

So `TLS_1_3` — a valid and *more secure* value for [`google_compute_ssl_policy`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_ssl_policy#min_tls_version-1) — was reported as insecure:

```
GCP-0039 (CRITICAL): TLS policy does not specify a minimum of TLS 1.2
```

There were two problems:
1. Exact equality instead of "at least 1.2", so `TLS_1_3` fails.
2. No `value.is_known` guard, so an unresolved value also produces a finding.

## Fix

Accept an allowed set (`TLS_1_2`, `TLS_1_3`) and add the `is_known` guard, mirroring the Azure checks — this is the same change that was just merged for AZU-0026 in #591:

```rego
import data.lib.cloud.value

allowed_tls_versions := {"TLS_1_2", "TLS_1_3"}

deny contains res if {
    some policy in input.google.compute.sslpolicies
    value.is_known(policy.minimumtlsversion)
    not policy.minimumtlsversion.value in allowed_tls_versions
    ...
}
```

Also added a `TLS_1_3` good example to `use_secure_tls_policy.yaml`.

## Tests

Expanded `use_secure_tls_policy_test.rego` to cover the full matrix: `TLS_1_0` (deny), `TLS_1_1` (deny), `TLS_1_2` (allow), `TLS_1_3` (allow), and an unresolved value (allow — no false positive).

**Verified RED→GREEN:** with the original check restored, exactly the new `TLS_1_3` and unknown-value cases fail; with the fix they pass.

## Validation (real results)

- `opa test lib/ checks/ examples/`: **1943/1943 pass**
- `opa test` on `checks/cloud/google/compute/`: **107/107 pass**
- `opa fmt --list` and `opa check` on the changed files: clean

(The `test/` schema conformance test needs `make download-schemas`, which requires network; it fails identically on a clean checkout and is unrelated to this change.)
