### PR TITLE
fix(aws): false positives in TLS policy checks (AWS-0126, AWS-0112)

### DIFF
--- a/checks/cloud/aws/apigateway/use_secure_tls_policy.rego
+++ b/checks/cloud/aws/apigateway/use_secure_tls_policy.rego
@@ -30,13 +30,12 @@ package builtin.aws.apigateway.aws0005
 
 import rego.v1
 
+import data.lib.cloud.aws.apigateway
 import data.lib.cloud.metadata
-
-policies := ["TLS_1_2", "SecurityPolicy_TLS12_*_EDGE", "SecurityPolicy_TLS13_*"]
 
 deny contains res if {
 	some domain in input.aws.apigateway.v1.domainnames
-	not is_SecurityPolicy_TLS12(domain)
+	apigateway.is_outdated_security_policy(domain.securitypolicy)
 	res := result.new(
 		"Domain name is configured with an outdated TLS policy.",
 		metadata.obj_by_path(domain, "securitypolicy"),
@@ -45,14 +44,9 @@ deny contains res if {
 
 deny contains res if {
 	some domain in input.aws.apigateway.v2.domainnames
-	not is_SecurityPolicy_TLS12(domain)
+	apigateway.is_outdated_security_policy(domain.securitypolicy)
 	res := result.new(
 		"Domain name is configured with an outdated TLS policy.",
 		metadata.obj_by_path(domain, "securitypolicy"),
 	)
-}
-
-is_SecurityPolicy_TLS12(domain) if {
-	some p in policies
-	glob.match(p, [], domain.securitypolicy.value)
 }

--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
@@ -29,20 +29,14 @@ package builtin.aws.elasticsearch.aws0126
 
 import rego.v1
 
+import data.lib.cloud.aws.apigateway
 import data.lib.cloud.metadata
 
 deny contains res if {
 	some domain in input.aws.elasticsearch.domains
-	not is_tls_policy_secure(domain)
+	apigateway.is_outdated_elasticsearch_tls_policy(domain.endpoint.tlspolicy)
 	res := result.new(
 		"Domain does not have a secure TLS policy.",
 		metadata.obj_by_path(domain, ["endpoint", "tlspolicy"]),
 	)
 }
-
-recommended_tls_policies := {
-	"Policy-Min-TLS-1-2-2019-07",
-	"Policy-Min-TLS-1-2-PFS-2023-10",
-}
-
-is_tls_policy_secure(domain) if domain.endpoint.tlspolicy.value in recommended_tls_policies

--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
@@ -17,8 +17,20 @@ test_allow_use_secure_tls_policy_2 if {
 	test.assert_empty(check.deny) with input as inp
 }
 
+test_allow_use_secure_tls_policy_fips if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
 test_deny_does_not_use_secure_tls_policy if {
 	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-0-2019-07"}}}]}}}
 
 	test.assert_equal_message("Domain does not have a secure TLS policy.", check.deny) with input as inp
+}
+
+test_allow_unknown_tls_policy if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "", "unresolvable": true}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
 }

--- a/checks/cloud/aws/sam/api_use_secure_tls_policy.rego
+++ b/checks/cloud/aws/sam/api_use_secure_tls_policy.rego
@@ -29,16 +29,14 @@ package builtin.aws.sam.aws0112
 
 import rego.v1
 
+import data.lib.cloud.aws.apigateway
 import data.lib.cloud.metadata
-import data.lib.cloud.value
 
 deny contains res if {
 	some api in input.aws.sam.apis
-	not is_secure_tls_policy(api)
+	apigateway.is_outdated_security_policy(api.domainconfiguration.securitypolicy)
 	res := result.new(
 		"Domain name is configured with an outdated TLS policy.",
 		metadata.obj_by_path(api, ["domainconfiguration", "securitypolicy"]),
 	)
 }
-
-is_secure_tls_policy(api) if value.is_equal(api.domainconfiguration.securitypolicy, "TLS_1_2")

--- a/checks/cloud/aws/sam/api_use_secure_tls_policy_test.rego
+++ b/checks/cloud/aws/sam/api_use_secure_tls_policy_test.rego
@@ -16,3 +16,27 @@ test_allow_tls_v_1_2 if {
 
 	test.assert_empty(check.deny) with input as inp
 }
+
+test_allow_SecurityPolicy_TLS12_PFS_2025_EDGE if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_TLS12_PFS_2025_EDGE"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_SecurityPolicy_TLS13_1_3_2025_09 if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_TLS13_1_3_2025_09"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_SecurityPolicy_TLS13_1_2_2021_06 if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_TLS13_1_2_2021_06"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_unknown_security_policy if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "", "unresolvable": true}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}

--- a/lib/cloud/aws_apigateway.rego
+++ b/lib/cloud/aws_apigateway.rego
@@ -1,0 +1,47 @@
+# METADATA
+# scope: package
+# schemas:
+#   - input: schema["cloud"]
+package lib.cloud.aws.apigateway
+
+import rego.v1
+
+import data.lib.cloud.value
+
+# Patterns rather than exact names, so policies added to the same families
+# are covered without a change here.
+secure_security_policies := [
+	"TLS_1_2",
+	"SecurityPolicy_TLS12_*_EDGE",
+	"SecurityPolicy_TLS13_*",
+]
+
+# True if the security policy permits TLS versions below 1.2.
+# Unresolvable values yield no result.
+is_outdated_security_policy(policy) if {
+	value.is_known(policy)
+	not _is_secure_security_policy(policy)
+}
+
+_is_secure_security_policy(policy) if {
+	some pattern in secure_security_policies
+	glob.match(pattern, [], policy.value)
+}
+
+# Patterns for Elasticsearch domain TLS policies.
+secure_elasticsearch_tls_policies := [
+	"Policy-Min-TLS-1-2-*",
+	"Policy-Min-TLS-1-3-*",
+]
+
+# True if the Elasticsearch TLS policy is outdated.
+# Unresolvable values yield no result.
+is_outdated_elasticsearch_tls_policy(policy) if {
+	value.is_known(policy)
+	not _is_secure_elasticsearch_tls_policy(policy)
+}
+
+_is_secure_elasticsearch_tls_policy(policy) if {
+	some pattern in secure_elasticsearch_tls_policies
+	glob.match(pattern, [], policy.value)
+}


### PR DESCRIPTION
This PR fixes false positives in two AWS TLS policy checks:

## AWS-0126 (Elasticsearch domain TLS policy)
**Issue**: #11118 - The check rejected  (the strictest TLS 1.3 FIPS policy) as outdated.

**Fix**: Changed from exact name matching to glob patterns:
-  covers all three current secure policies (2019-07, PFS-2023-10, RFC9151-FIPS-2024-08)
-  covers future TLS 1.3 minimum policies

## AWS-0112 (SAM API domain TLS policy)
**Issue**: #11117 - The check only accepted , rejecting 10 other secure policies including TLS 1.3 variants.

**Fix**: Now uses the same shared patterns as AWS-0005 (API Gateway):
- 
- 
- 

## Refactoring
- Created  with shared patterns and helper functions
- Both AWS-0005 and AWS-0112 now use the shared lib
- Added  guard to avoid findings on unresolvable values

## Tests
- Added tests for FIPS policy, TLS 1.3 policies, and unresolvable values
- All 1949 existing tests pass
- OPA check passes for latest, v0.67.0, v0.63.0 schemas