### PR TITLE
fix(aws): correct ELB weak TLS policy detection

### DIFF
--- a/checks/cloud/aws/elb/use_secure_tls_policy.rego
+++ b/checks/cloud/aws/elb/use_secure_tls_policy.rego
@@ -32,12 +32,13 @@ outdated_ssl_policies := {
 	"ELBSecurityPolicy-2016-08",
 	"ELBSecurityPolicy-FS-2018-06",
 	"ELBSecurityPolicy-FS-1-1-2019-08",
-	"ELBSecurityPolicy-TLS-1-0-2015-04",
 	"ELBSecurityPolicy-TLS-1-1-2017-01",
+	"ELBSecurityPolicy-TLS13-1-0-FIPS-2023-04",
+	"ELBSecurityPolicy-TLS13-1-0-FIPS-PQ-2025-09",
+	"ELBSecurityPolicy-TLS13-1-0-PQ-2025-09",
 	"ELBSecurityPolicy-TLS13-1-0-2021-06",
+	"ELBSecurityPolicy-TLS13-1-1-FIPS-2023-04",
 	"ELBSecurityPolicy-TLS13-1-1-2021-06",
-	"ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06",
-	"ELBSecurityPolicy-TLS13-1-2-Ext2-2021-06",
 }
 
 deny contains res if {

--- a/checks/cloud/aws/elb/use_secure_tls_policy_test.rego
+++ b/checks/cloud/aws/elb/use_secure_tls_policy_test.rego
@@ -5,23 +5,38 @@ import rego.v1
 import data.builtin.aws.elb.aws0047 as check
 import data.lib.test
 
-test_deny_with_outdated_tls_policy if {
-	inp := {"aws": {"elb": {"loadbalancers": [{"listeners": [{"tlspolicy": {"value": "ELBSecurityPolicy-TLS-1-0-2015-04"}}]}]}}}
+test_deny_with_outdated_tls_policies if {
+	policies := {
+		"ELBSecurityPolicy-TLS13-1-0-FIPS-2023-04",
+		"ELBSecurityPolicy-TLS13-1-0-FIPS-PQ-2025-09",
+		"ELBSecurityPolicy-TLS13-1-0-PQ-2025-09",
+		"ELBSecurityPolicy-TLS13-1-1-FIPS-2023-04",
+	}
 
-	test.assert_equal_message("Listener uses an outdated TLS policy.", check.deny) with input as inp
+	every policy in policies {
+		inp := {"aws": {"elb": {"loadbalancers": [{"listeners": [{"tlspolicy": {"value": policy}}]}]}}}
+		test.assert_equal_message("Listener uses an outdated TLS policy.", check.deny) with input as inp
+	}
 }
 
 test_allow_not_managed if {
 	inp := {"aws": {"elb": {"loadbalancers": [{
 		"__defsec_metadata": {"managed": false},
-		"listeners": [{"tlspolicy": {"value": "ELBSecurityPolicy-TLS-1-0-2015-04"}}],
+		"listeners": [{"tlspolicy": {"value": "ELBSecurityPolicy-TLS13-1-0-FIPS-2023-04"}}],
 	}]}}}
 
 	test.assert_empty(check.deny) with input as inp
 }
 
-test_allow_with_actual_tls_policy if {
-	inp := {"aws": {"elb": {"loadbalancers": [{"listeners": [{"tlspolicy": {"value": "ELBSecurityPolicy-TLS-1-2-2017-01"}}]}]}}}
+test_allow_with_secure_tls_policies if {
+	policies := {
+		"ELBSecurityPolicy-TLS-1-2-2017-01",
+		"ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06",
+		"ELBSecurityPolicy-TLS13-1-2-Ext2-2021-06",
+	}
 
-	test.assert_empty(check.deny) with input as inp
+	every policy in policies {
+		inp := {"aws": {"elb": {"loadbalancers": [{"listeners": [{"tlspolicy": {"value": policy}}]}]}}}
+		test.assert_empty(check.deny) with input as inp
+	}
 }


### PR DESCRIPTION
## Description

Addresses https://github.com/aquasecurity/trivy/issues/11121.

AWS-0047 omitted four predefined ELB policies that permit TLS 1.0 or 1.1 and incorrectly classified two TLS 1.2 Ext policies as outdated.

## Changes

- Add the missing TLS 1.0/1.1 FIPS and post-quantum policies.
- Treat the TLS 1.2 Ext1/Ext2 policies as secure.
- Add table-driven regression coverage for weak and secure policies.

## Testing

- `go run ./cmd/opa test --explain=fails lib/ checks/ examples/ --ignore '*.yaml'`
- Result: 1943/1943 tests passed.