### PR TITLE
fix: use glob patterns for TLS policies in AWS-0126

### DIFF
--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
@@ -31,8 +31,14 @@ import rego.v1
 
 import data.lib.cloud.metadata
 
+secure_tls_policies := [
+	"Policy-Min-TLS-1-2-*",
+	"Policy-Min-TLS-1-3-*",
+]
+
 deny contains res if {
 	some domain in input.aws.elasticsearch.domains
+	value.is_known(domain.endpoint.tlspolicy)
 	not is_tls_policy_secure(domain)
 	res := result.new(
 		"Domain does not have a secure TLS policy.",
@@ -40,9 +46,7 @@ deny contains res if {
 	)
 }
 
-recommended_tls_policies := {
-	"Policy-Min-TLS-1-2-2019-07",
-	"Policy-Min-TLS-1-2-PFS-2023-10",
+is_tls_policy_secure(domain) if {
+	some pattern in secure_tls_policies
+	glob.match(pattern, [], domain.endpoint.tlspolicy.value)
 }
-
-is_tls_policy_secure(domain) if domain.endpoint.tlspolicy.value in recommended_tls_policies

--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy.yaml
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy.yaml
@@ -7,11 +7,21 @@ cloudformation:
           Properties:
             DomainEndpointOptions:
               TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
+    - |-
+      Resources:
+        GoodExample:
+          Type: AWS::Elasticsearch::Domain
+          Properties:
+            DomainEndpointOptions:
+              TLSSecurityPolicy: Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08
   bad:
     - |-
       Resources:
         BadExample:
           Type: AWS::Elasticsearch::Domain
+          Properties:
+            DomainEndpointOptions:
+              TLSSecurityPolicy: Policy-Min-TLS-1-0-2019-07
 terraform:
   links:
     - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain#tls_security_policy
@@ -21,6 +31,13 @@ terraform:
         domain_endpoint_options {
           enforce_https       = true
           tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+        }
+      }
+    - |-
+      resource "aws_elasticsearch_domain" "good_example_fips" {
+        domain_endpoint_options {
+          enforce_https       = true
+          tls_security_policy = "Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08"
         }
       }
   bad:

--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
@@ -17,6 +17,18 @@ test_allow_use_secure_tls_policy_2 if {
 	test.assert_empty(check.deny) with input as inp
 }
 
+test_allow_use_secure_tls_policy_fips if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_unresolvable_tls_policy if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
 test_deny_does_not_use_secure_tls_policy if {
 	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-0-2019-07"}}}]}}}
 


### PR DESCRIPTION
Fixes #11118

## Changes
- Replace hardcoded policy list with glob patterns to match all TLS 1.2+ policies (\Policy-Min-TLS-1-2-*\, \Policy-Min-TLS-1-3-*\)
- Add \alue.is_known\ guard to skip unresolvable values
- Fixes false positive for \Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08\ (TLS 1.3 with FIPS)
- Follows the same pattern used in AWS-0005 for API Gateway security policies

## Testing
- Added test case for FIPS policy (\	est_allow_use_secure_tls_policy_fips\)
- Added test case for unresolvable values (\	est_allow_unresolvable_tls_policy\)
- Updated YAML examples with FIPS policy as good example