### PR TITLE
fix(aws-elb): add missing TLS 1.0/1.1 policies to the outdated set

### DIFF
--- a/checks/cloud/aws/elb/use_secure_tls_policy.rego
+++ b/checks/cloud/aws/elb/use_secure_tls_policy.rego
@@ -35,7 +35,11 @@ outdated_ssl_policies := {
 	"ELBSecurityPolicy-TLS-1-0-2015-04",
 	"ELBSecurityPolicy-TLS-1-1-2017-01",
 	"ELBSecurityPolicy-TLS13-1-0-2021-06",
+	"ELBSecurityPolicy-TLS13-1-0-FIPS-2023-04",
+	"ELBSecurityPolicy-TLS13-1-0-FIPS-PQ-2025-09",
+	"ELBSecurityPolicy-TLS13-1-0-PQ-2025-09",
 	"ELBSecurityPolicy-TLS13-1-1-2021-06",
+	"ELBSecurityPolicy-TLS13-1-1-FIPS-2023-04",
 	"ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06",
 	"ELBSecurityPolicy-TLS13-1-2-Ext2-2021-06",
 }


### PR DESCRIPTION
Closes aquasecurity/trivy#11121.

Four predefined policies permit TLS 1.0 or TLS 1.1 but were not in the `outdated_ssl_policies` set: `ELBSecurityPolicy-TLS13-1-0-FIPS-2023-04`, `-TLS13-1-0-FIPS-PQ-2025-09`, `-TLS13-1-0-PQ-2025-09`, and `-TLS13-1-1-FIPS-2023-04`.

AWS documentation flags all policies with TLS 1.0 or 1.1 as outdated. The four new entries join the existing eleven; the rule now matches AWS guidance.