### PR TITLE
fix(AWS-0126): allow secure TLS policies and ignore unresolvable values

### DIFF
--- a/avd_docs/aws/elasticsearch/AWS-0126/Terraform.md
+++ b/avd_docs/aws/elasticsearch/AWS-0126/Terraform.md
@@ -9,6 +9,14 @@ resource "aws_elasticsearch_domain" "good_example" {
   }
 }
 ```
+```hcl
+resource "aws_elasticsearch_domain" "good_example_fips" {
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08"
+  }
+}
+```
 
 #### Remediation Links
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain#tls_security_policy

--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
@@ -30,19 +30,27 @@ package builtin.aws.elasticsearch.aws0126
 import rego.v1
 
 import data.lib.cloud.metadata
+import data.lib.cloud.value
 
 deny contains res if {
 	some domain in input.aws.elasticsearch.domains
-	not is_tls_policy_secure(domain)
+	non_compliant_tls_policy(domain)
 	res := result.new(
 		"Domain does not have a secure TLS policy.",
 		metadata.obj_by_path(domain, ["endpoint", "tlspolicy"]),
 	)
 }
 
-recommended_tls_policies := {
-	"Policy-Min-TLS-1-2-2019-07",
-	"Policy-Min-TLS-1-2-PFS-2023-10",
+# Patterns rather than exact names, so policies added to the same families
+# (e.g. future FIPS/PFS variants) are covered without a change here.
+secure_tls_policies := ["Policy-Min-TLS-1-2-*", "Policy-Min-TLS-1-3-*"]
+
+non_compliant_tls_policy(domain) if {
+	value.is_known(domain.endpoint.tlspolicy)
+	not is_tls_policy_secure(domain.endpoint.tlspolicy.value)
 }
 
-is_tls_policy_secure(domain) if domain.endpoint.tlspolicy.value in recommended_tls_policies
+is_tls_policy_secure(policy) if {
+	some p in secure_tls_policies
+	glob.match(p, [], policy)
+}

--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy.yaml
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy.yaml
@@ -23,6 +23,13 @@ terraform:
           tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
         }
       }
+    - |-
+      resource "aws_elasticsearch_domain" "good_example_fips" {
+        domain_endpoint_options {
+          enforce_https       = true
+          tls_security_policy = "Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08"
+        }
+      }
   bad:
     - |-
       resource "aws_elasticsearch_domain" "bad_example" {

--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
@@ -17,8 +17,20 @@ test_allow_use_secure_tls_policy_2 if {
 	test.assert_empty(check.deny) with input as inp
 }
 
+test_allow_use_secure_tls_policy_fips if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
 test_deny_does_not_use_secure_tls_policy if {
 	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-0-2019-07"}}}]}}}
 
 	test.assert_equal_message("Domain does not have a secure TLS policy.", check.deny) with input as inp
+}
+
+test_allow_tls_policy_is_unresolvable if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "", "unresolvable": true}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
 }


### PR DESCRIPTION
The check only accepted two exact TLS policy names, so the newer and stricter `Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08` policy was reported as outdated. It also lacked a `value.is_known` guard, so an unresolved value produced a finding.

Match on `Policy-Min-TLS-1-2-*` and `Policy-Min-TLS-1-3-*` patterns instead of an exact list, so future policies in the same families are covered without a further change, and guard on `value.is_known`, matching the pattern already used by `AWS-0005` and the recently-fixed Azure/GCP TLS checks (`AZU-0026`, `GCP-0039`).

Closes aquasecurity/trivy#11118.

## Testing

- Added test cases for the previously-false-flagged FIPS policy and for an unresolvable value, alongside the existing test cases.
- Added a `good` Terraform example demonstrating the FIPS policy and regenerated the docs.
- `make rego` passes clean (fmt, schema check, lint, tests, docs) — 1945/1945 tests pass.