### PR TITLE
refactor(rego): move the result parsing from Trivy

### DIFF
--- a/internal/rego/parse.go
+++ b/internal/rego/parse.go
@@ -1,0 +1,129 @@
+package rego
+
+import (
+	"encoding/json"
+	"iter"
+
+	"github.com/open-policy-agent/opa/v1/rego"
+)
+
+// Result is a finding reported by a check, built by the result.new built-in.
+type Result struct {
+	Message      string
+	Filepath     string
+	Resource     string
+	StartLine    int
+	EndLine      int
+	SourcePrefix string
+	Explicit     bool
+	Managed      bool
+	FSKey        string
+	Parent       *Result
+}
+
+// ParseResults reads back the findings the checks reported. A rule that builds a set
+// gives all of its findings in one expression, a complete rule gives a single one.
+func ParseResults(rs rego.ResultSet) iter.Seq[Result] {
+	return func(yield func(Result) bool) {
+		for _, result := range rs {
+			for _, expression := range result.Expressions {
+				values, ok := expression.Value.([]any)
+				if !ok {
+					values = []any{expression.Value}
+				}
+
+				for _, value := range values {
+					if !yield(parseResult(value)) {
+						return
+					}
+				}
+			}
+		}
+	}
+}
+
+// The checks here always report the result.new object. A plain message, or a message
+// next to the object, is read for backward compatibility.
+func parseResult(raw any) Result {
+	var result Result
+	result.Managed = true
+	switch val := raw.(type) {
+	case []any:
+		var msg string
+		for _, item := range val {
+			switch raw := item.(type) {
+			case map[string]any:
+				result = parseCause(raw)
+			case string:
+				msg = raw
+			}
+		}
+		result.Message = msg
+	case string:
+		result.Message = val
+	case map[string]any:
+		result = parseCause(val)
+	default:
+		result.Message = "Rego check resulted in DENY"
+	}
+	return result
+}
+
+func parseCause(cause map[string]any) Result {
+	var result Result
+	result.Managed = true
+	if msg, ok := cause[resultKeyMessage]; ok {
+		result.Message = parseString(msg)
+	}
+	if filepath, ok := cause[resultKeyFilepath]; ok {
+		result.Filepath = parseString(filepath)
+	}
+	if fskey, ok := cause[resultKeyFSKey]; ok {
+		result.FSKey = parseString(fskey)
+	}
+	if resource, ok := cause[resultKeyResource]; ok {
+		result.Resource = parseString(resource)
+	}
+	if start, ok := cause[resultKeyStartLine]; ok {
+		result.StartLine = parseLineNumber(start)
+	}
+	if end, ok := cause[resultKeyEndLine]; ok {
+		result.EndLine = parseLineNumber(end)
+	}
+	if prefix, ok := cause[resultKeySourcePrefix]; ok {
+		result.SourcePrefix = parseString(prefix)
+	}
+	if explicit, ok := cause[resultKeyExplicit]; ok {
+		if set, ok := explicit.(bool); ok {
+			result.Explicit = set
+		}
+	}
+	if managed, ok := cause[resultKeyManaged]; ok {
+		if set, ok := managed.(bool); ok {
+			result.Managed = set
+		}
+	}
+	if parent, ok := cause[resultKeyParent]; ok {
+		if m, ok := parent.(map[string]any); ok {
+			parentResult := parseCause(m)
+			result.Parent = &parentResult
+		}
+	}
+	return result
+}
+
+func parseString(raw any) string {
+	s, _ := raw.(string)
+	return s
+}
+
+// OPA keeps the text of a number instead of turning it into a float, so that large
+// integers survive the conversion.
+func parseLineNumber(raw any) int {
+	num, ok := raw.(json.Number)
+	if !ok {
+		return 0
+	}
+	n, _ := num.Int64()
+	return int(n)
+}

