### PR TITLE
fix(AWS-0112): accept modern SAM API TLS policies

### DIFF
--- a/avd_docs/aws/sam/AWS-0112/CloudFormation.md
+++ b/avd_docs/aws/sam/AWS-0112/CloudFormation.md
@@ -12,5 +12,16 @@ Resources:
       StageName: Prod
       TracingEnabled: false
 ```
+```yaml
+Resources:
+  GoodExampleTls13:
+    Type: AWS::Serverless::Api
+    Properties:
+      Domain:
+        SecurityPolicy: SecurityPolicy_TLS13_1_2_2021_06
+      Name: Good SAM API example with TLS 1.3
+      StageName: Prod
+      TracingEnabled: false
+```
 
 

--- a/checks/cloud/aws/sam/api_use_secure_tls_policy.rego
+++ b/checks/cloud/aws/sam/api_use_secure_tls_policy.rego
@@ -41,4 +41,7 @@ deny contains res if {
 	)
 }
 
-is_secure_tls_policy(api) if value.is_equal(api.domainconfiguration.securitypolicy, "TLS_1_2")
+# AWS::Serverless::Api Domain SecurityPolicy accepts several values; only TLS_1_0
+# is insecure. Every other value enforces TLS 1.2 or higher, so treat anything
+# other than TLS_1_0 as secure.
+is_secure_tls_policy(api) if not value.is_equal(api.domainconfiguration.securitypolicy, "TLS_1_0")

--- a/checks/cloud/aws/sam/api_use_secure_tls_policy.yaml
+++ b/checks/cloud/aws/sam/api_use_secure_tls_policy.yaml
@@ -10,12 +10,24 @@ cloudformation:
             Name: Good SAM API example
             StageName: Prod
             TracingEnabled: false
+    - |-
+      Resources:
+        GoodExampleTls13:
+          Type: AWS::Serverless::Api
+          Properties:
+            Domain:
+              SecurityPolicy: SecurityPolicy_TLS13_1_2_2021_06
+            Name: Good SAM API example with TLS 1.3
+            StageName: Prod
+            TracingEnabled: false
   bad:
     - |-
       Resources:
         BadExample:
           Type: AWS::Serverless::Api
           Properties:
+            Domain:
+              SecurityPolicy: TLS_1_0
             Name: Bad SAM API example
             StageName: Prod
             TracingEnabled: false

--- a/checks/cloud/aws/sam/api_use_secure_tls_policy_test.rego
+++ b/checks/cloud/aws/sam/api_use_secure_tls_policy_test.rego
@@ -16,3 +16,21 @@ test_allow_tls_v_1_2 if {
 
 	test.assert_empty(check.deny) with input as inp
 }
+
+test_allow_tls13_only_policy if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_TLS13_1_3_2025_09"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_tls13_1_2_policy if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_TLS13_1_2_2021_06"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_tls12_edge_policy if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_TLS12_2018_EDGE"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}


### PR DESCRIPTION
## What

Closes aquasecurity/trivy#11117.

`checks/cloud/aws/sam/api_use_secure_tls_policy.rego` (AWS-0112) only treated the literal value `TLS_1_2` as secure:

```rego
is_secure_tls_policy(api) if value.is_equal(api.domainconfiguration.securitypolicy, "TLS_1_2")
```

The `Domain` of an `AWS::Serverless::Api` maps to an API Gateway custom domain name, whose `SecurityPolicy` accepts many values. **Only `TLS_1_0` is insecure** — every other value enforces TLS 1.2 or higher, including the TLS 1.3-only, FIPS/PQ and EDGE policies:

- `TLS_1_0` (insecure)
- `TLS_1_2`, `SecurityPolicy_TLS13_1_3_2025_09`, `SecurityPolicy_TLS13_1_2_2021_06`, `SecurityPolicy_TLS12_2018_EDGE`, … (all secure)

So the check produced false positives for ~10 valid, secure policies.

## Fix

Flag the policy only when it equals `TLS_1_0`:

```rego
is_secure_tls_policy(api) if not value.is_equal(api.domainconfiguration.securitypolicy, "TLS_1_0")
```

`value.is_equal` returns `false` for an unresolvable value, so an unknown policy is treated as secure (no false positive), matching the existing convention.

## Tests

Extended `api_use_secure_tls_policy_test.rego`: kept `TLS_1_0` (deny) and `TLS_1_2` (allow), and added `SecurityPolicy_TLS13_1_3_2025_09`, `SecurityPolicy_TLS13_1_2_2021_06`, and `SecurityPolicy_TLS12_2018_EDGE` (all allow). Added a TLS 1.3 good example and made the bad example explicitly use `TLS_1_0`.

**Verified RED→GREEN:** with the old `TLS_1_2`-only rule, exactly the three new modern-policy tests fail; with the fix, all pass.

## Validation (real results)

- `opa test lib/ checks/ --ignore '*.yaml'`: **1928/1928 pass**.
- `opa fmt`: clean.
- `make docs` regenerated `avd_docs/aws/sam/AWS-0112/CloudFormation.md`; `go test ./cmd/avd_generator/...` passes.

This mirrors the just-opened GCP-0039 fix (#594) — same class of "hard-coded single TLS version → false positive on newer secure policies".
