### PR TITLE
fix(misconf): accept modern AWS-0126 TLS policies

### DIFF
--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
@@ -30,9 +30,11 @@ package builtin.aws.elasticsearch.aws0126
 import rego.v1
 
 import data.lib.cloud.metadata
+import data.lib.cloud.value
 
 deny contains res if {
 	some domain in input.aws.elasticsearch.domains
+	value.is_known(domain.endpoint.tlspolicy)
 	not is_tls_policy_secure(domain)
 	res := result.new(
 		"Domain does not have a secure TLS policy.",
@@ -40,9 +42,9 @@ deny contains res if {
 	)
 }
 
-recommended_tls_policies := {
-	"Policy-Min-TLS-1-2-2019-07",
-	"Policy-Min-TLS-1-2-PFS-2023-10",
-}
+secure_tls_policies := ["Policy-Min-TLS-1-2-*", "Policy-Min-TLS-1-3-*"]
 
-is_tls_policy_secure(domain) if domain.endpoint.tlspolicy.value in recommended_tls_policies
+is_tls_policy_secure(domain) if {
+	some pattern in secure_tls_policies
+	glob.match(pattern, [], domain.endpoint.tlspolicy.value)
+}

--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
@@ -17,6 +17,18 @@ test_allow_use_secure_tls_policy_2 if {
 	test.assert_empty(check.deny) with input as inp
 }
 
+test_allow_use_secure_tls_policy_fips if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_unresolved_tls_policy if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "", "unresolvable": true}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
 test_deny_does_not_use_secure_tls_policy if {
 	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-0-2019-07"}}}]}}}
 


### PR DESCRIPTION
## Summary

- accept the TLS 1.2 and TLS 1.3 policy families supported by Amazon OpenSearch Service
- skip unresolved TLS policy values instead of reporting a false positive
- cover the FIPS policy and unresolved-value cases with regression tests

Before this change, `Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08` and unresolved values produced AWS-0126 findings. After it, modern secure policies and unresolved values pass while TLS 1.0 remains denied.

Fixes aquasecurity/trivy#11118

## Test plan

- `go run ./cmd/opa fmt --fail checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego`
- strict OPA validation for the changed rule and test
- focused OPA tests: 40/40 passed
- Regal 0.34.1 lint for the changed rule and test
- `make check-rego`
- `make test-rego`: 1942/1942 passed