--- a/internal/rego/parse_test.go
+++ b/internal/rego/parse_test.go
@@ -1,0 +1,59 @@
+package rego
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseResult(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      any
+		expected Result
+	}{
+		{
+			name:     "message only",
+			raw:      "something is wrong",
+			expected: Result{Message: "something is wrong", Managed: true},
+		},
+		{
+			name: "result object",
+			raw: map[string]any{
+				"msg":       "something is wrong",
+				"startline": json.Number("7"),
+				"filepath":  "main.tf",
+			},
+			expected: Result{
+				Message:   "something is wrong",
+				Filepath:  "main.tf",
+				StartLine: 7,
+				Managed:   true,
+			},
+		},
+		{
+			name: "message next to a result object",
+			raw: []any{
+				"something is wrong",
+				map[string]any{"filepath": "main.tf"},
+			},
+			expected: Result{
+				Message:  "something is wrong",
+				Filepath: "main.tf",
+				Managed:  true,
+			},
+		},
+		{
+			name:     "nothing to read",
+			raw:      true,
+			expected: Result{Message: "Rego check resulted in DENY", Managed: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, parseResult(tt.raw))
+		})
+	}
+}

--- a/internal/rego/result.go
+++ b/internal/rego/result.go
@@ -9,7 +9,6 @@ import (
 )
 
 // Keys of the object returned by the result.new built-in.
-// Trivy reads the object back by these keys, so they must be changed in both projects.
 const (
 	resultKeyMessage      = "msg"
 	resultKeyStartLine    = "startline"

--- a/pkg/rego/result.go
+++ b/pkg/rego/result.go
@@ -1,0 +1,17 @@
+package rego
+
+import (
+	"iter"
+
+	"github.com/aquasecurity/trivy-checks/internal/rego"
+	opa "github.com/open-policy-agent/opa/v1/rego"
+)
+
+// Result is a finding reported by a check, built by the result.new built-in.
+type Result = rego.Result
+
+// ParseResults reads back the findings the checks reported. A rule that builds a set
+// gives all of its findings in one expression, a complete rule gives a single one.
+func ParseResults(rs opa.ResultSet) iter.Seq[Result] {
+	return rego.ParseResults(rs)
+}

--- a/pkg/rego/result_test.go
+++ b/pkg/rego/result_test.go
@@ -1,0 +1,70 @@
+package rego
+
+import (
+	"slices"
+	"testing"
+
+	opa "github.com/open-policy-agent/opa/v1/rego"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The check builds the result with result.new and this package reads it back, so the
+// test goes through OPA to cover both halves of the contract at once.
+func TestParseResults(t *testing.T) {
+	RegisterBuiltins()
+
+	const module = `package test
+
+import rego.v1
+
+deny contains res if {
+	res := result.new("message", input)
+}
+`
+
+	rs, err := opa.New(
+		opa.Query("data.test.deny"),
+		opa.Module("test.rego", module),
+		opa.Input(map[string]any{
+			"__defsec_metadata": map[string]any{
+				"startline":    3,
+				"endline":      5,
+				"sourceprefix": "git",
+				"filepath":     "main.tf",
+				"explicit":     true,
+				"managed":      false,
+				"fskey":        "fs-key",
+				"resource":     "aws_s3_bucket.this",
+				"parent": map[string]any{
+					"startline": 1,
+					"endline":   10,
+					"filepath":  "module.tf",
+				},
+			},
+		}),
+	).Eval(t.Context())
+	require.NoError(t, err)
+
+	expected := []Result{
+		{
+			Message:      "message",
+			Filepath:     "main.tf",
+			Resource:     "aws_s3_bucket.this",
+			StartLine:    3,
+			EndLine:      5,
+			SourcePrefix: "git",
+			Explicit:     true,
+			Managed:      false,
+			FSKey:        "fs-key",
+			Parent: &Result{
+				Filepath:  "module.tf",
+				StartLine: 1,
+				EndLine:   10,
+				Managed:   true,
+			},
+		},
+	}
+
+	assert.Equal(t, expected, slices.Collect(ParseResults(rs)))
+}


### PR DESCRIPTION
The `result.new` built-in lives here, but reading its object back lived in Trivy, so the two halves of the same contract sat in different repositories and could only be tested apart. Reading now happens here too, next to the built-in that builds the object, and Trivy takes the parsed result and fills in what only it knows.