### PR TITLE
fix: use glob patterns for TLS policies in AWS-0126

### DIFF
--- a/checks/cloud/aws/apigateway/use_secure_tls_policy.rego
+++ b/checks/cloud/aws/apigateway/use_secure_tls_policy.rego
@@ -30,13 +30,12 @@ package builtin.aws.apigateway.aws0005
 
 import rego.v1
 
+import data.lib.aws.apigateway as apigateway
 import data.lib.cloud.metadata
-
-policies := ["TLS_1_2", "SecurityPolicy_TLS12_*_EDGE", "SecurityPolicy_TLS13_*"]
 
 deny contains res if {
 	some domain in input.aws.apigateway.v1.domainnames
-	not is_SecurityPolicy_TLS12(domain)
+	apigateway.is_outdated_security_policy(domain.securitypolicy)
 	res := result.new(
 		"Domain name is configured with an outdated TLS policy.",
 		metadata.obj_by_path(domain, "securitypolicy"),
@@ -45,14 +44,9 @@ deny contains res if {
 
 deny contains res if {
 	some domain in input.aws.apigateway.v2.domainnames
-	not is_SecurityPolicy_TLS12(domain)
+	apigateway.is_outdated_security_policy(domain.securitypolicy)
 	res := result.new(
 		"Domain name is configured with an outdated TLS policy.",
 		metadata.obj_by_path(domain, "securitypolicy"),
 	)
-}
-
-is_SecurityPolicy_TLS12(domain) if {
-	some p in policies
-	glob.match(p, [], domain.securitypolicy.value)
 }

--- a/checks/cloud/aws/apigateway/use_secure_tls_policy_test.rego
+++ b/checks/cloud/aws/apigateway/use_secure_tls_policy_test.rego
@@ -25,3 +25,8 @@ test_deny_with_tls_1_0 if {
 	inp := {"aws": {"apigateway": {"v1": {"domainnames": [{"securitypolicy": {"value": "TLS_1_0"}}]}}}}
 	test.assert_count(check.deny, 1) with input as inp
 }
+
+test_allow_unresolvable_security_policy if {
+	inp := {"aws": {"apigateway": {"v1": {"domainnames": [{"securitypolicy": {}}]}}}}
+	test.assert_empty(check.deny) with input as inp
+}

--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
@@ -31,8 +31,14 @@ import rego.v1
 
 import data.lib.cloud.metadata
 
+secure_tls_policies := [
+	"Policy-Min-TLS-1-2-*",
+	"Policy-Min-TLS-1-3-*",
+]
+
 deny contains res if {
 	some domain in input.aws.elasticsearch.domains
+	value.is_known(domain.endpoint.tlspolicy)
 	not is_tls_policy_secure(domain)
 	res := result.new(
 		"Domain does not have a secure TLS policy.",
@@ -40,9 +46,7 @@ deny contains res if {
 	)
 }
 
-recommended_tls_policies := {
-	"Policy-Min-TLS-1-2-2019-07",
-	"Policy-Min-TLS-1-2-PFS-2023-10",
+is_tls_policy_secure(domain) if {
+	some pattern in secure_tls_policies
+	glob.match(pattern, [], domain.endpoint.tlspolicy.value)
 }
-
-is_tls_policy_secure(domain) if domain.endpoint.tlspolicy.value in recommended_tls_policies

--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy.yaml
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy.yaml
@@ -7,11 +7,21 @@ cloudformation:
           Properties:
             DomainEndpointOptions:
               TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
+    - |-
+      Resources:
+        GoodExample:
+          Type: AWS::Elasticsearch::Domain
+          Properties:
+            DomainEndpointOptions:
+              TLSSecurityPolicy: Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08
   bad:
     - |-
       Resources:
         BadExample:
           Type: AWS::Elasticsearch::Domain
+          Properties:
+            DomainEndpointOptions:
+              TLSSecurityPolicy: Policy-Min-TLS-1-0-2019-07
 terraform:
   links:
     - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain#tls_security_policy
@@ -21,6 +31,13 @@ terraform:
         domain_endpoint_options {
           enforce_https       = true
           tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+        }
+      }
+    - |-
+      resource "aws_elasticsearch_domain" "good_example_fips" {
+        domain_endpoint_options {
+          enforce_https       = true
+          tls_security_policy = "Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08"
         }
       }
   bad:

--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
@@ -17,6 +17,18 @@ test_allow_use_secure_tls_policy_2 if {
 	test.assert_empty(check.deny) with input as inp
 }
 
+test_allow_use_secure_tls_policy_fips if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_unresolvable_tls_policy if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
 test_deny_does_not_use_secure_tls_policy if {
 	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-0-2019-07"}}}]}}}
 

--- a/checks/cloud/aws/sam/api_use_secure_tls_policy.rego
+++ b/checks/cloud/aws/sam/api_use_secure_tls_policy.rego
@@ -29,16 +29,14 @@ package builtin.aws.sam.aws0112
 
 import rego.v1
 
+import data.lib.aws.apigateway as apigateway
 import data.lib.cloud.metadata
-import data.lib.cloud.value
 
 deny contains res if {
 	some api in input.aws.sam.apis
-	not is_secure_tls_policy(api)
+	apigateway.is_outdated_security_policy(api.domainconfiguration.securitypolicy)
 	res := result.new(
 		"Domain name is configured with an outdated TLS policy.",
 		metadata.obj_by_path(api, ["domainconfiguration", "securitypolicy"]),
 	)
 }
-
-is_secure_tls_policy(api) if value.is_equal(api.domainconfiguration.securitypolicy, "TLS_1_2")

--- a/checks/cloud/aws/sam/api_use_secure_tls_policy.yaml
+++ b/checks/cloud/aws/sam/api_use_secure_tls_policy.yaml
@@ -10,6 +10,26 @@ cloudformation:
             Name: Good SAM API example
             StageName: Prod
             TracingEnabled: false
+    - |-
+      Resources:
+        GoodExample:
+          Type: AWS::Serverless::Api
+          Properties:
+            Domain:
+              SecurityPolicy: SecurityPolicy_TLS13_1_2_2021_06
+            Name: Good SAM API example
+            StageName: Prod
+            TracingEnabled: false
+    - |-
+      Resources:
+        GoodExample:
+          Type: AWS::Serverless::Api
+          Properties:
+            Domain:
+              SecurityPolicy: SecurityPolicy_TLS13_2025_EDGE
+            Name: Good SAM API example
+            StageName: Prod
+            TracingEnabled: false
   bad:
     - |-
       Resources:

--- a/checks/cloud/aws/sam/api_use_secure_tls_policy_test.rego
+++ b/checks/cloud/aws/sam/api_use_secure_tls_policy_test.rego
@@ -16,3 +16,69 @@ test_allow_tls_v_1_2 if {
 
 	test.assert_empty(check.deny) with input as inp
 }
+
+test_allow_security_policy_tls13_1_2_2021_06 if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_TLS13_1_2_2021_06"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_security_policy_tls13_1_3_2025_09 if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_TLS13_1_3_2025_09"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_security_policy_tls13_1_3_fips_2025_09 if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_TLS13_1_3_FIPS_2025_09"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_security_policy_tls13_1_2_pfs_pq_2025_09 if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_TLS13_1_2_PFS_PQ_2025_09"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_security_policy_tls13_1_2_fips_pq_2025_09 if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_TLS13_1_2_FIPS_PQ_2025_09"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_security_policy_tls13_1_2_fips_pfs_pq_2025_09 if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_TLS13_1_2_FIPS_PFS_PQ_2025_09"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_security_policy_tls13_1_2_pq_2025_09 if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_TLS13_1_2_PQ_2025_09"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_security_policy_tls13_2025_edge if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_TLS13_2025_EDGE"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_security_policy_tls12_pfs_2025_edge if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_TLS12_PFS_2025_EDGE"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_security_policy_tls12_2018_edge if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_TLS12_2018_EDGE"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_unresolvable_security_policy if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}

--- a/lib/cloud/aws_apigateway.rego
+++ b/lib/cloud/aws_apigateway.rego
@@ -1,0 +1,29 @@
+# METADATA
+# title: AWS API Gateway security policy helpers
+# description: Shared helpers for evaluating API Gateway TLS security policies
+# scope: package
+package lib.aws.apigateway
+
+import rego.v1
+
+import data.lib.cloud.value
+
+# Patterns rather than exact names, so policies added to the same families
+# are covered without a change here.
+secure_security_policies := [
+	"TLS_1_2",
+	"SecurityPolicy_TLS12_*_EDGE",
+	"SecurityPolicy_TLS13_*",
+]
+
+# True if the security policy permits TLS versions below 1.2.
+# Unresolvable values yield no result.
+is_outdated_security_policy(policy) if {
+	value.is_known(policy)
+	not _is_secure_security_policy(policy)
+}
+
+_is_secure_security_policy(policy) if {
+	some pattern in secure_security_policies
+	glob.match(pattern, [], policy.value)
+}


### PR DESCRIPTION
Fixes #11118

## Changes
- Replace hardcoded policy list with glob patterns to match all TLS 1.2+ policies (Policy-Min-TLS-1-2-*, Policy-Min-TLS-1-3-*)
- Add alue.is_known guard to skip unresolvable values
- Fixes false positive for Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08 (TLS 1.3 with FIPS)
- Follows the same pattern used in AWS-0005 for API Gateway security policies

## Testing
- Added test case for FIPS policy (	est_allow_use_secure_tls_policy_fips)
- Added test case for unresolvable values (	est_allow_unresolvable_tls_policy)
- Updated YAML examples with FIPS policy as good example