### PR TITLE
fix(aws-0047): flag FIPS/PQ ELB policies that allow TLS 1.0/1.1

### DIFF
--- a/checks/cloud/aws/elb/use_secure_tls_policy.rego
+++ b/checks/cloud/aws/elb/use_secure_tls_policy.rego
@@ -38,6 +38,10 @@ outdated_ssl_policies := {
 	"ELBSecurityPolicy-TLS13-1-1-2021-06",
 	"ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06",
 	"ELBSecurityPolicy-TLS13-1-2-Ext2-2021-06",
+	"ELBSecurityPolicy-TLS13-1-0-FIPS-2023-04",
+	"ELBSecurityPolicy-TLS13-1-0-FIPS-PQ-2025-09",
+	"ELBSecurityPolicy-TLS13-1-0-PQ-2025-09",
+	"ELBSecurityPolicy-TLS13-1-1-FIPS-2023-04",
 }
 
 deny contains res if {

--- a/checks/cloud/aws/elb/use_secure_tls_policy_test.rego
+++ b/checks/cloud/aws/elb/use_secure_tls_policy_test.rego
@@ -25,3 +25,27 @@ test_allow_with_actual_tls_policy if {
 
 	test.assert_empty(check.deny) with input as inp
 }
+
+test_deny_with_tls13_1_0_fips_tls_policy if {
+	inp := {"aws": {"elb": {"loadbalancers": [{"listeners": [{"tlspolicy": {"value": "ELBSecurityPolicy-TLS13-1-0-FIPS-2023-04"}}]}]}}}
+
+	test.assert_equal_message("Listener uses an outdated TLS policy.", check.deny) with input as inp
+}
+
+test_deny_with_tls13_1_0_fips_pq_tls_policy if {
+	inp := {"aws": {"elb": {"loadbalancers": [{"listeners": [{"tlspolicy": {"value": "ELBSecurityPolicy-TLS13-1-0-FIPS-PQ-2025-09"}}]}]}}}
+
+	test.assert_equal_message("Listener uses an outdated TLS policy.", check.deny) with input as inp
+}
+
+test_deny_with_tls13_1_0_pq_tls_policy if {
+	inp := {"aws": {"elb": {"loadbalancers": [{"listeners": [{"tlspolicy": {"value": "ELBSecurityPolicy-TLS13-1-0-PQ-2025-09"}}]}]}}}
+
+	test.assert_equal_message("Listener uses an outdated TLS policy.", check.deny) with input as inp
+}
+
+test_deny_with_tls13_1_1_fips_tls_policy if {
+	inp := {"aws": {"elb": {"loadbalancers": [{"listeners": [{"tlspolicy": {"value": "ELBSecurityPolicy-TLS13-1-1-FIPS-2023-04"}}]}]}}}
+
+	test.assert_equal_message("Listener uses an outdated TLS policy.", check.deny) with input as inp
+}


### PR DESCRIPTION
## What

AWS-0047 (`outdated_ssl_policies`) missed four predefined ELB security policies that still allow TLS 1.0 or TLS 1.1. Their protocol range matches the already-flagged `ELBSecurityPolicy-TLS13-1-0-2021-06` / `ELBSecurityPolicy-TLS13-1-1-2021-06` entries; they sit in the FIPS and post-quantum sections of the AWS docs.

Added to the deny set:

- `ELBSecurityPolicy-TLS13-1-0-FIPS-2023-04`
- `ELBSecurityPolicy-TLS13-1-0-FIPS-PQ-2025-09`
- `ELBSecurityPolicy-TLS13-1-0-PQ-2025-09`
- `ELBSecurityPolicy-TLS13-1-1-FIPS-2023-04`

Unit tests cover each new policy name.

## Scope

Minimal fix only (protocol-min criterion in the check metadata). Intentionally out of scope, as follow-ups:

- Adapter default when `ssl_policy` is omitted
- Classic Load Balancer (`aws_elb`) coverage
- PFS / Ext cipher-list classification

## Related

Fixes aquasecurity/trivy#11121

Note: #599 and #627 already target the same four policy names. This PR is scoped the same way (set + tests) and does not expand into those follow-ups.