### PR TITLE
aws/elasticsearch: accept RFC9151-FIPS-2024-08 as a secure TLS policy…

### DIFF
--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
@@ -43,6 +43,7 @@ deny contains res if {
 recommended_tls_policies := {
 	"Policy-Min-TLS-1-2-2019-07",
 	"Policy-Min-TLS-1-2-PFS-2023-10",
+	"Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08",
 }
 
 is_tls_policy_secure(domain) if domain.endpoint.tlspolicy.value in recommended_tls_policies

--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
@@ -17,6 +17,12 @@ test_allow_use_secure_tls_policy_2 if {
 	test.assert_empty(check.deny) with input as inp
 }
 
+test_allow_use_secure_tls_policy_3 if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
 test_deny_does_not_use_secure_tls_policy if {
 	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-0-2019-07"}}}]}}}
 


### PR DESCRIPTION
… (AWS-0126)

AWS-0126 flagged OpenSearch/Elasticsearch domains using Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08 as having an outdated TLS policy. That value is one of the four TLSSecurityPolicy options AWS accepts and is the strictest (TLS 1.2+, FIPS / RFC 9151), so treating it as insecure is a false positive.

Add it to recommended_tls_policies and cover it with a test.