### PR TITLE
docs: rewrite the contribution guide and project layout

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,118 +2,310 @@
 
 Welcome, and thank you for considering contributing to trivy-checks!
 
-The following guide gives an overview of the project and some directions on how to make common types of contribution. If something is missing, or you get stuck, please [start a discussion](https://github.com/aquasecurity/trivy/discussions/new) and we'll do our best to help.
+This guide covers what is specific to this repository, from how a check is laid out to what CI verifies. If something is missing, or you get stuck, please [start a discussion](https://github.com/aquasecurity/trivy/discussions/new) and we'll do our best to help.
 
-## Writing Checks
+Background reading that is not repeated here:
 
-Writing a new rule can be relatively simple, but there are a few things to keep in mind. The following guide will help you get started.
+- [Contribute Rego Checks](https://trivy.dev/docs/latest/community/contribute/checks/overview/) for a general overview.
+- [Custom checks](https://trivy.dev/docs/latest/guide/scanner/misconfiguration/custom/) for the check metadata reference, [schemas](https://trivy.dev/docs/latest/guide/scanner/misconfiguration/custom/schema/) and [testing](https://trivy.dev/docs/latest/guide/scanner/misconfiguration/custom/testing/).
+- The [OPA documentation](https://www.openpolicyagent.org/docs/policy-language/) to learn Rego, and the [Rego Playground](https://play.openpolicyagent.org/) to try things out.
+- The [OPA Slack](https://slack.openpolicyagent.org/) for questions about Rego itself.
 
-First of all, you should check if the provider your rule targets is supported by _defsec_. If it's not, you'll need to add support for it. See [Adding Support for a New Cloud Provider](https://github.com/aquasecurity/defsec/blob/master/CONTRIBUTING.md#adding-support-for-a-new-cloud-provider) for more information. You can check if support exists by looking for a directory with the provider name in `pkg/providers`.  If you find your provider, navigate into the directory and check for a directory with the name of the service you're targeting. If you can't find that, you'll need to add support for it. See [Adding Support for a New Service](https://github.com/aquasecurity/defsec/blob/master/CONTRIBUTING.md#adding-support-for-a-new-service) for more information.
+## Prerequisites
 
-Next up, you'll need to check if the properties you want to target are supported, and if not, add support for them. The guide on [Adding Support for a New Service](https://github.com/aquasecurity/defsec/blob/master/CONTRIBUTING.md#adding-support-for-a-new-service) covers adding new properties.
+- **Go**, the version from `go.mod`.
+- **[Regal](https://github.com/open-policy-agent/regal)**.
+- **jq**.
+- **Docker**.
+- **GNU sed**, installed as `gsed` on macOS.
 
-At last, it's time to write your rule code! Rules are defined using _OPA Rego_. You can find a number of examples in the `checks/cloud` directory. The [OPA documentation](https://www.openpolicyagent.org/docs/latest/policy-language/) is a great place to start learning Rego. You can also check out the [Rego Playground](https://play.openpolicyagent.org/) to experiment with Rego, and [join the OPA Slack](https://slack.openpolicyagent.org/).
+Do not reach for a stock `opa` binary. The checks call built-in functions that plain OPA does not
+have, `result.new` and `isManaged` from Trivy among them, and `cidr.is_public` or
+`sh.parse_commands` from this repository. Every `make` target goes through `go run ./cmd/opa`, an
+OPA build with all of these registered, and that is the only way to compile or test a check
+locally.
 
-Create a new file in `checks/cloud` with the name of your rule. You should nest it in the existing directory structure as applicable. The package name should be in the format `builtin.PROVIDER.SERVICE.ID`, e.g. `builtin.aws.rds.aws0176`.
+## Writing checks
 
-Running `make id` will provide you with the next available _ID_ for your rule. You can use this ID in your rule code to identify it.
+### Anatomy of a check
 
-A simple rule looks like the following example:
+Up to three hand-written files live side by side, and the documentation is generated from them:
+
+```
+checks/cloud/azure/appservice/web_app_https_only.rego       # the check
+checks/cloud/azure/appservice/web_app_https_only_test.rego  # unit tests
+checks/cloud/azure/appservice/web_app_https_only.yaml       # good/bad examples
+avd_docs/azure/appservice/AZU-0072/docs.md                  # generated, do not edit by hand
+avd_docs/azure/appservice/AZU-0072/Terraform.md             # generated from the examples
+```
+
+Checks are grouped by target. Cloud providers live in `checks/cloud`, Dockerfiles in
+`checks/docker` and Kubernetes manifests in `checks/kubernetes`.
+
+### Verify the provider and service exist
+
+Cloud checks read from a data structure that Trivy builds from the scanned input, so the provider
+and service you target must already be supported. Look for them in
+[`pkg/iac/providers`](https://github.com/aquasecurity/trivy/tree/main/pkg/iac/providers) in the
+Trivy repository. If the service or the property you need is missing, add it first. See
+[Add Service Support](https://trivy.dev/docs/latest/community/contribute/checks/service-support/),
+and note that this change goes to the Trivy repository, not to this one.
+
+Kubernetes and Dockerfile checks need no provider definitions.
+
+### Pick an ID
+
+Run `make id`. It prints the next free ID for every prefix in use, so take the one that matches
+the target you are writing for.
+
+### Write the check
 
 ```rego
 # METADATA
-# title: "RDS IAM Database Authentication Disabled"
-# description: "Ensure IAM Database Authentication is enabled for RDS database instances to manage database access"
+# title: Web App Accepting Traffic Other Than HTTPS
+# description: |
+#   Allowing HTTP undermines transport encryption and exposes user data.
 # scope: package
 # schemas:
-# - input: schema["aws"]
+#   - input: schema["cloud"]
 # related_resources:
-# - https://docs.aws.amazon.com/neptune/latest/userguide/iam-auth.html
+#   - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service#https_only
 # custom:
-#   id: AVD-AWS-0176
-#   avd_id: AVD-AWS-0176
-#   provider: aws
-#   service: rds
+#   id: AZU-0072
+#   long_id: azure-appservice-web-app-https-only
+#   aliases:
+#     - AVD-AZU-0072
+#     - web-app-https-only
+#     - azure-appservice-web-app-https-only
+#   provider: azure
+#   service: appservice
 #   severity: MEDIUM
-#   short_code: enable-iam-auth
-#   recommended_action: "Modify the PostgreSQL and MySQL type RDS instances to enable IAM database authentication."
+#   minimum_trivy_version: 0.68.0
+#   recommended_action: Set 'HTTPS Only' to true in App Service TLS settings to force encrypted transport.
 #   input:
 #     selector:
-#     - type: cloud
-#       subtypes:
-#         - service: rds
-#           provider: aws
+#       - type: cloud
+#         subtypes:
+#           - service: appservice
+#             provider: azure
+#   examples: checks/cloud/azure/appservice/web_app_https_only.yaml
+package builtin.azure.appservice.azure0072
 
-package builtin.aws.rds.aws0176
+import rego.v1
 
-deny[res] {
- instance := input.aws.rds.instances[_]
- instance.engine.value == ["postgres", "mysql"][_]
- not instance.iamauthenabled.value
- res := result.new("Instance does not have IAM Authentication enabled", instance.iamauthenabled)
+deny contains res if {
+	some service in input.azure.appservice.services
+	isManaged(service)
+	not service.httpsonly.value
+	res := result.new(
+		"App service does not have HTTPS enforced.",
+		object.get(service, "httpsonly", service),
+	)
 }
 ```
 
-In fact, this is the code for an actual rule. You can find it in `checks/cloud/aws/rds/enable_iam_auth.rego`.
+This is a real check, and you can find it in
+`checks/cloud/azure/appservice/web_app_https_only.rego`.
 
-The metadata is the top section that starts with `# METADATA`, and is fairly verbose. You can copy and paste from another rule as a starting point. This format is effectively _yaml_ within a Rego comment, and is [defined as part of Rego itself](https://www.openpolicyagent.org/docs/latest/policy-language/#metadata).
+#### Package name
 
-Let's break the metadata down.
+There is no strict rule. Follow the checks that already live in the same directory:
 
-- `title` is fairly self-explanatory - it is a title for the rule. The title should clearly and succinctly state the problem which is being detected.
-- `description` is also fairly self-explanatory - it is a description of the problem which is being detected. The description should be a little more verbose than the title, and should describe what the rule is trying to achieve. Imagine it completing a sentence starting with `You should...`.
-- `scope` is used to define the scope of the policy. In this case, we are defining a policy that applies to the entire package. _defsec_ only supports using package scope for metadata at the moment, so this should always be the same.
-- `schemas` tells Rego that it should use the `AWS` schema to validate the use of the input data in the policy. We currently support [these](https://github.com/aquasecurity/defsec/tree/9b3cc255faff5dc57de5ff77ed0ce0009c80a4bb/pkg/rego/schemas) schemas. Using a schema can help you validate your policy faster for syntax issues.
-- `custom` is used to define custom fields that can be used by defsec to provide additional context to the policy and any related detections. This can contain the following:
-  - `avd_id` is the ID of the rule in the [AWS Vulnerability Database](https://avd.aquasec.com/). This is used to link the rule to the AVD entry. You can generate an ID to use for this field using `make id`.
-  - `provider` is the name of the provider the rule targets. This should be the same as the provider name in the `pkg/providers` directory, e.g. `aws`.
-  - `service` is the name of the service the rule targets. This should be the same as the service name in the `pkg/providers` directory, e.g. `rds`.
-  - `severity` is the severity of the rule. This should be one of `LOW`, `MEDIUM`, `HIGH`, or `CRITICAL`.
-  - `short_code` is a short code for the rule. This should be a short, descriptive name for the rule, separating words with hyphens. You should omit provider/service from this.
-  - `recommended_action` is a recommended remediation action for the rule. This should be a short, descriptive sentence describing what the user should do to resolve the issue.
-  - `input` tells _defsec_ what inputs this rule should be applied to. Cloud provider rules should always use the `selector` input, and should always use the `type` selector with `cloud`. Rules targeting Kubernetes yaml can use `kubernetes`, RBAC can use `rbac`, and so on.
-  - `subtypes` aid the engine to determine if it should load this policy or not for scanning. This can aid with the performance of scanning, especially if you have a lot of checks but not all apply to the IaC that you are trying to scan.
-  
-Now you'll need to write the rule logic. This is the code that will be executed to detect the issue. You should define a rule named `deny` and place your code inside this.
+```
+AZU-0072   ->  builtin.azure.appservice.azure0072
+AWS-0176   ->  builtin.aws.rds.aws0176
+KSV-01010  ->  builtin.kubernetes.KSV01010
+DS-0006    ->  builtin.dockerfile.DS006
+```
+
+Cloud checks are lowercase and carry the service. Kubernetes and Dockerfile checks have no service
+and keep the ID uppercase.
+
+#### Syntax
+
+Checks use Rego v1, so write `deny contains res if { ... }` with `import rego.v1`. CI rejects the
+old `deny[res] { ... }` form.
+
+#### Helpers
+
+`result.new` and `isManaged` come from the runtime and need no import. The second argument of
+`result.new` is the value the finding points at, and that is what gives the finding its line
+numbers.
+
+Prefer the helpers in `lib/` over raw comparisons. `lib/cloud/value.rego` deals with values Trivy
+could not resolve. For such a value `value.is_equal`, `value.is_true`, `value.greater_than` and
+friends evaluate to `false`, so the check stays silent instead of reporting a false positive. Take
+care when negating them, because `not value.is_true(x)` succeeds for an unresolvable `x` and
+brings the false positive back. Guard that case with `value.is_known`. `lib/cloud/metadata.rego`
+provides `metadata.obj_by_path` for pointing a finding at a nested attribute that may be absent.
+
+The `schemas` annotation validates your input references against the Trivy schema, which catches
+typos in property paths early. `related_resources` and `minimum_trivy_version` are optional. The
+example sets the latter because App Service support arrived in Trivy at the same time, see
+[`minimum_trivy_version`](#minimum_trivy_version) below.
+
+### Metadata fields
+
+Metadata is yaml inside a Rego comment, and it is
+[part of Rego itself](https://www.openpolicyagent.org/docs/policy-language/#metadata). Built-in
+checks must have it.
+
+`make lint-rego` rejects any field under `custom` that is not listed below, using the schema in
+[`.regal/rules/custom/invalid-metadata`](.regal/rules/custom/invalid-metadata/invalid_metadata.rego).
+That schema only insists on `id` and `input`; the other required fields are conventions that every
+built-in check follows.
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `id` | yes | The ID from `make id`. |
+| `input.selector` | yes | Which inputs the check applies to. Cloud checks select `type: cloud` and narrow by `provider` and `service`, Kubernetes checks select `type: kubernetes` and narrow by `kind`, Dockerfile checks select `type: dockerfile`. Limiting the subtypes keeps scans fast. |
+| `long_id` | yes | Stable human-readable ID in the form `provider-service-short-description`. |
+| `aliases` | yes | Previously used IDs, including the `AVD-` prefixed one. Keep old IDs here so existing ignore files keep working. |
+| `severity` | yes | One of `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`. |
+| `recommended_action` | yes | What the user should do to resolve the finding. `recommended_actions` is an older spelling that is still accepted, but do not set both. |
+| `provider`, `service` | cloud only | Must match the directory names under `pkg/iac/providers` in Trivy. Kubernetes and Dockerfile checks set neither. |
+| `examples` | no | Path to the yaml examples file, for checks that have one. |
+| `minimum_trivy_version` | no | The first Trivy release whose data model the check can rely on. Valid semver, see [below](#minimum_trivy_version). |
+| `deprecated` | no | Set to `true` rather than deleting a check that is no longer wanted, so its ID stays taken and existing ignore rules keep resolving. Trivy skips deprecated checks unless the scan passes `--include-deprecated-checks`. |
+| `frameworks` | no | Maps the check to compliance controls, e.g. `cis-aws-1.4: ["4.6"]`. See [Writing compliance reports](#writing-compliance-reports). |
+| `terraform`, `cloud_formation` | no | Legacy per-engine `links`, `good_examples` and `bad_examples`. Superseded by the yaml examples file, so no new check needs them. |
+
+#### minimum_trivy_version
+
+Checks are validated against the schemas of several Trivy versions, and at scan time they run
+against whatever data model the installed Trivy builds. A check that reads a field an older model
+does not have would break on both counts, and `minimum_trivy_version` declares the first release
+it can rely on. `make check-rego-matrix` skips the check for every version below that, and Trivy
+does the same when scanning.
+
+Set it when the check needs a model Trivy has only just gained, either because the check is
+written together with new provider support, or because it starts reading a field that came with a
+change on the Trivy side.
+
+The value is normally a release that does not exist yet rather than the one you have installed.
+Until it ships, the integration tests cover the check with the `canary` image, or with your own
+build of Trivy through `TRIVY_BINARY` (see [Run the check with Trivy](#run-the-check-with-trivy)).
+Bump the value if the change slips to a later release.
+
+### Add examples
+
+Examples live in a yaml file next to the check. Each top-level key is an engine, one of
+`terraform`, `cloudformation`, `kubernetes` or `dockerfile`, and a check may declare several.
+Terraform is by far the most common:
+
+```yaml
+terraform:
+  links:
+    - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service#https_only
+  good:
+    - |-
+      resource "azurerm_app_service" "good_example" {
+        https_only = true
+      }
+  bad:
+    - |-
+      resource "azurerm_app_service" "bad_example" {
+        https_only = false
+      }
+```
+
+The integration tests scan these examples, and `make docs` renders them into `avd_docs`, which is
+what ends up on [avd.aquasec.com](https://avd.aquasec.com/). Only `terraform` and `cloudformation`
+get a page there (`Terraform.md`, `CloudFormation.md`), while the other two engines are used by
+the tests only.
+
+Add a `good` example for every configuration the check is meant to accept, and a `bad` one for
+every configuration it is meant to reject, including the case where the attribute is omitted and
+the default applies.
+
+### Add tests
+
+Tests live next to the check in `NAME_test.rego`, in the package of the check with a `_test`
+suffix:
 
 ```rego
-deny[res] {
- instance := input.aws.rds.instances[_]
- instance.engine.value == ["postgres", "mysql"][_]
- not instance.iamauthenabled.value
- res := result.new("Instance does not have IAM Authentication enabled", instance.iamauthenabled)
+package builtin.azure.appservice.azure0072_test
+
+import rego.v1
+
+import data.builtin.azure.appservice.azure0072 as check
+
+test_deny_https_disabled if {
+	inp := {"azure": {"appservice": {"services": [{"httpsonly": {"value": false}}]}}}
+	res := check.deny with input as inp
+	count(res) == 1
+}
+
+test_allow_https_enabled if {
+	inp := {"azure": {"appservice": {"services": [{"httpsonly": {"value": true}}]}}}
+	res := check.deny with input as inp
+	res == set()
 }
 ```
 
-The rule should return a result, which can be created using `result.new` (this function does not need to be imported, it is defined internally and provided at runtime). The first argument is the message to display, and the second argument is the resource that the issue was detected on.
+Cover the denied case, the allowed case, and, when the check reads a value that may be
+unresolvable, an input with `{"value": "", "unresolvable": true}` to prove it produces no finding.
 
-In the example above, you'll notice properties are being accessed from the `input.aws` object. The full set of schemas containing all of these properties is [available here](https://github.com/aquasecurity/defsec/tree/master/pkg/rego/schemas). You can match the schema name to the type of input you want to scan.
+Many existing tests use the assertion helpers from `lib/test` (`import data.lib.test`). They print
+the actual value when a test fails, which a bare comparison does not:
 
-You should also write a test for your rule(s). There are many examples of these in the `checks/cloud` directory.
+```rego
+test.assert_count(check.deny, 1) with input as inp
+test.assert_empty(check.deny) with input as inp
+test.assert_equal_message("App service does not have HTTPS enforced.", check.deny) with input as inp
+```
 
-Finally, you'll want to generate documentation for your newly added rule. Please run `make docs` to generate the documentation for your new policy and submit a PR for us to take a look at.
+### Run the check with Trivy
 
-You can see a full example PR for a new rule being added here: [https://github.com/aquasecurity/defsec/pull/1000](https://github.com/aquasecurity/defsec/pull/1000).
+Unit tests only cover handcrafted input. To see the check work end to end on real configuration
+files, build the checks into a bundle and point Trivy at it:
 
-## Writing Compliance reports
+```bash
+make start-registry  # local OCI registry on port 5111
+make push-bundle     # builds bundle.tar.gz and pushes it there
+trivy conf --checks-bundle-repository localhost:5111/trivy-checks:latest ./path/to/terraform
+make stop-registry
+```
 
-To write a compliance report please check the following [compliance guide](./pkg/compliance/README.md)
+The integration tests do the same thing under the hood. Do not reach for `--config-check` instead.
+Trivy already ships these checks, and loading them a second time fails with
+`rego_type_error: package annotation redeclared`.
 
-Supported compliance report IDs include:
+When the check depends on a Trivy change that is not released yet, build Trivy from your branch
+and run the examples test against that binary:
 
-### AWS
+```bash
+TRIVY_BINARY=/path/to/trivy go test -tags=integration -run TestScanCheckExamples ./integration/
+```
 
-- aws-cis-1.2
-- aws-cis-1.4
+The test then makes a single pass with your build instead of the pinned release images, so there
+is no need to build and push a Trivy image first. Filtering by `minimum_trivy_version` follows the
+version the binary reports, and a prerelease version is never filtered out, so a check written for
+the upcoming release still runs. Docker is needed either way, since the bundle is served from a
+local registry in both modes.
 
-### Docker
+## Before opening a PR
 
-- docker-cis-1.6.0
+`make rego` runs the fast loop: `fmt-rego`, `check-rego`, `lint-rego`, `test-rego` and `docs`. The
+remaining commands are not part of it and have to be run separately.
 
-## Kubernetes
+| Command | What it does | CI job |
+| --- | --- | --- |
+| `make fmt-rego` | Formats the Rego in `lib`, `checks` and `examples`. | Test Rego |
+| `make check-rego` | Validates syntax and input references against the latest Trivy schema. | Test Rego |
+| `make lint-rego` | Runs Regal, including this repository's custom rules in `.regal/rules`. | Test Rego |
+| `make test-rego` | Runs the Rego unit tests. | Test Rego |
+| `make docs` | Reformats the yaml examples and regenerates `avd_docs` from them. | Test Docs |
+| `make check-rego-matrix` | Validates the checks against the schemas of every version in `TRIVY_VERSIONS`, taking `minimum_trivy_version` into account. | Test Rego |
+| `make test` | Runs the Go tests. | Test Go |
+| `make test-integration` | Scans the yaml examples with several real Trivy versions, `canary` included, or with your own build via `TRIVY_BINARY`. Needs Docker and takes a few minutes. | Integration Tests |
 
-- eks-cis-1.4
-- k8s-cis-1.23
-- k8s-nsa-1.0
-- k8s-pss-baseline-0.1
-- k8s-pss-restricted-0.1
+`make fmt-rego` and `make docs` change files instead of reporting problems. CI reruns both and
+fails on any diff, so commit everything they touch, including the reformatted yaml examples.
+
+## Writing compliance reports
+
+To write a compliance report please check the following [compliance guide](./pkg/compliance/README.md).
+
+The supported reports are the yaml files in [`pkg/compliance`](./pkg/compliance), each named after
+its report ID.

--- a/README.md
+++ b/README.md
@@ -10,15 +10,14 @@ Join the community, and talk to us about any matter in [GitHub Discussion](https
 
 The directory structure is broken down as follows:
 
-- `cmd/` - These CLI tools are primarily used during development for end-to-end testing without requiring the use of a library.
-  - `cmd/id` - This command helps generate the next available ID that is free when writing a new check.
-- `checks/` - All the checks are defined in this directory.
-  - `kubernetes/` - Kubernetes-specific security checks
-    - `access/` - RBAC, authentication, and authorization related checks
-    - `network/` - Network security checks including network policies, host network access, and service configurations
-    - `resources/` - Resource quotas, limits, and management checks
-    - `security/` - Core security checks including Pod Security Standards
-    - `workloads/` - Workload-specific security checks
-  - `cloud/kubernetes/` - Cloud-specific Kubernetes security checks
-- `commands/` - All [Node-collector](https://github.com/aquasecurity/k8s-node-collector) commands are defined in this directory.
-- `test/` - Integration tests and other high-level tests that require a full build of the project.
+- `checks/` - the checks themselves, grouped by target: `cloud/<provider>/<service>/`, `docker/`, `kubernetes/`.
+- `lib/` - shared Rego helpers the checks import: `lib/cloud`, `lib/kubernetes`, `lib/docker`, `lib/test`.
+- `avd_docs/` - documentation generated from the check examples by `make docs`, published on [avd.aquasec.com](https://avd.aquasec.com/).
+- `commands/` - [Node-collector](https://github.com/aquasecurity/k8s-node-collector) commands.
+- `pkg/compliance/` - compliance report specs, one yaml per report ID.
+- `cmd/` - development tools, e.g. `cmd/id` for the next free check ID and `cmd/avd_generator` behind `make docs`.
+- `examples/` - sample IaC and custom checks used by the integration tests.
+- `integration/` - integration tests that run real Trivy.
+- `test/` - Go tests over the checks and their metadata.
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to write a check.


### PR DESCRIPTION
The contribution guide still pointed at _defsec_, showed Rego v0 syntax and metadata fields that no longer exist (`avd_id`, `short_code`), so it could not be followed as written.

Rewritten around what is specific to this repository: writing a check, its metadata, examples, tests, and what to run before opening a PR.

`README.md` listed `checks/kubernetes/` subdirectories that do not exist and described `test/` as the integration tests, which live in `integration/`. Project Layout updated to the current tree.

No functional changes.