### PR TITLE
fix(AWS-0112): allow TLS 1.3 and enhanced security policies

### DIFF
--- a/checks/cloud/aws/sam/api_use_secure_tls_policy.rego
+++ b/checks/cloud/aws/sam/api_use_secure_tls_policy.rego
@@ -30,7 +30,6 @@ package builtin.aws.sam.aws0112
 import rego.v1
 
 import data.lib.cloud.metadata
-import data.lib.cloud.value
 
 deny contains res if {
 	some api in input.aws.sam.apis
@@ -41,4 +40,24 @@ deny contains res if {
 	)
 }
 
-is_secure_tls_policy(api) if value.is_equal(api.domainconfiguration.securitypolicy, "TLS_1_2")
+# Every SecurityPolicy value accepted by AWS::ApiGateway::DomainName except
+# TLS_1_0, which is the only one that permits TLS 1.0. The rest negotiate
+# TLS 1.2 or higher, so flagging them as "outdated" is a false positive.
+#
+# This is an allow list rather than a deny list on TLS_1_0 so that a policy
+# AWS introduces later is reported until it has been reviewed, instead of
+# being silently accepted.
+secure_tls_policies := {
+	"TLS_1_2",
+	"SecurityPolicy_TLS13_1_3_2025_09",
+	"SecurityPolicy_TLS13_1_3_FIPS_2025_09",
+	"SecurityPolicy_TLS13_1_2_PFS_PQ_2025_09",
+	"SecurityPolicy_TLS13_1_2_FIPS_PQ_2025_09",
+	"SecurityPolicy_TLS13_1_2_PQ_2025_09",
+	"SecurityPolicy_TLS13_1_2_2021_06",
+	"SecurityPolicy_TLS13_2025_EDGE",
+	"SecurityPolicy_TLS12_PFS_2025_EDGE",
+	"SecurityPolicy_TLS12_2018_EDGE",
+}
+
+is_secure_tls_policy(api) if api.domainconfiguration.securitypolicy.value in secure_tls_policies

--- a/checks/cloud/aws/sam/api_use_secure_tls_policy_test.rego
+++ b/checks/cloud/aws/sam/api_use_secure_tls_policy_test.rego
@@ -16,3 +16,30 @@ test_allow_tls_v_1_2 if {
 
 	test.assert_empty(check.deny) with input as inp
 }
+
+# Every remaining SecurityPolicy value documented for
+# AWS::ApiGateway::DomainName. All of them negotiate TLS 1.2 or higher, so
+# none should be reported as an outdated policy.
+test_allow_enhanced_security_policies if {
+	every policy in {
+		"SecurityPolicy_TLS13_1_3_2025_09",
+		"SecurityPolicy_TLS13_1_3_FIPS_2025_09",
+		"SecurityPolicy_TLS13_1_2_PFS_PQ_2025_09",
+		"SecurityPolicy_TLS13_1_2_FIPS_PQ_2025_09",
+		"SecurityPolicy_TLS13_1_2_PQ_2025_09",
+		"SecurityPolicy_TLS13_1_2_2021_06",
+		"SecurityPolicy_TLS13_2025_EDGE",
+		"SecurityPolicy_TLS12_PFS_2025_EDGE",
+		"SecurityPolicy_TLS12_2018_EDGE",
+	} {
+		test.assert_empty(check.deny) with input as {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": policy}}}]}}}
+	}
+}
+
+# An unrecognised value is reported rather than assumed safe, so a policy AWS
+# adds later surfaces for review instead of passing silently.
+test_deny_unknown_policy if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_Not_A_Real_Value"}}}]}}}
+
+	test.assert_count(check.deny, 1) with input as inp
+}


### PR DESCRIPTION
AWS-0112 compared the SAM API domain security policy against `TLS_1_2` exactly, so every enhanced policy that negotiates TLS 1.3 was reported as outdated. It now accepts a set of policies, the same way `aws-elasticsearch-use-secure-tls-policy` already does.

The set is an allow list rather than a deny on `TLS_1_0` so that a policy AWS introduces later is reported until it has been reviewed, instead of being silently accepted. A test covers that case.

The values are taken from the `SecurityPolicy` allowed values documented for `AWS::ApiGateway::DomainName`, which is where SAM passes this property through to. Of the eleven documented values, only `TLS_1_0` permits TLS 1.0.

### Relates issues:
- https://github.com/aquasecurity/trivy/issues/11117