### PR TITLE
fix(aws-0126): match secure TLS policies by prefix

### DIFF
--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
@@ -30,19 +30,33 @@ package builtin.aws.elasticsearch.aws0126
 import rego.v1
 
 import data.lib.cloud.metadata
+import data.lib.cloud.value
 
 deny contains res if {
 	some domain in input.aws.elasticsearch.domains
-	not is_tls_policy_secure(domain)
+	non_compliant_tls(domain)
 	res := result.new(
 		"Domain does not have a secure TLS policy.",
 		metadata.obj_by_path(domain, ["endpoint", "tlspolicy"]),
 	)
 }
 
-recommended_tls_policies := {
-	"Policy-Min-TLS-1-2-2019-07",
-	"Policy-Min-TLS-1-2-PFS-2023-10",
+# A missing TLS policy is a misconfiguration: report it.
+non_compliant_tls(domain) if not domain.endpoint.tlspolicy
+
+# A present but resolved value is only compliant when it matches one of the
+# secure policy families. Matching by prefix (rather than an exact allowlist)
+# also accepts newer entries such as Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08
+# and any future TLS 1.3-minimum family, while still rejecting
+# Policy-Min-TLS-1-0-2019-07.
+non_compliant_tls(domain) if {
+	value.is_known(domain.endpoint.tlspolicy)
+	not is_tls_policy_secure(domain)
 }
 
-is_tls_policy_secure(domain) if domain.endpoint.tlspolicy.value in recommended_tls_policies
+secure_tls_policies := ["Policy-Min-TLS-1-2-*", "Policy-Min-TLS-1-3-*"]
+
+is_tls_policy_secure(domain) if {
+	some p in secure_tls_policies
+	glob.match(p, [], domain.endpoint.tlspolicy.value)
+}

--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
@@ -17,8 +17,31 @@ test_allow_use_secure_tls_policy_2 if {
 	test.assert_empty(check.deny) with input as inp
 }
 
+# Regression: the FIPS/RFC9151 policy is secure (TLS 1.2-minimum, FIPS) and must
+# not be flagged. See aquasecurity/trivy#11118.
+test_allow_use_secure_tls_policy_fips if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+# A future TLS 1.3-minimum family should also be accepted without a rule edit.
+test_allow_use_secure_tls_policy_tls13 if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-3-2025-01"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
 test_deny_does_not_use_secure_tls_policy if {
 	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-0-2019-07"}}}]}}}
 
 	test.assert_equal_message("Domain does not have a secure TLS policy.", check.deny) with input as inp
+}
+
+# An unresolved TLS policy value must not produce a finding: the engine cannot
+# determine the configured policy, so flagging it would be a false positive.
+test_no_finding_for_unresolved_tls_policy if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"unresolvable": true}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
 }


### PR DESCRIPTION
## What

Fixes a false positive in **AWS-0126** (`aws-elasticsearch-use-secure-tls-policy`) reported in aquasecurity/trivy#11118.

Closes aquasecurity/trivy#11118

## Problem

The check only accepted two exact policy names as secure:

- `Policy-Min-TLS-1-2-2019-07`
- `Policy-Min-TLS-1-2-PFS-2023-10`

so it flagged `Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08` as insecure, even though that policy enforces a **TLS 1.2 minimum with FIPS compliance** — the strictest of the currently available families. Any future secure policy name would require another rule edit. Unresolved TLS policy values also produced false findings.

## Fix

Replace the exact-name allowlist with **prefix matching** over:

```rego
secure_tls_policies := ["Policy-Min-TLS-1-2-*", "Policy-Min-TLS-1-3-*"]
```

mirroring the convention already used by AWS-0005 (`aws-apigateway-use-secure-tls-policy`). This:

- accepts all current secure families (including the FIPS/RFC9151 policy),
- accepts any future TLS 1.2-minimum or TLS 1.3-minimum addition without a rule edit,
- still rejects `Policy-Min-TLS-1-0-2019-07` (genuinely insecure).

A `value.is_known(domain.endpoint.tlspolicy)` guard (the idiom used by `azure-storage-use-secure-tls-policy` and `google-sql-encrypt-in-transit-data`) means an **unresolved** TLS policy value produces no finding, while a genuinely **missing** policy is still reported as a misconfiguration.

## Tests

`use_secure_tls_policy_test.rego` adds:

- `test_allow_use_secure_tls_policy_fips` — `Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08` → no finding (regression for #11118)
- `test_allow_use_secure_tls_policy_tls13` — `Policy-Min-TLS-1-3-2025-01` → no finding (future-proofing)
- `test_no_finding_for_unresolved_tls_policy` — unresolved value → no finding

The existing `test_allow_use_secure_tls_policy`, `test_allow_use_secure_tls_policy_2`, and `test_deny_does_not_use_secure_tls_policy` are unchanged and still pass.

## Verification

```
$ go run ./cmd/opa test lib/ checks/ examples/ --ignore '*.yaml'
PASS: 1943/1943

$ go run ./cmd/opa check lib checks --v0-v1 --strict -s schemas/latest
(no errors)
```