### PR TITLE
fix(aws): match Elasticsearch TLS policy families instead of exact names

### DIFF
--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
@@ -30,9 +30,11 @@ package builtin.aws.elasticsearch.aws0126
 import rego.v1
 
 import data.lib.cloud.metadata
+import data.lib.cloud.value
 
 deny contains res if {
 	some domain in input.aws.elasticsearch.domains
+	value.is_known(domain.endpoint.tlspolicy)
 	not is_tls_policy_secure(domain)
 	res := result.new(
 		"Domain does not have a secure TLS policy.",
@@ -40,9 +42,9 @@ deny contains res if {
 	)
 }
 
-recommended_tls_policies := {
-	"Policy-Min-TLS-1-2-2019-07",
-	"Policy-Min-TLS-1-2-PFS-2023-10",
-}
+recommended_tls_policies := ["Policy-Min-TLS-1-2-*", "Policy-Min-TLS-1-3-*"]
 
-is_tls_policy_secure(domain) if domain.endpoint.tlspolicy.value in recommended_tls_policies
+is_tls_policy_secure(domain) if {
+	some policy in recommended_tls_policies
+	glob.match(policy, [], domain.endpoint.tlspolicy.value)
+}

--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy.yaml
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy.yaml
@@ -7,6 +7,13 @@ cloudformation:
           Properties:
             DomainEndpointOptions:
               TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
+    - |-
+      Resources:
+        GoodExample:
+          Type: AWS::Elasticsearch::Domain
+          Properties:
+            DomainEndpointOptions:
+              TLSSecurityPolicy: Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08
   bad:
     - |-
       Resources:
@@ -21,6 +28,13 @@ terraform:
         domain_endpoint_options {
           enforce_https       = true
           tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+        }
+      }
+    - |-
+      resource "aws_elasticsearch_domain" "good_example" {
+        domain_endpoint_options {
+          enforce_https       = true
+          tls_security_policy = "Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08"
         }
       }
   bad:

--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
@@ -17,6 +17,18 @@ test_allow_use_secure_tls_policy_2 if {
 	test.assert_empty(check.deny) with input as inp
 }
 
+test_allow_use_secure_tls_policy_newest if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_use_secure_tls_policy_unresolvable if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "", "unresolvable": true}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
 test_deny_does_not_use_secure_tls_policy if {
 	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-0-2019-07"}}}]}}}
 


### PR DESCRIPTION
## Summary

Fixes the false positive in AWS-0126 (`aws-elasticsearch-use-secure-tls-policy`): `Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08` (the strictest valid TLS policy, TLS 1.3 with FIPS) was reported as outdated because the check compared against two hard-coded names.

## Changes

- `use_secure_tls_policy.rego`: match the `Policy-Min-TLS-1-2-*` and `Policy-Min-TLS-1-3-*` families with `glob.match` (same approach as AWS-0005) instead of an exact-name allowlist, and guard with `value.is_known` so an unresolvable value no longer produces a finding.
- `use_secure_tls_policy_test.rego`: add regression tests for the FIPS policy and for an unresolvable value.
- `use_secure_tls_policy.yaml`: add the FIPS policy to the good examples (CloudFormation + Terraform).

Behavior matrix after the change (matches the issue's expectation):

| tlspolicy | result |
| --- | --- |
| `Policy-Min-TLS-1-0-2019-07` | finding |
| `Policy-Min-TLS-1-2-2019-07` / `-PFS-2023-10` / `-RFC9151-FIPS-2024-08` | no finding |
| missing | finding (unchanged) |
| unresolvable | no finding |

## Verification

- `go run ./cmd/opa test --explain=fails lib/ checks/ --ignore '*.yaml'`: 1939/1939 PASS
- `go run ./cmd/opa check lib checks --strict --v0-v1 -s schemas/latest`: no errors
- `regal lint lib checks --config-file .regal/config.yaml --timeout 5m`: 0 violations (`regal test .regal/rules`: 4/4)
- `go run ./cmd/opa fmt -w` on changed rego files: no further changes
- `go test ./...`: `TestCheckIDsUnique`/`TestInputsConformToSchema` fail on this machine with `open checks\.manifest: file does not exist` — a pre-existing Windows-only issue (OPA loader converts embed paths to backslashes), reproduced identically on a clean checkout without these changes.

Fixes aquasecurity/trivy#11118