### PR TITLE
fix(aws): accept modern Elasticsearch TLS policies

### DIFF
--- a/avd_docs/aws/elasticsearch/AWS-0126/Terraform.md
+++ b/avd_docs/aws/elasticsearch/AWS-0126/Terraform.md
@@ -9,6 +9,14 @@ resource "aws_elasticsearch_domain" "good_example" {
   }
 }
 ```
+```hcl
+resource "aws_elasticsearch_domain" "fips_good_example" {
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08"
+  }
+}
+```
 
 #### Remediation Links
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain#tls_security_policy

--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy.rego
@@ -30,9 +30,11 @@ package builtin.aws.elasticsearch.aws0126
 import rego.v1
 
 import data.lib.cloud.metadata
+import data.lib.cloud.value
 
 deny contains res if {
 	some domain in input.aws.elasticsearch.domains
+	value.is_known(domain.endpoint.tlspolicy)
 	not is_tls_policy_secure(domain)
 	res := result.new(
 		"Domain does not have a secure TLS policy.",
@@ -40,9 +42,9 @@ deny contains res if {
 	)
 }
 
-recommended_tls_policies := {
-	"Policy-Min-TLS-1-2-2019-07",
-	"Policy-Min-TLS-1-2-PFS-2023-10",
-}
+secure_tls_policies := ["Policy-Min-TLS-1-2-*", "Policy-Min-TLS-1-3-*"]
 
-is_tls_policy_secure(domain) if domain.endpoint.tlspolicy.value in recommended_tls_policies
+is_tls_policy_secure(domain) if {
+	some policy in secure_tls_policies
+	glob.match(policy, [], domain.endpoint.tlspolicy.value)
+}

--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy.yaml
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy.yaml
@@ -23,6 +23,13 @@ terraform:
           tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
         }
       }
+    - |-
+      resource "aws_elasticsearch_domain" "fips_good_example" {
+        domain_endpoint_options {
+          enforce_https       = true
+          tls_security_policy = "Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08"
+        }
+      }
   bad:
     - |-
       resource "aws_elasticsearch_domain" "bad_example" {

--- a/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
+++ b/checks/cloud/aws/elasticsearch/use_secure_tls_policy_test.rego
@@ -17,6 +17,18 @@ test_allow_use_secure_tls_policy_2 if {
 	test.assert_empty(check.deny) with input as inp
 }
 
+test_allow_use_secure_tls_policy_3 if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-2-RFC9151-FIPS-2024-08"}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
+test_allow_unresolvable_tls_policy if {
+	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "", "unresolvable": true}}}]}}}
+
+	test.assert_empty(check.deny) with input as inp
+}
+
 test_deny_does_not_use_secure_tls_policy if {
 	inp := {"aws": {"elasticsearch": {"domains": [{"endpoint": {"tlspolicy": {"value": "Policy-Min-TLS-1-0-2019-07"}}}]}}}
 


### PR DESCRIPTION
Fixes #11118.

- Accept Policy-Min-TLS-1-2-* and Policy-Min-TLS-1-3-* policies
- Skip findings when the TLS policy value is unresolvable
- Add FIPS policy unit and Terraform example coverage

Validation completed:

- make fmt-rego
- make test-rego
- make check-rego
- make check-rego-matrix
- make lint-rego
- make docs