### PR TITLE
fix(sam): use pattern matching for TLS policy check

### DIFF
--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
@@ -40,9 +40,12 @@ deny contains res if {
 	)
 }
 
-recommended_tls_policies := {
-	"Policy-Min-TLS-1-2-2019-07",
-	"Policy-Min-TLS-1-2-PFS-2023-10",
-}
+# Patterns rather than exact names, so policies added to the same families
+# are covered without a change here.
+secure_tls_policies := ["Policy-Min-TLS-1-2-*", "Policy-Min-TLS-1-3-*"]
 
-is_tls_policy_secure(domain) if domain.endpoint.tlspolicy.value in recommended_tls_policies
+is_tls_policy_secure(domain) if {
+	value.is_known(domain.endpoint.tlspolicy)
+	some p in secure_tls_policies
+	glob.match(p, [], domain.endpoint.tlspolicy.value)
+}

--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
@@ -17,8 +17,26 @@ test_allow_use_secure_tls_policy_2 if {
 	test.assert_empty(check.deny) with input as inp
 }
 
+test_allow_use_secure_tls_policy_fips if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_use_secure_tls_policy_tls13 if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-3-2025-01"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
 test_deny_does_not_use_secure_tls_policy if {
 	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-0-2019-07"}}}]}}}
+
+	test.assert_equal_message("Domain does not have a secure TLS policy.", check.deny) with input as inp
+}
+
+test_deny_unresolvable_value if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "unresolvable"}}}]}}}
 
 	test.assert_equal_message("Domain does not have a secure TLS policy.", check.deny) with input as inp
 }

--- a/checks/cloud/aws/sam/api_use_secure_tls_policy.rego
+++ b/checks/cloud/aws/sam/api_use_secure_tls_policy.rego
@@ -32,6 +32,10 @@ import rego.v1
 import data.lib.cloud.metadata
 import data.lib.cloud.value
 
+# Patterns rather than exact names, so policies added to the same families
+# are covered without a change here.
+secure_security_policies := ["TLS_1_2", "SecurityPolicy_TLS12_*_EDGE", "SecurityPolicy_TLS13_*"]
+
 deny contains res if {
 	some api in input.aws.sam.apis
 	not is_secure_tls_policy(api)
@@ -41,4 +45,8 @@ deny contains res if {
 	)
 }
 
-is_secure_tls_policy(api) if value.is_equal(api.domainconfiguration.securitypolicy, "TLS_1_2")
+is_secure_tls_policy(api) if {
+	value.is_known(api.domainconfiguration.securitypolicy)
+	some p in secure_security_policies
+	glob.match(p, [], api.domainconfiguration.securitypolicy.value)
+}

--- a/checks/cloud/aws/sam/api_use_secure_tls_policy_test.rego
+++ b/checks/cloud/aws/sam/api_use_secure_tls_policy_test.rego
@@ -16,3 +16,27 @@ test_allow_tls_v_1_2 if {
 
 	test.assert_empty(check.deny) with input as inp
 }
+
+test_allow_security_policy_tls12_edge if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_TLS12_2018_EDGE"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_security_policy_tls13 if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_TLS13_1_2_2021_06"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_security_policy_tls13_fips if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "SecurityPolicy_TLS13_1_3_FIPS_2025_09"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_deny_unresolvable_value if {
+	inp := {"aws": {"sam": {"apis": [{"domainconfiguration": {"securitypolicy": {"value": "unresolvable"}}}]}}}
+
+	test.assert_count(check.deny, 1) with input as inp
+}


### PR DESCRIPTION
## Description

Fix false positive in AWS-0112 when using newer TLS policies like SecurityPolicy_TLS13 and SecurityPolicy_TLS12 EDGE.

## Problem

The check only accepted the literal value TLS_1_2 as a secure policy, rejecting all other secure policies.

## Fix

Use the same pattern matching approach as AWS-0005 (API Gateway):
- TLS_1_2 (exact match)
- SecurityPolicy_TLS12_*_EDGE (pattern)
- SecurityPolicy_TLS13_* (pattern)

This covers all 12 valid policies and automatically covers future policies of the same families.

Also add value.is_known guard to prevent false positives on unresolvable values.

## Related Issues

Fixes #11117
