### PR TITLE
fix(azure): recognize the Internet service tag in NSG rules

### DIFF
--- a/checks/cloud/azure/network/disable_rdp_from_internet_test.rego
+++ b/checks/cloud/azure/network/disable_rdp_from_internet_test.rego
@@ -20,6 +20,22 @@ test_deny_inbound_rule_allows_rdp_access_from_internet if {
 	count(res) == 1
 }
 
+test_deny_inbound_rule_allows_rdp_access_from_internet_service_tag if {
+	inp := {"azure": {"network": {"securitygroups": [{"rules": [{
+		"outbound": {"value": false},
+		"allow": {"value": true},
+		"protocol": {"value": "Tcp"},
+		"sourceaddresses": [{"value": "Internet"}],
+		"destinationports": [{
+			"start": {"value": 3310},
+			"end": {"value": 3390},
+		}],
+	}]}]}}}
+
+	res := check.deny with input as inp
+	count(res) == 1
+}
+
 test_allow_inbound_rule_allow_rdp_access_from_specific_address if {
 	inp := {"azure": {"network": {"securitygroups": [{"rules": [{
 		"outbound": {"value": false},

--- a/checks/cloud/azure/network/no_public_egress_test.rego
+++ b/checks/cloud/azure/network/no_public_egress_test.rego
@@ -26,6 +26,17 @@ test_deny_outbound_rule_with_public_destination_address if {
 	count(res) == 1
 }
 
+test_deny_outbound_rule_with_internet_service_tag_destination_address if {
+	inp := {"azure": {"network": {"securitygroups": [{"rules": [{
+		"allow": {"value": true},
+		"outbound": {"value": true},
+		"destinationaddresses": [{"value": "Internet"}],
+	}]}]}}}
+
+	res := check.deny with input as inp
+	count(res) == 1
+}
+
 test_allow_outbound_rule_with_private_destination_address if {
 	inp := {"azure": {"network": {"securitygroups": [{"rules": [{
 		"allow": {"value": true},

--- a/checks/cloud/azure/network/no_public_ingress.yaml
+++ b/checks/cloud/azure/network/no_public_ingress.yaml
@@ -24,3 +24,9 @@ terraform:
         source_address_prefix = "0.0.0.0/0"
         access                = "Allow"
       }
+    - |-
+      resource "azurerm_network_security_rule" "internet_service_tag" {
+        direction             = "Inbound"
+        source_address_prefix = "Internet" // service tag for the whole public internet
+        access                = "Allow"
+      }

--- a/checks/cloud/azure/network/no_public_ingress_test.rego
+++ b/checks/cloud/azure/network/no_public_ingress_test.rego
@@ -15,6 +15,17 @@ test_deny_inbound_rule_with_wildcard_source_address if {
 	count(res) == 1
 }
 
+test_deny_inbound_rule_with_internet_service_tag_source_address if {
+	inp := {"azure": {"network": {"securitygroups": [{"rules": [{
+		"allow": {"value": true},
+		"outbound": {"value": false},
+		"sourceaddresses": [{"value": "Internet"}],
+	}]}]}}}
+
+	res := check.deny with input as inp
+	count(res) == 1
+}
+
 test_allow_inbound_rule_with_private_source_address if {
 	inp := {"azure": {"network": {"securitygroups": [{"rules": [{
 		"allow": {"value": true},

--- a/checks/cloud/azure/network/sensitive_port_exposed_to_network_test.rego
+++ b/checks/cloud/azure/network/sensitive_port_exposed_to_network_test.rego
@@ -36,6 +36,22 @@ test_deny_sensitive_port_range_exposed if {
 	count(res) > 0
 }
 
+test_deny_sensitive_port_exposed_to_internet_service_tag if {
+	inp := {"azure": {"network": {"securitygroups": [{"rules": [{
+		"allow": {"value": true},
+		"outbound": {"value": false},
+		"protocol": {"value": "TCP"},
+		"destinationports": [{
+			"start": {"value": 23},
+			"end": {"value": 23},
+		}],
+		"sourceaddresses": [{"value": "Internet"}],
+	}]}]}}}
+
+	res := check.deny with input as inp
+	count(res) == 1
+}
+
 test_allow_non_sensitive_port if {
 	inp := {"azure": {"network": {"securitygroups": [{"rules": [{
 		"allow": {"value": true},

--- a/checks/cloud/azure/network/ssh_blocked_from_internet_test.rego
+++ b/checks/cloud/azure/network/ssh_blocked_from_internet_test.rego
@@ -20,6 +20,22 @@ test_deny_inbound_rule_allows_rdp_access_from_internet if {
 	count(res) == 1
 }
 
+test_deny_inbound_rule_allows_ssh_access_from_internet_service_tag if {
+	inp := {"azure": {"network": {"securitygroups": [{"rules": [{
+		"outbound": {"value": false},
+		"allow": {"value": true},
+		"protocol": {"value": "Tcp"},
+		"sourceaddresses": [{"value": "Internet"}],
+		"destinationports": [{
+			"start": {"value": 22},
+			"end": {"value": 22},
+		}],
+	}]}]}}}
+
+	res := check.deny with input as inp
+	count(res) == 1
+}
+
 test_allow_inbound_rule_allow_rdp_access_from_specific_address if {
 	inp := {"azure": {"network": {"securitygroups": [{"rules": [{
 		"outbound": {"value": false},

--- a/lib/cloud/net.rego
+++ b/lib/cloud/net.rego
@@ -14,6 +14,11 @@ rdp_port := 3389
 
 all_ips := {"0.0.0.0/0", "0000:0000:0000:0000:0000:0000:0000:0000/0", "::/0", "*"}
 
+# Some providers accept a keyword in place of a CIDR. Azure network security groups
+# use the "Internet" service tag to mean the public internet address space.
+# https://learn.microsoft.com/en-us/azure/virtual-network/service-tags-overview
+all_ips_keywords := {"internet", "any"}
+
 # "-1" or "all" equivalent to all protocols
 # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AuthorizeSecurityGroupIngress.html
 # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall#protocol
@@ -50,6 +55,8 @@ is_port_range_include(from, to, port) if {
 
 # check if CIDR defines an IP block containing all possible IP addresses
 cidr_allows_all_ips(cidr) if cidr in all_ips
+
+cidr_allows_all_ips(cidr) if lower(cidr) in all_ips_keywords
 
 protocol(v) := lower(v) if is_string(v)
 

--- a/lib/cloud/net_test.rego
+++ b/lib/cloud/net_test.rego
@@ -1,0 +1,26 @@
+package lib.net_test
+
+import rego.v1
+
+import data.lib.net
+
+test_cidr_allows_all_ips_for_cidr if {
+	net.cidr_allows_all_ips("0.0.0.0/0")
+	net.cidr_allows_all_ips("::/0")
+	net.cidr_allows_all_ips("*")
+}
+
+test_cidr_allows_all_ips_for_keyword if {
+	net.cidr_allows_all_ips("internet")
+	net.cidr_allows_all_ips("Internet")
+	net.cidr_allows_all_ips("INTERNET")
+	net.cidr_allows_all_ips("any")
+	net.cidr_allows_all_ips("Any")
+}
+
+test_cidr_allows_all_ips_for_restricted_address if {
+	not net.cidr_allows_all_ips("10.0.0.0/16")
+	not net.cidr_allows_all_ips("1.2.3.4/32")
+	not net.cidr_allows_all_ips("VirtualNetwork")
+	not net.cidr_allows_all_ips("AzureCloud")
+}


### PR DESCRIPTION
The Azure NSG checks matched only literal CIDR values, so a rule with `source_address_prefix = "Internet"` looked restricted and nothing was reported, even though the rule allows the whole public internet. The Go implementation handled this keyword, but it was lost when these checks moved to Rego in #202.

Now the shared helper also accepts the `internet` and `any` keywords in any case, so the five affected checks (AZU-0047, AZU-0048, AZU-0050, AZU-0051 and AZU-0074) behave the same for `Internet` and for `0.0.0.0/0`.

Fixes https://github.com/aquasecurity/trivy/issues/11187

Before:
```console
trivy conf . -q

Report Summary

┌────────┬───────────┬───────────────────┐
│ Target │   Type    │ Misconfigurations │
├────────┼───────────┼───────────────────┤
│ .      │ terraform │         0         │
└────────┴───────────┴───────────────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)
```


After:
```console
trivy conf . -q --checks-bundle-repository localhost:5111/trivy-checks:latest --cache-dir ./cache | grep AZU-\*
AZU-0047 (CRITICAL): Security group rule allows unrestricted ingress from any IP address.
AZU-0048 (CRITICAL): Security group rule allows unrestricted ingress to RDP port from any IP address.
AZU-0050 (CRITICAL): Security group rule allows unrestricted ingress to SSH port from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 110 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 135 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 139 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 143 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 1433 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 1521 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 161 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 20 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 21 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 23 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 25 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 3306 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 389 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 53 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 5432 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 636 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 6379 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 993 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 995 from any IP address.
```