### PR TITLE
fix(aws-0047): flag outdated FIPS/PQ ELB TLS policies

### DIFF
--- a/checks/cloud/aws/elb/use_secure_tls_policy.rego
+++ b/checks/cloud/aws/elb/use_secure_tls_policy.rego
@@ -38,6 +38,14 @@ outdated_ssl_policies := {
 	"ELBSecurityPolicy-TLS13-1-1-2021-06",
 	"ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06",
 	"ELBSecurityPolicy-TLS13-1-2-Ext2-2021-06",
+	# FIPS / post-quantum variants whose minimum protocol is TLS 1.0 or 1.1.
+	# They share the protocol range of the TLS13-1-0/1-1-2021-06 policies above
+	# (AWS documents them as "legacy compatibility" policies) and are not in the
+	# AWS Security Hub recommended set. See aquasecurity/trivy#11121.
+	"ELBSecurityPolicy-TLS13-1-0-FIPS-2023-04",
+	"ELBSecurityPolicy-TLS13-1-0-FIPS-PQ-2025-09",
+	"ELBSecurityPolicy-TLS13-1-0-PQ-2025-09",
+	"ELBSecurityPolicy-TLS13-1-1-FIPS-2023-04",
 }
 
 deny contains res if {

--- a/checks/cloud/aws/elb/use_secure_tls_policy_test.rego
+++ b/checks/cloud/aws/elb/use_secure_tls_policy_test.rego
@@ -25,3 +25,30 @@ test_allow_with_actual_tls_policy if {
 
 	test.assert_empty(check.deny) with input as inp
 }
+
+# The FIPS / post-quantum "legacy compatibility" variants expose a TLS 1.0 or
+# 1.1 minimum protocol and are therefore outdated, just like their non-FIPS
+# TLS13-1-0/1-1-2021-06 counterparts. See aquasecurity/trivy#11121.
+test_deny_with_tls13_1_0_fips_tls_policy if {
+	inp := {"aws": {"elb": {"loadbalancers": [{"listeners": [{"tlspolicy": {"value": "ELBSecurityPolicy-TLS13-1-0-FIPS-2023-04"}}]}]}}}
+
+	test.assert_equal_message("Listener uses an outdated TLS policy.", check.deny) with input as inp
+}
+
+test_deny_with_tls13_1_0_fips_pq_tls_policy if {
+	inp := {"aws": {"elb": {"loadbalancers": [{"listeners": [{"tlspolicy": {"value": "ELBSecurityPolicy-TLS13-1-0-FIPS-PQ-2025-09"}}]}]}}}
+
+	test.assert_equal_message("Listener uses an outdated TLS policy.", check.deny) with input as inp
+}
+
+test_deny_with_tls13_1_0_pq_tls_policy if {
+	inp := {"aws": {"elb": {"loadbalancers": [{"listeners": [{"tlspolicy": {"value": "ELBSecurityPolicy-TLS13-1-0-PQ-2025-09"}}]}]}}}
+
+	test.assert_equal_message("Listener uses an outdated TLS policy.", check.deny) with input as inp
+}
+
+test_deny_with_tls13_1_1_fips_tls_policy if {
+	inp := {"aws": {"elb": {"loadbalancers": [{"listeners": [{"tlspolicy": {"value": "ELBSecurityPolicy-TLS13-1-1-FIPS-2023-04"}}]}]}}}
+
+	test.assert_equal_message("Listener uses an outdated TLS policy.", check.deny) with input as inp
+}


### PR DESCRIPTION
## What

Adds four AWS ELB "legacy compatibility" TLS policies to the `outdated_ssl_policies` set in `checks/cloud/aws/elb/use_secure_tls_policy.rego` (AWS-0047):

- `ELBSecurityPolicy-TLS13-1-0-FIPS-2023-04`
- `ELBSecurityPolicy-TLS13-1-0-FIPS-PQ-2025-09`
- `ELBSecurityPolicy-TLS13-1-0-PQ-2025-09`
- `ELBSecurityPolicy-TLS13-1-1-FIPS-2023-04`

These FIPS / post-quantum variants share the protocol range of the already-flagged `ELBSecurityPolicy-TLS13-1-0-2021-06` / `ELBSecurityPolicy-TLS13-1-1-2021-06` policies (minimum protocol TLS 1.0 / 1.1). AWS documents them as "legacy compatibility" policies, and they are not in the AWS Security Hub recommended set, so a listener using one should produce the same finding as its non-FIPS counterpart.

Closes aquasecurity/trivy#11121 (sub-point 1).

## Scope

This PR addresses only sub-point 1 of trivy#11121 (the missing outdated policy names). The other sub-points raised in the issue are intentionally out of scope here:

- Default/obsolete policy handling at the defsec adapter layer — separate concern, different repo area.
- Forward-secrecy classification — ambiguous policy decision better made by maintainers.
- Metadata/description updates — no metadata change needed for a set addition.

Happy to split any of those into follow-up PRs if wanted.

## Verification

- `go run ./cmd/opa test lib/ checks/ examples/ --ignore '*.yaml'` → 1944/1944 PASS (4 new tests added, one per new policy).
- `go run ./cmd/opa check lib checks --v0-v1 --strict -s schemas/latest` → clean.
- `go run ./cmd/opa fmt -w` applied; no further diff.
- `make docs` → no `avd_docs/` changes (set addition only, no metadata change).

Each new test asserts the corresponding policy now produces `Listener uses an outdated TLS policy.`, mirroring the existing `test_deny_with_outdated_tls_policy`.