### PR TITLE
fix(AZU-0074): report one finding per rule instead of one per port

### DIFF
--- a/checks/cloud/azure/network/sensitive_port_exposed_to_network.rego
+++ b/checks/cloud/azure/network/sensitive_port_exposed_to_network.rego
@@ -61,18 +61,35 @@ deny contains res if {
 	rule.allow.value
 	not rule.outbound.value
 	lower(rule.protocol.value) != "icmp"
-	some ports in rule.destinationports
-	some sensitive_port in sensitive_ports
-	net.is_port_range_include(ports.start.value, ports.end.value, sensitive_port)
 	some ip in rule.sourceaddresses
 	net.cidr_allows_all_ips(ip.value)
+
+	exposed := sort({sensitive_port |
+		some ports in rule.destinationports
+		some sensitive_port in sensitive_ports
+		net.is_port_range_include(ports.start.value, ports.end.value, sensitive_port)
+	})
+	count(exposed) > 0
+
 	res := result.new(
-		sprintf("Security group rule allows unrestricted ingress to sensitive port %d from any IP address.", [sensitive_port]),
+		sprintf("Security group rule allows unrestricted ingress to sensitive %s from any IP address.", [exposed_ports(exposed)]),
 		ip,
 	)
 }
 
-port_range_includes(from, to, port) if {
-	from.value <= port
-	port <= to.value
+max_listed_ports := 5
+
+exposed_ports(ports) := sprintf("port %d", [ports[0]]) if count(ports) == 1
+
+exposed_ports(ports) := sprintf("ports %s", [format_ports(ports)]) if count(ports) > 1
+
+format_ports(ports) := join_ports(ports) if count(ports) <= max_listed_ports
+
+format_ports(ports) := sprintf("%s and %d more", [
+	join_ports(array.slice(ports, 0, max_listed_ports)),
+	count(ports) - max_listed_ports,
+]) if {
+	count(ports) > max_listed_ports
 }
+
+join_ports(ports) := concat(", ", [format_int(port, 10) | some port in ports])

--- a/checks/cloud/azure/network/sensitive_port_exposed_to_network_test.rego
+++ b/checks/cloud/azure/network/sensitive_port_exposed_to_network_test.rego
@@ -18,6 +18,7 @@ test_deny_sensitive_port_exposed_to_all if {
 
 	res := check.deny with input as inp
 	count(res) == 1
+	res[_].msg == "Security group rule allows unrestricted ingress to sensitive port 23 from any IP address."
 }
 
 test_deny_sensitive_port_range_exposed if {
@@ -33,7 +34,25 @@ test_deny_sensitive_port_range_exposed if {
 	}]}]}}}
 
 	res := check.deny with input as inp
-	count(res) > 0
+	count(res) == 1
+	res[_].msg == "Security group rule allows unrestricted ingress to sensitive ports 20, 21, 23, 25 from any IP address."
+}
+
+test_deny_all_ports_exposed if {
+	inp := {"azure": {"network": {"securitygroups": [{"rules": [{
+		"allow": {"value": true},
+		"outbound": {"value": false},
+		"protocol": {"value": "TCP"},
+		"destinationports": [{
+			"start": {"value": 0},
+			"end": {"value": 65535},
+		}],
+		"sourceaddresses": [{"value": "*"}],
+	}]}]}}}
+
+	res := check.deny with input as inp
+	count(res) == 1
+	res[_].msg == "Security group rule allows unrestricted ingress to sensitive ports 20, 21, 23, 25, 53 and 14 more from any IP address."
 }
 
 test_allow_non_sensitive_port if {


### PR DESCRIPTION
A rule that opens a wide port range matched every sensitive port separately, so a single rule with `destination_port_range = "*"` produced 19 findings. They all pointed at the same address on the same line and differed only in the message text.

Now such a rule gives one finding per source address, with the exposed ports listed in the message.

Before:

```console
trivy conf main.tf -q | grep AZU-\*                                                  
AZU-0047 (CRITICAL): Security group rule allows unrestricted ingress from any IP address.
AZU-0048 (CRITICAL): Security group rule allows unrestricted ingress to RDP port from any IP address.
AZU-0050 (CRITICAL): Security group rule allows unrestricted ingress to SSH port from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 110 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 135 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 139 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 143 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 1433 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 1521 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 161 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 20 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 21 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 23 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 25 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 3306 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 389 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 53 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 5432 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 636 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 6379 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 993 from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive port 995 from any IP address.
```

After:
```console
trivy conf main.tf -q --checks-bundle-repository localhost:5111/trivy-checks:latest --cache-dir ./cache | grep AZU-\*
AZU-0047 (CRITICAL): Security group rule allows unrestricted ingress from any IP address.
AZU-0048 (CRITICAL): Security group rule allows unrestricted ingress to RDP port from any IP address.
AZU-0050 (CRITICAL): Security group rule allows unrestricted ingress to SSH port from any IP address.
AZU-0074 (HIGH): Security group rule allows unrestricted ingress to sensitive ports 20, 21, 23, 25, 53 and 14 more from any IP address.
```

